### PR TITLE
Add WireMock integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,12 @@ dependencies {
   implementation("org.jsoup:jsoup:1.21.1")
   implementation("com.google.guava:guava:33.4.8-jre")
 
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
   testImplementation("io.mockk:mockk:1.14.3")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.12.2")
+  testImplementation("org.testcontainers:junit-jupiter:1.19.7")
+  testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.1")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.12.2")
 }
 
@@ -44,7 +47,14 @@ tasks.withType<KotlinCompile> {
   }
 }
 
-tasks.withType<Test> { useJUnitPlatform() }
+tasks.withType<Test> {
+  useJUnitPlatform()
+  systemProperty("BASE_URL", "http://localhost")
+  systemProperty("SPOTIFY_CLIENT_ID", "id")
+  systemProperty("SPOTIFY_CLIENT_SECRET", "secret")
+  systemProperty("LASTFM_API_KEY", "key")
+  systemProperty("LASTFM_API_SECRET", "secret")
+}
 
 // Configure ktfmt to use Google Style
 ktfmt { googleStyle() }

--- a/src/main/kotlin/com/lis/spotify/Environment.kt
+++ b/src/main/kotlin/com/lis/spotify/Environment.kt
@@ -7,16 +7,20 @@ package com.lis.spotify
  */
 object AppEnvironment {
   // Base URL used to assemble callback URLs for both Spotify and Last.fm.
+  // CHANGE START
   val BASE_URL: String =
     System.getenv("BASE_URL")
+      ?: System.getProperty("BASE_URL")
       ?: throw IllegalArgumentException("BASE_URL environment variable is missing")
 
   object Spotify {
     val CLIENT_ID: String =
       System.getenv("SPOTIFY_CLIENT_ID")
+        ?: System.getProperty("SPOTIFY_CLIENT_ID")
         ?: throw IllegalArgumentException("SPOTIFY_CLIENT_ID environment variable is missing")
     val CLIENT_SECRET: String =
       System.getenv("SPOTIFY_CLIENT_SECRET")
+        ?: System.getProperty("SPOTIFY_CLIENT_SECRET")
         ?: throw IllegalArgumentException("SPOTIFY_CLIENT_SECRET environment variable is missing")
 
     // Define the callback path and combine it with BASE_URL.
@@ -24,17 +28,25 @@ object AppEnvironment {
     val CALLBACK_URL: String = "$BASE_URL$CALLBACK_PATH"
 
     // Spotify endpoints and scopes.
-    const val AUTH_URL: String = "https://accounts.spotify.com/authorize"
-    const val TOKEN_URL: String = "https://accounts.spotify.com/api/token"
+    val AUTH_URL: String =
+      System.getenv("SPOTIFY_AUTH_URL")
+        ?: System.getProperty("SPOTIFY_AUTH_URL")
+        ?: "https://accounts.spotify.com/authorize"
+    val TOKEN_URL: String =
+      System.getenv("SPOTIFY_TOKEN_URL")
+        ?: System.getProperty("SPOTIFY_TOKEN_URL")
+        ?: "https://accounts.spotify.com/api/token"
     const val SCOPES: String = "user-top-read playlist-modify-public"
   }
 
   object LastFm {
     val API_KEY: String =
       System.getenv("LASTFM_API_KEY")
+        ?: System.getProperty("LASTFM_API_KEY")
         ?: throw IllegalArgumentException("LASTFM_API_KEY environment variable is missing")
     val API_SECRET: String =
       System.getenv("LASTFM_API_SECRET")
+        ?: System.getProperty("LASTFM_API_SECRET")
         ?: throw IllegalArgumentException("LASTFM_API_SECRET environment variable is missing")
 
     // Define the callback path and combine it with BASE_URL.
@@ -42,7 +54,14 @@ object AppEnvironment {
     val CALLBACK_URL: String = "$BASE_URL$CALLBACK_PATH"
 
     // Last.fm endpoints.
-    const val AUTHORIZE_URL: String = "http://www.last.fm/api/auth/"
-    const val API_URL: String = "http://ws.audioscrobbler.com/2.0/"
+    val AUTHORIZE_URL: String =
+      System.getenv("LASTFM_AUTHORIZE_URL")
+        ?: System.getProperty("LASTFM_AUTHORIZE_URL")
+        ?: "http://www.last.fm/api/auth/"
+    val API_URL: String =
+      System.getenv("LASTFM_API_URL")
+        ?: System.getProperty("LASTFM_API_URL")
+        ?: "http://ws.audioscrobbler.com/2.0/"
   }
 }
+// CHANGE END

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
@@ -1,0 +1,85 @@
+package com.lis.spotify.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@Testcontainers
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: TestRestTemplate) {
+  companion object {
+    val wm =
+      GenericContainer(DockerImageName.parse("wiremock/wiremock:3.5.2-alpine"))
+        .withExposedPorts(8080)
+    val baseUrl: String
+      get() = "http://localhost:${wm.getMappedPort(8080)}"
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      System.setProperty("BASE_URL", "http://localhost")
+      System.setProperty("SPOTIFY_CLIENT_ID", "id")
+      System.setProperty("SPOTIFY_CLIENT_SECRET", "secret")
+      System.setProperty("LASTFM_API_KEY", "key")
+      System.setProperty("LASTFM_API_SECRET", "secret")
+      wm.start()
+      configureFor("localhost", wm.getMappedPort(8080))
+      val base = baseUrl
+      System.setProperty("LASTFM_API_URL", "$base/2.0/")
+      System.setProperty("LASTFM_AUTHORIZE_URL", "$base/auth")
+      System.setProperty("SPOTIFY_AUTH_URL", "$base/s-auth")
+      System.setProperty("SPOTIFY_TOKEN_URL", "$base/s-token")
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stop() {
+      wm.stop()
+    }
+  }
+
+  @BeforeEach
+  fun resetStubs() {
+    wireMockReset()
+  }
+
+  @Test
+  fun authenticateUserRedirects() {
+    val response = rest.getForEntity("/auth/lastfm", String::class.java)
+    assertAll(
+      { assertEquals(HttpStatus.FOUND, response.statusCode) },
+      { assertTrue(response.headers.location!!.toString().startsWith(baseUrl)) },
+    )
+  }
+
+  @Test
+  fun callbackSetsCookie() {
+    stubFor(post(urlPathEqualTo("/2.0/")).willReturn(okJson("""{"session":{"key":"val"}}""")))
+    val response = rest.getForEntity("/auth/lastfm/callback?token=t", String::class.java)
+    val cookie = response.headers["Set-Cookie"]!!.first()
+    assertAll(
+      { assertEquals(HttpStatus.OK, response.statusCode) },
+      { assertTrue(cookie.contains("lastFmToken=val")) },
+      { assertTrue(response.body!!.startsWith("redirect:/")) },
+    )
+  }
+}

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
@@ -1,0 +1,87 @@
+package com.lis.spotify.integration
+
+import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@Testcontainers
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class LastFmControllerIT @Autowired constructor(private val rest: TestRestTemplate) {
+  companion object {
+    val wm =
+      GenericContainer(DockerImageName.parse("wiremock/wiremock:3.5.2-alpine"))
+        .withExposedPorts(8080)
+    val baseUrl: String
+      get() = "http://localhost:${wm.getMappedPort(8080)}"
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      System.setProperty("BASE_URL", "http://localhost")
+      System.setProperty("SPOTIFY_CLIENT_ID", "id")
+      System.setProperty("SPOTIFY_CLIENT_SECRET", "secret")
+      System.setProperty("LASTFM_API_KEY", "key")
+      System.setProperty("LASTFM_API_SECRET", "secret")
+      wm.start()
+      configureFor("localhost", wm.getMappedPort(8080))
+      val base = baseUrl
+      System.setProperty("LASTFM_API_URL", "$base/2.0/")
+      System.setProperty("LASTFM_AUTHORIZE_URL", "$base/auth")
+      System.setProperty("SPOTIFY_AUTH_URL", "$base/s-auth")
+      System.setProperty("SPOTIFY_TOKEN_URL", "$base/s-token")
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stop() {
+      wm.stop()
+    }
+  }
+
+  @BeforeEach
+  fun resetStubs() {
+    wireMockReset()
+  }
+
+  @Test
+  fun verifyLoginTrue() {
+    stubFor(
+      get(urlPathEqualTo("/2.0/"))
+        .willReturn(
+          okJson(
+            """{"recenttracks":{"totalPages":"1","track":[{"artist":{"#text":"A"},"name":"B"}]}}"""
+          )
+        )
+    )
+    val resp = rest.postForEntity("/verifyLastFmId/login", null, Boolean::class.java)
+    assertAll({ assertEquals(HttpStatus.OK, resp.statusCode) }, { assertEquals(true, resp.body) })
+  }
+
+  @Test
+  fun verifyLoginFalse() {
+    stubFor(
+      get(urlPathEqualTo("/2.0/"))
+        .willReturn(okJson("""{"recenttracks":{"totalPages":"1","track":[]}}"""))
+    )
+    val resp = rest.postForEntity("/verifyLastFmId/login", null, Boolean::class.java)
+    assertAll({ assertEquals(HttpStatus.OK, resp.statusCode) }, { assertEquals(false, resp.body) })
+  }
+}


### PR DESCRIPTION
## Summary
- make environment configurable via system properties
- add Spring Boot integration tests using WireMock
- configure test task with default env vars

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test` *(fails: GenericContainer could not start)*

------
https://chatgpt.com/codex/tasks/task_e_687f20c337848326ac3e731b0929f481