### PR TITLE
Ensure Last.fm cookie path is configured

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -39,7 +39,9 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
     return if (sessionData != null) {
       val key = ((sessionData["session"] as? Map<*, *>)?.get("key") as? String)
       if (!key.isNullOrEmpty()) {
-        response.addCookie(Cookie("lastFmToken", key))
+        val cookie = Cookie("lastFmToken", key)
+        cookie.path = "/"
+        response.addCookie(cookie)
       }
       "redirect:/"
     } else {

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -1,8 +1,12 @@
 package com.example.lastfm.controller
 
 import com.lis.spotify.service.LastFmAuthenticationService
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -23,5 +27,17 @@ class LastFmAuthenticationControllerTest {
     every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
     val result = controller.handleCallback("tok", mockk(relaxed = true))
     assertTrue(result.startsWith("redirect:/"))
+  }
+
+  @Test
+  fun handleCallbackSetsCookiePath() {
+    every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
+    val response = mockk<HttpServletResponse>(relaxed = true)
+    val cookieSlot: CapturingSlot<Cookie> = slot()
+    every { response.addCookie(capture(cookieSlot)) } answers {}
+
+    controller.handleCallback("tok", response)
+
+    assertEquals("/", cookieSlot.captured.path)
   }
 }


### PR DESCRIPTION
## Summary
- configure `lastFmToken` cookie path to `/`
- check cookie path in `LastFmAuthenticationControllerTest`

## Testing
- `BASE_URL=http://example.com SPOTIFY_CLIENT_ID=id SPOTIFY_CLIENT_SECRET=secret LASTFM_API_KEY=key LASTFM_API_SECRET=secret ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687f1e84faec83269b875be8b84dcab9