### PR TITLE
Fix WebSocket endpoint registration

### DIFF
--- a/src/main/kotlin/com/lis/spotify/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/lis/spotify/config/WebSocketConfig.kt
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.websocket.HandshakeResponse
 import javax.websocket.server.HandshakeRequest
 import javax.websocket.server.ServerEndpointConfig
-import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.context.annotation.Bean
@@ -37,7 +37,7 @@ class WebSocketConfig {
 @Component
 class WebsocketSpringConfigurator : ServerEndpointConfig.Configurator(), ApplicationContextAware {
   companion object {
-    private var context: BeanFactory? = null
+    private lateinit var context: AutowireCapableBeanFactory
   }
 
   override fun modifyHandshake(
@@ -56,11 +56,11 @@ class WebsocketSpringConfigurator : ServerEndpointConfig.Configurator(), Applica
     return field.get(request) as HttpServletRequest
   }
 
-  override fun <T> getEndpointInstance(clazz: Class<T>): T? {
-    return context?.getBean(clazz)
+  override fun <T> getEndpointInstance(clazz: Class<T>): T {
+    return context.createBean(clazz)
   }
 
   override fun setApplicationContext(applicationContext: ApplicationContext) {
-    context = applicationContext
+    context = applicationContext.autowireCapableBeanFactory
   }
 }

--- a/src/main/kotlin/com/lis/spotify/endpoint/YearlyPlaylistsEndpoint.kt
+++ b/src/main/kotlin/com/lis/spotify/endpoint/YearlyPlaylistsEndpoint.kt
@@ -17,9 +17,7 @@ import com.lis.spotify.service.SpotifyTopPlaylistsService
 import javax.websocket.*
 import javax.websocket.server.PathParam
 import javax.websocket.server.ServerEndpoint
-import org.springframework.stereotype.Component
 
-@Component
 @ServerEndpoint("/socket/{login}", configurator = WebsocketSpringConfigurator::class)
 class YearlyPlaylistsEndpoint(var spotifyTopPlaylistsService: SpotifyTopPlaylistsService) {
 

--- a/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
+++ b/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
@@ -5,26 +5,29 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.context.ApplicationContext
 import org.springframework.web.socket.server.standard.ServerEndpointExporter
 
 class WebSocketConfigTest {
-    @Test
-    fun serverEndpointExporterReturnsExporter() {
-        val exporter = WebSocketConfig().serverEndpointExporter()
-        assertTrue(exporter is ServerEndpointExporter)
-    }
+  @Test
+  fun serverEndpointExporterReturnsExporter() {
+    val exporter = WebSocketConfig().serverEndpointExporter()
+    assertTrue(exporter is ServerEndpointExporter)
+  }
 
-    class Dummy
+  class Dummy
 
-    @Test
-    fun getEndpointInstanceReturnsBean() {
-        val bean = Dummy()
-        val ctx = mockk<ApplicationContext>()
-        every { ctx.getBean(Dummy::class.java) } returns bean
-        val configurator = WebsocketSpringConfigurator()
-        configurator.setApplicationContext(ctx)
-        val result = configurator.getEndpointInstance(Dummy::class.java)
-        assertSame(bean, result)
-    }
+  @Test
+  fun getEndpointInstanceReturnsBean() {
+    val bean = Dummy()
+    val factory = mockk<AutowireCapableBeanFactory>()
+    every { factory.createBean(Dummy::class.java) } returns bean
+    val ctx = mockk<ApplicationContext>()
+    every { ctx.autowireCapableBeanFactory } returns factory
+    val configurator = WebsocketSpringConfigurator()
+    configurator.setApplicationContext(ctx)
+    val result = configurator.getEndpointInstance(Dummy::class.java)
+    assertSame(bean, result)
+  }
 }


### PR DESCRIPTION
## Summary
- avoid Spring proxies on the WebSocket endpoint
- create endpoint instances via the configurator's bean factory
- update unit test for new configurator behaviour

## Testing
- `./gradlew ktfmtFormat`
- `BASE_URL=http://test SPOTIFY_CLIENT_ID=id SPOTIFY_CLIENT_SECRET=secret LASTFM_API_KEY=key LASTFM_API_SECRET=secret ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687e9d1743b08326b8a4bcc6b2c3a1aa