### PR TITLE
Add verbose logging

### DIFF
--- a/src/main/kotlin/com/lis/spotify/Application.kt
+++ b/src/main/kotlin/com/lis/spotify/Application.kt
@@ -29,10 +29,12 @@ class Application {
 
   @Bean
   fun taskScheduler(): TaskScheduler {
+    log.debug("Creating TaskScheduler bean")
     return ThreadPoolTaskScheduler()
   }
 }
 
 fun main(args: Array<String>) {
+  LoggerFactory.getLogger("Main").info("Starting Spotify Web API Demo")
   runApplication<Application>(*args)
 }

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -1,15 +1,13 @@
 package com.example.lastfm.controller
 
 import com.lis.spotify.service.LastFmAuthenticationService
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.view.RedirectView
-import javax.servlet.http.Cookie
-import javax.servlet.http.HttpServletResponse
 
 /**
  * LastFmAuthenticationController provides endpoints for handling Last.fm authentication.
@@ -29,10 +27,7 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
   }
 
   @GetMapping("/auth/lastfm/callback")
-  fun handleCallback(
-    @RequestParam token: String?,
-    response: HttpServletResponse,
-  ): String {
+  fun handleCallback(@RequestParam token: String?, response: HttpServletResponse): String {
     if (token.isNullOrEmpty()) {
       logger.warn("Token is missing in Last.fm callback")
       return "redirect:/error"

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmController.kt
@@ -13,6 +13,7 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmService
+import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
@@ -21,6 +22,13 @@ import org.springframework.web.bind.annotation.RestController
 class LastFmController(val lastFmService: LastFmService) {
   @PostMapping("/verifyLastFmId/{lastFmLogin}")
   fun verifyLastFmId(@PathVariable("lastFmLogin") lastFmLogin: String): Boolean {
-    return lastFmService.globalChartlist(lastFmLogin).isNotEmpty()
+    logger.debug("Verifying Last.fm login '{}'.", lastFmLogin)
+    val result = lastFmService.globalChartlist(lastFmLogin).isNotEmpty()
+    logger.info("Verification result for '{}': {}", lastFmLogin, result)
+    return result
+  }
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(LastFmController::class.java)
   }
 }

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -14,6 +14,7 @@ package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
+import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
@@ -25,6 +26,13 @@ class SpotifyTopPlaylistsController(
 ) {
   @PostMapping("/updateTopPlaylists")
   fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
-    return spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    logger.debug("Updating top playlists for clientId={}", clientId)
+    val playlists = spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    logger.info("Updated {} playlists for clientId={}", playlists.size, clientId)
+    return playlists
+  }
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(SpotifyTopPlaylistsController::class.java)
   }
 }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -30,6 +30,7 @@ class LastFmAuthenticationService {
    * Format: http://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
    */
   fun getAuthorizationUrl(): String {
+    logger.debug("Generating Last.fm authorization URL")
     return "${LastFm.AUTHORIZE_URL}?api_key=${LastFm.API_KEY}&cb=${LastFm.CALLBACK_URL}"
   }
 
@@ -47,6 +48,7 @@ class LastFmAuthenticationService {
    * @return A map containing session data if successful; otherwise, null.
    */
   fun getSession(token: String): Map<String, Any>? {
+    logger.debug("Requesting session for token {}", token)
     val method = "auth.getSession"
     // Create signature string:
     // "api_keyYOUR_API_KEYmethodauth.getSessiontokenYOUR_TOKENYOUR_API_SECRET"
@@ -69,6 +71,7 @@ class LastFmAuthenticationService {
 
     return try {
       val response = restTemplate.postForEntity(LastFm.API_URL, request, Map::class.java)
+      logger.info("Received session response from Last.fm")
       response.body as? Map<String, Any>
     } catch (ex: Exception) {
       logger.error("Error getting session for token $token", ex)

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -6,8 +6,8 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.web.util.UriComponentsBuilder
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 @Service
 class LastFmService {
@@ -15,12 +15,8 @@ class LastFmService {
   private val rest = RestTemplate()
   private val log = LoggerFactory.getLogger(LastFmService::class.java)
 
-  private fun fetchRecent(
-    user: String,
-    from: Long,
-    to: Long,
-    page: Int
-  ): Map<String, Any> {
+  private fun fetchRecent(user: String, from: Long, to: Long, page: Int): Map<String, Any> {
+    log.debug("Fetching recent tracks for user={} page={}", user, page)
     val uri =
       UriComponentsBuilder.fromHttpUrl(LastFm.API_URL)
         .queryParam("method", "user.getrecenttracks")
@@ -33,14 +29,12 @@ class LastFmService {
         .queryParam("format", "json")
         .build()
         .toUri()
-    return rest.getForObject(uri, Map::class.java) as Map<String, Any>
+    val result = rest.getForObject(uri, Map::class.java) as Map<String, Any>
+    log.debug("Fetched {} entries from Last.fm", (result["recenttracks"] as Map<*, *>)?.size ?: 0)
+    return result
   }
 
-  fun yearlyChartlist(
-    spotifyClientId: String,
-    year: Int,
-    lastFmLogin: String
-  ): List<Song> {
+  fun yearlyChartlist(spotifyClientId: String, year: Int, lastFmLogin: String): List<Song> {
     val from = LocalDate.of(year, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC)
     val to = LocalDate.of(year, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC)
     val songs = mutableListOf<Song>()

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopArtistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopArtistService.kt
@@ -14,6 +14,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Artist
 import com.lis.spotify.domain.Artists
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -24,9 +25,11 @@ class SpotifyTopArtistService(var spotifyRestService: SpotifyRestService) {
     private val SHORT_TERM = "short_term"
     private val MID_TERM = "medium_term"
     private val LONG_TERM = "long_term"
+    private val logger = LoggerFactory.getLogger(SpotifyTopArtistService::class.java)
   }
 
   private fun getTopArtists(term: String, clientId: String): Artists {
+    logger.debug("Fetching top artists for clientId={} term={}", clientId, term)
     return spotifyRestService.doGet<Artists>(
       URL,
       params = mapOf("limit" to 10, "time_range" to term),
@@ -35,14 +38,20 @@ class SpotifyTopArtistService(var spotifyRestService: SpotifyRestService) {
   }
 
   fun getTopArtistsLongTerm(clientId: String): List<Artist> {
-    return getTopArtists(LONG_TERM, clientId).items
+    val result = getTopArtists(LONG_TERM, clientId).items
+    logger.info("Fetched {} long term artists for clientId={}", result.size, clientId)
+    return result
   }
 
   fun getTopArtistsMidTerm(clientId: String): List<Artist> {
-    return getTopArtists(MID_TERM, clientId).items
+    val result = getTopArtists(MID_TERM, clientId).items
+    logger.info("Fetched {} mid term artists for clientId={}", result.size, clientId)
+    return result
   }
 
   fun getTopArtistsShortTerm(clientId: String): List<Artist> {
-    return getTopArtists(SHORT_TERM, clientId).items
+    val result = getTopArtists(SHORT_TERM, clientId).items
+    logger.info("Fetched {} short term artists for clientId={}", result.size, clientId)
+    return result
   }
 }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
@@ -14,6 +14,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Track
 import com.lis.spotify.domain.Tracks
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -24,9 +25,11 @@ class SpotifyTopTrackService(var spotifyRestService: SpotifyRestService) {
     private val SHORT_TERM = "short_term"
     private val MID_TERM = "medium_term"
     private val LONG_TERM = "long_term"
+    private val logger = LoggerFactory.getLogger(SpotifyTopTrackService::class.java)
   }
 
   private fun getTopTracks(term: String, clientId: String): Tracks {
+    logger.debug("Fetching top tracks for clientId={} term={}", clientId, term)
     return spotifyRestService.doGet<Tracks>(
       URL,
       params = mapOf("limit" to 50, "time_range" to term),
@@ -35,14 +38,20 @@ class SpotifyTopTrackService(var spotifyRestService: SpotifyRestService) {
   }
 
   fun getTopTracksLongTerm(clientId: String): List<Track> {
-    return getTopTracks(LONG_TERM, clientId).items
+    val result = getTopTracks(LONG_TERM, clientId).items
+    logger.info("Fetched {} long term tracks for clientId={}", result.size, clientId)
+    return result
   }
 
   fun getTopTracksMidTerm(clientId: String): List<Track> {
-    return getTopTracks(MID_TERM, clientId).items
+    val result = getTopTracks(MID_TERM, clientId).items
+    logger.info("Fetched {} mid term tracks for clientId={}", result.size, clientId)
+    return result
   }
 
   fun getTopTracksShortTerm(clientId: String): List<Track> {
-    return getTopTracks(SHORT_TERM, clientId).items
+    val result = getTopTracks(SHORT_TERM, clientId).items
+    logger.info("Fetched {} short term tracks for clientId={}", result.size, clientId)
+    return result
   }
 }

--- a/src/test/kotlin/com/lis/spotify/ApplicationTest.kt
+++ b/src/test/kotlin/com/lis/spotify/ApplicationTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 
 class ApplicationTest {
-    @Test
-    fun taskSchedulerReturnsThreadPoolScheduler() {
-        val scheduler = Application().taskScheduler()
-        assertTrue(scheduler is ThreadPoolTaskScheduler)
-    }
+  @Test
+  fun taskSchedulerReturnsThreadPoolScheduler() {
+    val scheduler = Application().taskScheduler()
+    assertTrue(scheduler is ThreadPoolTaskScheduler)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/EnvironmentTest.kt
+++ b/src/test/kotlin/com/lis/spotify/EnvironmentTest.kt
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class EnvironmentTest {
-    @Test
-    fun callbackUrlContainsBase() {
-        val url = AppEnvironment.Spotify.CALLBACK_URL
-        assertTrue(url.contains(AppEnvironment.BASE_URL))
-    }
+  @Test
+  fun callbackUrlContainsBase() {
+    val url = AppEnvironment.Spotify.CALLBACK_URL
+    assertTrue(url.contains(AppEnvironment.BASE_URL))
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
+++ b/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
@@ -9,22 +9,22 @@ import org.springframework.context.ApplicationContext
 import org.springframework.web.socket.server.standard.ServerEndpointExporter
 
 class WebSocketConfigTest {
-    @Test
-    fun serverEndpointExporterReturnsExporter() {
-        val exporter = WebSocketConfig().serverEndpointExporter()
-        assertTrue(exporter is ServerEndpointExporter)
-    }
+  @Test
+  fun serverEndpointExporterReturnsExporter() {
+    val exporter = WebSocketConfig().serverEndpointExporter()
+    assertTrue(exporter is ServerEndpointExporter)
+  }
 
-    class Dummy
+  class Dummy
 
-    @Test
-    fun getEndpointInstanceReturnsBean() {
-        val bean = Dummy()
-        val ctx = mockk<ApplicationContext>()
-        every { ctx.getBean(Dummy::class.java) } returns bean
-        val configurator = WebsocketSpringConfigurator()
-        configurator.setApplicationContext(ctx)
-        val result = configurator.getEndpointInstance(Dummy::class.java)
-        assertSame(bean, result)
-    }
+  @Test
+  fun getEndpointInstanceReturnsBean() {
+    val bean = Dummy()
+    val ctx = mockk<ApplicationContext>()
+    every { ctx.getBean(Dummy::class.java) } returns bean
+    val configurator = WebsocketSpringConfigurator()
+    configurator.setApplicationContext(ctx)
+    val result = configurator.getEndpointInstance(Dummy::class.java)
+    assertSame(bean, result)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -3,26 +3,25 @@ package com.example.lastfm.controller
 import com.lis.spotify.service.LastFmAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
-import javax.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LastFmAuthenticationControllerTest {
-    private val service = mockk<LastFmAuthenticationService>()
-    private val controller = LastFmAuthenticationController(service)
+  private val service = mockk<LastFmAuthenticationService>()
+  private val controller = LastFmAuthenticationController(service)
 
-    @Test
-    fun authenticateUserRedirects() {
-        every { service.getAuthorizationUrl() } returns "http://x"
-        val view = controller.authenticateUser()
-        assertEquals("http://x", view.url)
-    }
+  @Test
+  fun authenticateUserRedirects() {
+    every { service.getAuthorizationUrl() } returns "http://x"
+    val view = controller.authenticateUser()
+    assertEquals("http://x", view.url)
+  }
 
-    @Test
-    fun handleCallbackWithToken() {
-        every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
-        val result = controller.handleCallback("tok", mockk(relaxed = true))
-        assertTrue(result.startsWith("redirect:/"))
-    }
+  @Test
+  fun handleCallbackWithToken() {
+    every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
+    val result = controller.handleCallback("tok", mockk(relaxed = true))
+    assertTrue(result.startsWith("redirect:/"))
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmControllerTest.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LastFmControllerTest {
-    private val service = mockk<LastFmService>()
-    private val controller = LastFmController(service)
+  private val service = mockk<LastFmService>()
+  private val controller = LastFmController(service)
 
-    @Test
-    fun verifyLastFmIdUsesService() {
-        every { service.globalChartlist("login") } returns listOf()
-        val result = controller.verifyLastFmId("login")
-        assertTrue(result is Boolean)
-    }
+  @Test
+  fun verifyLastFmIdUsesService() {
+    every { service.globalChartlist("login") } returns listOf()
+    val result = controller.verifyLastFmId("login")
+    assertTrue(result is Boolean)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/MainControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/MainControllerTest.kt
@@ -9,22 +9,22 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class MainControllerTest {
-    private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
-    private val lastfmService = mockk<LastFmAuthenticationService>(relaxed = true)
-    private val controller = MainController(spotifyService, lastfmService)
+  private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
+  private val lastfmService = mockk<LastFmAuthenticationService>(relaxed = true)
+  private val controller = MainController(spotifyService, lastfmService)
 
-    @Test
-    fun redirectsToIndexWhenAuthorized() {
-        every { spotifyService.getAuthToken("abc") } returns mockk()
-        val result = controller.main("abc", "token")
-        assertEquals("forward:/index.html", result)
-        verify { spotifyService.refreshToken("abc") }
-    }
+  @Test
+  fun redirectsToIndexWhenAuthorized() {
+    every { spotifyService.getAuthToken("abc") } returns mockk()
+    val result = controller.main("abc", "token")
+    assertEquals("forward:/index.html", result)
+    verify { spotifyService.refreshToken("abc") }
+  }
 
-    @Test
-    fun redirectsToSpotifyWhenMissingToken() {
-        every { spotifyService.getAuthToken("abc") } returns null
-        val result = controller.main("abc", "token")
-        assertEquals("redirect:/auth/spotify", result)
-    }
+  @Test
+  fun redirectsToSpotifyWhenMissingToken() {
+    every { spotifyService.getAuthToken("abc") } returns null
+    val result = controller.main("abc", "token")
+    assertEquals("redirect:/auth/spotify", result)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -10,24 +10,25 @@ import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.web.client.RestTemplate
 
 class SpotifyAuthenticationControllerTest {
-    private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
-    private val restTemplate = mockk<RestTemplate>()
-    private val builder = mockk<RestTemplateBuilder>()
-    private val controller = SpotifyAuthenticationController(spotifyService, builder)
+  private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
+  private val restTemplate = mockk<RestTemplate>()
+  private val builder = mockk<RestTemplateBuilder>()
+  private val controller = SpotifyAuthenticationController(spotifyService, builder)
 
-    @Test
-    fun getCurrentUserIdHandlesError() {
-        every { builder.build() } returns restTemplate
-        val token = AuthToken("a","b","c",0,null,"cid")
-        every { spotifyService.getHeaders(token) } returns org.springframework.http.HttpHeaders()
-        every { restTemplate.exchange<Any>(any<String>(), any(), any(), Any::class.java) } throws RuntimeException()
-        val id = controller.getCurrentUserId(token)
-        assertNull(id)
-    }
+  @Test
+  fun getCurrentUserIdHandlesError() {
+    every { builder.build() } returns restTemplate
+    val token = AuthToken("a", "b", "c", 0, null, "cid")
+    every { spotifyService.getHeaders(token) } returns org.springframework.http.HttpHeaders()
+    every { restTemplate.exchange<Any>(any<String>(), any(), any(), Any::class.java) } throws
+      RuntimeException()
+    val id = controller.getCurrentUserId(token)
+    assertNull(id)
+  }
 
-    @Test
-    fun authorizeReturnsRedirect() {
-        val result = controller.authorize(mockk(), mockk(), "cid")
-        assert(result.startsWith("redirect:"))
-    }
+  @Test
+  fun authorizeReturnsRedirect() {
+    val result = controller.authorize(mockk(), mockk(), "cid")
+    assert(result.startsWith("redirect:"))
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsControllerTest.kt
@@ -8,14 +8,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class SpotifyTopPlaylistsControllerTest {
-    private val lastFmService = mockk<LastFmService>(relaxed = true)
-    private val topService = mockk<SpotifyTopPlaylistsService>()
-    private val controller = SpotifyTopPlaylistsController(lastFmService, topService)
+  private val lastFmService = mockk<LastFmService>(relaxed = true)
+  private val topService = mockk<SpotifyTopPlaylistsService>()
+  private val controller = SpotifyTopPlaylistsController(lastFmService, topService)
 
-    @Test
-    fun updateTopPlaylistsDelegatesToService() {
-        every { topService.updateTopPlaylists("cid") } returns listOf("1","2")
-        val result = controller.updateTopPlaylists("cid")
-        assertEquals(listOf("1","2"), result)
-    }
+  @Test
+  fun updateTopPlaylistsDelegatesToService() {
+    every { topService.updateTopPlaylists("cid") } returns listOf("1", "2")
+    val result = controller.updateTopPlaylists("cid")
+    assertEquals(listOf("1", "2"), result)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/domain/DomainClassesTest.kt
+++ b/src/test/kotlin/com/lis/spotify/domain/DomainClassesTest.kt
@@ -4,24 +4,24 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class DomainClassesTest {
-    @Test
-    fun playlistTrackHoldsTrack() {
-        val artist = Artist("a","artist")
-        val album = Album("b","album", listOf(artist))
-        val track = Track("t","name", listOf(artist), album)
-        val pt = PlaylistTrack(track)
-        assertEquals(track, pt.track)
-    }
+  @Test
+  fun playlistTrackHoldsTrack() {
+    val artist = Artist("a", "artist")
+    val album = Album("b", "album", listOf(artist))
+    val track = Track("t", "name", listOf(artist), album)
+    val pt = PlaylistTrack(track)
+    assertEquals(track, pt.track)
+  }
 
-    @Test
-    fun authTokenStoresValues() {
-        val token = AuthToken("a","type","scope",1,"r","cid")
-        assertEquals("a", token.access_token)
-    }
+  @Test
+  fun authTokenStoresValues() {
+    val token = AuthToken("a", "type", "scope", 1, "r", "cid")
+    assertEquals("a", token.access_token)
+  }
 
-    @Test
-    fun songStoresValues() {
-        val song = Song("artist","title")
-        assertEquals("title", song.title)
-    }
+  @Test
+  fun songStoresValues() {
+    val song = Song("artist", "title")
+    assertEquals("title", song.title)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/endpoint/YearlyPlaylistsEndpointTest.kt
+++ b/src/test/kotlin/com/lis/spotify/endpoint/YearlyPlaylistsEndpointTest.kt
@@ -1,24 +1,24 @@
 package com.lis.spotify.endpoint
 
+import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import javax.websocket.EndpointConfig
 import javax.websocket.Session
 import org.junit.jupiter.api.Test
-import com.lis.spotify.service.SpotifyTopPlaylistsService
 
 class YearlyPlaylistsEndpointTest {
-    @Test
-    fun onMessageTriggersUpdate() {
-        val service = mockk<SpotifyTopPlaylistsService>(relaxed = true)
-        val endpoint = YearlyPlaylistsEndpoint(service)
-        val config = mockk<EndpointConfig>()
-        every { config.userProperties["clientId"] } returns "cid"
-        endpoint.onOpen(mockk<Session>(), config, "login")
+  @Test
+  fun onMessageTriggersUpdate() {
+    val service = mockk<SpotifyTopPlaylistsService>(relaxed = true)
+    val endpoint = YearlyPlaylistsEndpoint(service)
+    val config = mockk<EndpointConfig>()
+    every { config.userProperties["clientId"] } returns "cid"
+    endpoint.onOpen(mockk<Session>(), config, "login")
 
-        endpoint.onMessage(mockk<Session>(), "msg")
+    endpoint.onMessage(mockk<Session>(), "msg")
 
-        verify { service.updateYearlyPlaylists("cid", any(), "login") }
-    }
+    verify { service.updateYearlyPlaylists("cid", any(), "login") }
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -11,23 +11,29 @@ import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
 
 class LastFmAuthenticationServiceTest {
-    @Test
-    fun getAuthorizationUrlFormatsCorrectly() {
-        val service = LastFmAuthenticationService()
-        val url = service.getAuthorizationUrl()
-        assert(url.contains("api_key"))
-    }
+  @Test
+  fun getAuthorizationUrlFormatsCorrectly() {
+    val service = LastFmAuthenticationService()
+    val url = service.getAuthorizationUrl()
+    assert(url.contains("api_key"))
+  }
 
-    @Test
-    fun getSessionHandlesResponse() {
-        val rest = mockk<RestTemplate>()
-        val service = LastFmAuthenticationService()
-        val field = LastFmAuthenticationService::class.java.getDeclaredField("restTemplate")
-        field.isAccessible = true
-        field.set(service, rest)
-        val expected = mapOf<String, Any>("session" to mapOf("name" to "val"))
-        every { rest.postForEntity(any<String>(), any<HttpEntity<MultiValueMap<String, String>>>(), Map::class.java) } returns ResponseEntity(expected, HttpStatus.OK)
-        val result = service.getSession("token")
-        assertEquals(expected, result)
-    }
+  @Test
+  fun getSessionHandlesResponse() {
+    val rest = mockk<RestTemplate>()
+    val service = LastFmAuthenticationService()
+    val field = LastFmAuthenticationService::class.java.getDeclaredField("restTemplate")
+    field.isAccessible = true
+    field.set(service, rest)
+    val expected = mapOf<String, Any>("session" to mapOf("name" to "val"))
+    every {
+      rest.postForEntity(
+        any<String>(),
+        any<HttpEntity<MultiValueMap<String, String>>>(),
+        Map::class.java,
+      )
+    } returns ResponseEntity(expected, HttpStatus.OK)
+    val result = service.getSession("token")
+    assertEquals(expected, result)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -5,26 +5,26 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
 
 class LastFmServiceTest {
-    @Test
-    fun yearlyChartlistParsesSongs() {
-        val rest = mockk<RestTemplate>()
-        val service = LastFmService()
-        val field = LastFmService::class.java.getDeclaredField("rest")
-        field.isAccessible = true
-        field.set(service, rest)
-        val map = mapOf(
-            "recenttracks" to mapOf(
-                "totalPages" to "1",
-                "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T"))
-            )
-        )
-        every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns map
-        val songs = service.yearlyChartlist("cid", 2020, "login")
-        assertEquals(listOf(Song("A", "T")), songs)
-    }
+  @Test
+  fun yearlyChartlistParsesSongs() {
+    val rest = mockk<RestTemplate>()
+    val service = LastFmService()
+    val field = LastFmService::class.java.getDeclaredField("rest")
+    field.isAccessible = true
+    field.set(service, rest)
+    val map =
+      mapOf(
+        "recenttracks" to
+          mapOf(
+            "totalPages" to "1",
+            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T")),
+          )
+      )
+    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns map
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+    assertEquals(listOf(Song("A", "T")), songs)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -11,25 +11,25 @@ import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.web.client.RestTemplate
 
 class SpotifyAuthenticationServiceTest {
-    private val restTemplate = mockk<RestTemplate>()
-    private val builder = mockk<RestTemplateBuilder>()
-    private val service = SpotifyAuthenticationService(builder)
+  private val restTemplate = mockk<RestTemplate>()
+  private val builder = mockk<RestTemplateBuilder>()
+  private val service = SpotifyAuthenticationService(builder)
 
-    init {
-        every { builder.build() } returns restTemplate
-    }
+  init {
+    every { builder.build() } returns restTemplate
+  }
 
-    @Test
-    fun setAndGetAuthTokenWorks() {
-        val token = AuthToken("a","b","c",0,"refresh","cid")
-        service.setAuthToken(token)
-        assertEquals(token, service.getAuthToken("cid"))
-    }
+  @Test
+  fun setAndGetAuthTokenWorks() {
+    val token = AuthToken("a", "b", "c", 0, "refresh", "cid")
+    service.setAuthToken(token)
+    assertEquals(token, service.getAuthToken("cid"))
+  }
 
-    @Test
-    fun isAuthorizedChecksCache() {
-        assertFalse(service.isAuthorized("cid"))
-        service.setAuthToken(AuthToken("a","b","c",0,"r","cid"))
-        assertTrue(service.isAuthorized("cid"))
-    }
+  @Test
+  fun isAuthorizedChecksCache() {
+    assertFalse(service.isAuthorized("cid"))
+    service.setAuthToken(AuthToken("a", "b", "c", 0, "r", "cid"))
+    assertTrue(service.isAuthorized("cid"))
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -5,14 +5,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class SpotifyPlaylistServiceTest {
-    private val rest = mockk<SpotifyRestService>(relaxed = true)
-    private val service = SpotifyPlaylistService(rest)
+  private val rest = mockk<SpotifyRestService>(relaxed = true)
+  private val service = SpotifyPlaylistService(rest)
 
-    @Test
-    fun getDiffReturnsRemovedElements() {
-        val method = SpotifyPlaylistService::class.java.getDeclaredMethod("getDiff", List::class.java, List::class.java)
-        method.isAccessible = true
-        val result = method.invoke(service, listOf("a", "b"), listOf("b")) as List<*>
-        assertEquals(listOf("a"), result)
-    }
+  @Test
+  fun getDiffReturnsRemovedElements() {
+    val method =
+      SpotifyPlaylistService::class
+        .java
+        .getDeclaredMethod("getDiff", List::class.java, List::class.java)
+    method.isAccessible = true
+    val result = method.invoke(service, listOf("a", "b"), listOf("b")) as List<*>
+    assertEquals(listOf("a"), result)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.web.client.RestTemplateBuilder
 
 class SpotifyRestServiceTest {
-    @Test
-    fun serviceCanBeCreated() {
-        val service = SpotifyRestService(RestTemplateBuilder(), mockk(relaxed = true))
-        assertNotNull(service)
-    }
+  @Test
+  fun serviceCanBeCreated() {
+    val service = SpotifyRestService(RestTemplateBuilder(), mockk(relaxed = true))
+    assertNotNull(service)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 class SpotifySearchServiceTest {
-    @Test
-    fun serviceInstantiates() {
-        val service = SpotifySearchService(mockk(relaxed = true))
-        assertNotNull(service)
-    }
+  @Test
+  fun serviceInstantiates() {
+    val service = SpotifySearchService(mockk(relaxed = true))
+    assertNotNull(service)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopArtistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopArtistServiceTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 class SpotifyTopArtistServiceTest {
-    @Test
-    fun serviceInstantiates() {
-        val service = SpotifyTopArtistService(mockk(relaxed = true))
-        assertNotNull(service)
-    }
+  @Test
+  fun serviceInstantiates() {
+    val service = SpotifyTopArtistService(mockk(relaxed = true))
+    assertNotNull(service)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -5,14 +5,15 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 class SpotifyTopPlaylistsServiceTest {
-    @Test
-    fun serviceInstantiates() {
-        val service = SpotifyTopPlaylistsService(
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true)
-        )
-        assertNotNull(service)
-    }
+  @Test
+  fun serviceInstantiates() {
+    val service =
+      SpotifyTopPlaylistsService(
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+      )
+    assertNotNull(service)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopTrackServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopTrackServiceTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 class SpotifyTopTrackServiceTest {
-    @Test
-    fun serviceInstantiates() {
-        val service = SpotifyTopTrackService(mockk(relaxed = true))
-        assertNotNull(service)
-    }
+  @Test
+  fun serviceInstantiates() {
+    val service = SpotifyTopTrackService(mockk(relaxed = true))
+    assertNotNull(service)
+  }
 }


### PR DESCRIPTION
## Summary
- add logging to various controllers, services and config classes
- update tests to new formatting

## Testing
- `./gradlew ktfmtFormat`
- `BASE_URL=http://localhost SPOTIFY_CLIENT_ID=x SPOTIFY_CLIENT_SECRET=x LASTFM_API_KEY=x LASTFM_API_SECRET=x ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687e91e1945c83269072fe2d9317442c