### PR TITLE
Enable debug logging via aspect

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")

--- a/src/main/kotlin/com/lis/spotify/config/LoggingAspect.kt
+++ b/src/main/kotlin/com/lis/spotify/config/LoggingAspect.kt
@@ -1,0 +1,26 @@
+package com.lis.spotify.config
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LoggingAspect {
+  @Around("execution(* com.lis.spotify..*(..)) && !within(com.lis.spotify.config.LoggingAspect)")
+  fun logAround(pjp: ProceedingJoinPoint): Any? {
+    val logger = LoggerFactory.getLogger(pjp.target.javaClass)
+    val signature = pjp.signature.toShortString()
+    logger.debug("Entering {} with args {}", signature, pjp.args.joinToString())
+    return try {
+      val result = pjp.proceed()
+      logger.debug("Exiting {} with result {}", signature, result)
+      result
+    } catch (throwable: Throwable) {
+      logger.error("Exception in {}", signature, throwable)
+      throw throwable
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.forward-headers-strategy=native
+logging.level.root=DEBUG


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-aop`
- create a `LoggingAspect` for method entry/exit
- set default logging level to `DEBUG`

## Testing
- `./gradlew ktfmtFormat`
- `BASE_URL=http://localhost SPOTIFY_CLIENT_ID=id SPOTIFY_CLIENT_SECRET=secret LASTFM_API_KEY=key LASTFM_API_SECRET=secret ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687e949a02ec8326afa35fd3eeed4917