### PR TITLE
Fix Last.fm auth controller package

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -1,4 +1,4 @@
-package com.example.lastfm.controller
+package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmAuthenticationService
 import jakarta.servlet.http.Cookie

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -1,4 +1,4 @@
-package com.example.lastfm.controller
+package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmAuthenticationService
 import io.mockk.every


### PR DESCRIPTION
## Summary
- move LastFmAuthenticationController to `com.lis.spotify.controller`
- update LastFmAuthenticationControllerTest package

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew bootRun` and `curl -I http://localhost:8080/auth/lastfm`

------
https://chatgpt.com/codex/tasks/task_e_687f1ea8ab0083269cd9c0429d882628