### PR TITLE
Configure HTTP11 logging

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 server.forward-headers-strategy=native
 logging.level.root=DEBUG
+logging.level.org.apache.coyote.http11.Http11Processor=WARN
+server.tomcat.keep-alive-timeout=10s
+server.tomcat.max-keep-alive-requests=1


### PR DESCRIPTION
## Summary
- downgrade Http11Processor logs to WARN
- shorten keep-alive timeouts

## Testing
- `./gradlew ktfmtFormat --no-daemon`
- `./gradlew test --no-daemon` *(fails: NoClassDefFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687ea0e96b0483269b1370186f07487b