### PR TITLE
Install tomcat-native

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN chmod +x gradlew && \
 
 # Runtime stage
 FROM eclipse-temurin:23-jre-alpine
+RUN apk add --no-cache tomcat-native
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar spotify-web-api-demo.jar
 


### PR DESCRIPTION
## Summary
- fix `LibraryNotFoundError` on Cloud Run by installing `tomcat-native` library

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test` *(fails: error downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e995672c4832687a02586372330d6