### PR TITLE
Switch Testcontainers to WireMockServer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,8 @@ dependencies {
   testImplementation("io.mockk:mockk:1.14.3")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.12.2")
   testImplementation("org.testcontainers:junit-jupiter:1.19.7")
-  testImplementation("com.github.tomakehurst:wiremock-jre8:2.35.1")
+  testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
+  testImplementation("javax.servlet:javax.servlet-api:4.0.1")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.12.2")
 }
 


### PR DESCRIPTION
## Summary
- replace Testcontainers-based WireMock with embedded WireMockServer in integration tests
- configure dynamic WireMock ports via `@DynamicPropertySource`
- mark tests with `@DirtiesContext` so each has its own application context
- update build dependencies to use WireMock standalone and servlet api

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test --no-parallel` *(fails: LastFmControllerIT > verifyLoginTrue() FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_687f2a97c8048326872741f4d09c86c7