### PR TITLE
Increase test suite coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.3"
     // Apply the ktfmt plugin
     id("com.ncorti.ktfmt.gradle") version "0.21.0"
+    id("jacoco")
 }
 
 group = "com.lis"
@@ -53,3 +54,24 @@ tasks.withType<Test> {
 ktfmt {
     googleStyle()
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.check { dependsOn(tasks.jacocoTestCoverageVerification) }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.web.client.RestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.net.URI
 
 class SpotifyAuthenticationServiceTest {
     private val restTemplate = mockk<RestTemplate>()
@@ -31,5 +34,17 @@ class SpotifyAuthenticationServiceTest {
         assertFalse(service.isAuthorized("cid"))
         service.setAuthToken(AuthToken("a","b","c",0,"r","cid"))
         assertTrue(service.isAuthorized("cid"))
+    }
+
+    @Test
+    fun refreshTokenStoresNewToken() {
+        val builderAuthed = mockk<RestTemplateBuilder>()
+        every { builder.basicAuthentication(any(), any()) } returns builderAuthed
+        every { builderAuthed.build() } returns restTemplate
+        val newToken = AuthToken("access","Bearer","",0,"new","cid")
+        every { restTemplate.postForObject(any<URI>(), any(), AuthToken::class.java) } returns newToken
+        service.setAuthToken(AuthToken("old","","",0,"refresh","cid"))
+        service.refreshToken("cid")
+        assertEquals(newToken, service.getAuthToken("cid"))
     }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -1,8 +1,17 @@
 package com.lis.spotify.service
 
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import com.lis.spotify.domain.Album
+import com.lis.spotify.domain.Playlist
+import com.lis.spotify.domain.PlaylistTrack
+import com.lis.spotify.domain.PlaylistTracks
+import com.lis.spotify.domain.Track
+import com.lis.spotify.domain.Playlists
 
 class SpotifyPlaylistServiceTest {
     private val rest = mockk<SpotifyRestService>(relaxed = true)
@@ -14,5 +23,21 @@ class SpotifyPlaylistServiceTest {
         method.isAccessible = true
         val result = method.invoke(service, listOf("a", "b"), listOf("b")) as List<*>
         assertEquals(listOf("a"), result)
+    }
+
+    @Test
+    fun playlistTrackIdsAreReturned() {
+        val tracks = PlaylistTracks(listOf(PlaylistTrack(Track("1", "t", emptyList(), Album("a","n", emptyList())))), null)
+        every { rest.doRequest(any<() -> Any>()) } returns tracks
+        val ids = service.getPlaylistTrackIds("id", clientId = "cid")
+        assertEquals(listOf("1"), ids)
+    }
+
+    @Test
+    fun getOrCreateReturnsExisting() {
+        val playlists = Playlists(listOf(Playlist("p1", "name")), null)
+        every { rest.doRequest(any<() -> Any>()) } returns playlists
+        val result = service.getOrCreatePlaylist("name", "cid")
+        assertEquals("p1", result.id)
     }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -1,14 +1,60 @@
 package com.lis.spotify.service
 
+import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestTemplate
 
 class SpotifyRestServiceTest {
     @Test
     fun serviceCanBeCreated() {
         val service = SpotifyRestService(RestTemplateBuilder(), mockk(relaxed = true))
         assertNotNull(service)
+    }
+
+    @Test
+    fun doGetRetriesAndReturns() {
+        val restTemplate = mockk<RestTemplate>()
+        val builder = mockk<RestTemplateBuilder>()
+        val auth = mockk<SpotifyAuthenticationService>()
+        every { builder.build() } returns restTemplate
+        every { auth.getHeaders(any<String>()) } returns HttpHeaders()
+        every {
+            restTemplate.exchange<String>(any(), HttpMethod.GET, any(), any<ParameterizedTypeReference<String>>(), any<Map<String, *>>())
+        } returns ResponseEntity("ok", HttpStatus.OK)
+
+        val service = SpotifyRestService(builder, auth)
+        val result = service.doGet<String>("http://test", clientId = "cid")
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun postAndDeleteReturnValues() {
+        val restTemplate = mockk<RestTemplate>()
+        val builder = mockk<RestTemplateBuilder>()
+        val auth = mockk<SpotifyAuthenticationService>()
+        every { builder.build() } returns restTemplate
+        every { auth.getHeaders(any<String>()) } returns HttpHeaders()
+        every {
+            restTemplate.exchange<String>(any(), HttpMethod.POST, any(), any<ParameterizedTypeReference<String>>(), any<Map<String, *>>())
+        } returns ResponseEntity("ok", HttpStatus.OK)
+        every {
+            restTemplate.exchange<String>(any(), HttpMethod.DELETE, any(), any<ParameterizedTypeReference<String>>(), any<Map<String, *>>())
+        } returns ResponseEntity("ok", HttpStatus.OK)
+
+        val service = SpotifyRestService(builder, auth)
+        val r1 = service.doPost<String>("http://test", clientId = "cid")
+        val r2 = service.doDelete<String>("http://test", clientId = "cid")
+        assertEquals("ok", r1)
+        assertEquals("ok", r2)
     }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
@@ -1,6 +1,14 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.domain.Album
+import com.lis.spotify.domain.Artist
+import com.lis.spotify.domain.SearchResult
+import com.lis.spotify.domain.SearchResultInternal
+import com.lis.spotify.domain.Song
+import com.lis.spotify.domain.Track
+import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
@@ -9,5 +17,16 @@ class SpotifySearchServiceTest {
     fun serviceInstantiates() {
         val service = SpotifySearchService(mockk(relaxed = true))
         assertNotNull(service)
+    }
+
+    @Test
+    fun searchListReturnsIds() {
+        val rest = mockk<SpotifyRestService>()
+        val service = SpotifySearchService(rest)
+        val track = Track("1", "t", listOf(Artist("2","a")), Album("3","al", emptyList()))
+        val result = SearchResult(SearchResultInternal(listOf(track)))
+        every { rest.doRequest(any<() -> Any>()) } returns result
+        val ids = service.doSearch(listOf(Song("a","t")), "cid")
+        assertEquals(listOf("1"), ids)
     }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -1,8 +1,16 @@
 package com.lis.spotify.service
 
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.justRun
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import com.lis.spotify.domain.Playlist
+import com.lis.spotify.domain.Track
+import com.lis.spotify.domain.Album
+import com.lis.spotify.service.LastFmService
 
 class SpotifyTopPlaylistsServiceTest {
     @Test
@@ -14,5 +22,24 @@ class SpotifyTopPlaylistsServiceTest {
             mockk(relaxed = true)
         )
         assertNotNull(service)
+    }
+
+    @Test
+    fun updateTopPlaylistsReturnsIds() {
+        val playlistService = mockk<SpotifyPlaylistService>()
+        val trackService = mockk<SpotifyTopTrackService>()
+        val lastFmService = mockk<LastFmService>()
+        val searchService = mockk<SpotifySearchService>()
+
+        every { trackService.getTopTracksShortTerm(any()) } returns listOf(Track("1", "t", emptyList(), Album("a","n", emptyList())))
+        every { trackService.getTopTracksMidTerm(any()) } returns listOf(Track("2", "t", emptyList(), Album("a","n", emptyList())))
+        every { trackService.getTopTracksLongTerm(any()) } returns listOf(Track("3", "t", emptyList(), Album("a","n", emptyList())))
+        every { playlistService.getOrCreatePlaylist(any(), any()) } returns Playlist("id", "n")
+        every { playlistService.modifyPlaylist(any(), any(), any()) } returns emptyMap()
+
+        val service = SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+        val ids = service.updateTopPlaylists("cid")
+        assertEquals(4, ids.size)
+        verify(exactly = 4) { playlistService.modifyPlaylist(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary
- add Jacoco plugin and coverage checks
- expand unit tests for Spotify service classes

## Testing
- `BASE_URL=http://localhost SPOTIFY_CLIENT_ID=123 SPOTIFY_CLIENT_SECRET=xyz LASTFM_API_KEY=key LASTFM_API_SECRET=secret ./gradlew test`
- `BASE_URL=http://localhost SPOTIFY_CLIENT_ID=123 SPOTIFY_CLIENT_SECRET=xyz LASTFM_API_KEY=key LASTFM_API_SECRET=secret ./gradlew jacocoTestReport jacocoTestCoverageVerification` *(fails: coverage 49% < 80%)*

------
https://chatgpt.com/codex/tasks/task_e_687e8ca0262c8326a8012262149ea804