### PR TITLE
Fix authToken cache invalidation

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -63,7 +63,7 @@ class SpotifyAuthenticationService(
             .deleteMany(BsonDocument("clientId", BsonString(token.clientId)))
         mongoTemplate.save(token, "auth")
 
-        tokenCache.invalidate("clientId")
+        token.clientId?.let { tokenCache.invalidate(it) }
     }
 
     fun getAuthToken(clientId: String): AuthToken? {


### PR DESCRIPTION
## Summary
- fix cache invalidation when storing new Spotify auth token

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687e852f87508326b6371540a9f8001e