### PR TITLE
Fix Spotify OAuth redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ https://spotify-web-api-demo.herokuapp.com/
 Set these values when deploying (e.g., to Cloud Run) so callback URLs and API
 credentials are available at runtime:
 
-- `BASE_URL` – Public URL of the running service
+- `BASE_URL` – Public URL of the running service (used as a fallback for
+  callbacks)
 - `SPOTIFY_CLIENT_ID` – Spotify application client ID
 - `SPOTIFY_CLIENT_SECRET` – Spotify application client secret
 - `LASTFM_API_KEY` – Last.fm API key

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -10,24 +10,25 @@ import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.web.client.RestTemplate
 
 class SpotifyAuthenticationControllerTest {
-    private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
-    private val restTemplate = mockk<RestTemplate>()
-    private val builder = mockk<RestTemplateBuilder>()
-    private val controller = SpotifyAuthenticationController(spotifyService, builder)
+  private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
+  private val restTemplate = mockk<RestTemplate>()
+  private val builder = mockk<RestTemplateBuilder>()
+  private val controller = SpotifyAuthenticationController(spotifyService, builder)
 
-    @Test
-    fun getCurrentUserIdHandlesError() {
-        every { builder.build() } returns restTemplate
-        val token = AuthToken("a","b","c",0,null,"cid")
-        every { spotifyService.getHeaders(token) } returns org.springframework.http.HttpHeaders()
-        every { restTemplate.exchange<Any>(any<String>(), any(), any(), Any::class.java) } throws RuntimeException()
-        val id = controller.getCurrentUserId(token)
-        assertNull(id)
-    }
+  @Test
+  fun getCurrentUserIdHandlesError() {
+    every { builder.build() } returns restTemplate
+    val token = AuthToken("a", "b", "c", 0, null, "cid")
+    every { spotifyService.getHeaders(token) } returns org.springframework.http.HttpHeaders()
+    every { restTemplate.exchange<Any>(any<String>(), any(), any(), Any::class.java) } throws
+      RuntimeException()
+    val id = controller.getCurrentUserId(token)
+    assertNull(id)
+  }
 
-    @Test
-    fun authorizeReturnsRedirect() {
-        val result = controller.authorize(mockk(), mockk(), "cid")
-        assert(result.startsWith("redirect:"))
-    }
+  @Test
+  fun authorizeReturnsRedirect() {
+    val result = controller.authorize(mockk(relaxed = true), mockk(), mockk(), "cid")
+    assert(result.startsWith("redirect:"))
+  }
 }


### PR DESCRIPTION
## Summary
- compute Spotify callback URL from request headers
- update tests for new parameter
- document BASE_URL as a fallback

## Testing
- `./gradlew ktfmtFormat`
- `BASE_URL=http://localhost:8080 SPOTIFY_CLIENT_ID=a SPOTIFY_CLIENT_SECRET=b LASTFM_API_KEY=c LASTFM_API_SECRET=d ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687e921a575883268081528e8274b068