### PR TITLE
Fix Last.fm auth loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # spotify-web-api-demo
 https://spotify-web-api-demo.herokuapp.com/
+
+## Required environment variables
+
+Set these values when deploying (e.g., to Cloud Run) so callback URLs and API
+credentials are available at runtime:
+
+- `BASE_URL` – Public URL of the running service
+- `SPOTIFY_CLIENT_ID` – Spotify application client ID
+- `SPOTIFY_CLIENT_SECRET` – Spotify application client secret
+- `LASTFM_API_KEY` – Last.fm API key
+- `LASTFM_API_SECRET` – Last.fm API secret

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -3,9 +3,10 @@ package com.example.lastfm.controller
 import com.lis.spotify.service.LastFmAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
+import javax.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 
 class LastFmAuthenticationControllerTest {
     private val service = mockk<LastFmAuthenticationService>()
@@ -20,8 +21,8 @@ class LastFmAuthenticationControllerTest {
 
     @Test
     fun handleCallbackWithToken() {
-        every { service.getSession("tok") } returns mapOf("k" to "v")
-        val response = controller.handleCallback("tok")
-        assertEquals(HttpStatus.OK, response.statusCode)
+        every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
+        val result = controller.handleCallback("tok", mockk(relaxed = true))
+        assertTrue(result.startsWith("redirect:/"))
     }
 }


### PR DESCRIPTION
## Summary
- store `lastFmToken` cookie after Last.fm callback and redirect to `/`
- add environment variable documentation
- update LastFmAuthenticationController test

## Testing
- `BASE_URL=http://localhost SPOTIFY_CLIENT_ID=cid SPOTIFY_CLIENT_SECRET=sec LASTFM_API_KEY=key LASTFM_API_SECRET=sec ./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687e8a3f37208326ba38f19729ea2a94