### PR TITLE
Fix integration tests

### DIFF
--- a/src/main/kotlin/com/lis/spotify/Environment.kt
+++ b/src/main/kotlin/com/lis/spotify/Environment.kt
@@ -8,60 +8,76 @@ package com.lis.spotify
 object AppEnvironment {
   // Base URL used to assemble callback URLs for both Spotify and Last.fm.
   // CHANGE START
-  val BASE_URL: String =
-    System.getenv("BASE_URL")
-      ?: System.getProperty("BASE_URL")
-      ?: throw IllegalArgumentException("BASE_URL environment variable is missing")
+  val BASE_URL: String
+    get() =
+      System.getenv("BASE_URL")
+        ?: System.getProperty("BASE_URL")
+        ?: throw IllegalArgumentException("BASE_URL environment variable is missing")
 
   object Spotify {
-    val CLIENT_ID: String =
-      System.getenv("SPOTIFY_CLIENT_ID")
-        ?: System.getProperty("SPOTIFY_CLIENT_ID")
-        ?: throw IllegalArgumentException("SPOTIFY_CLIENT_ID environment variable is missing")
-    val CLIENT_SECRET: String =
-      System.getenv("SPOTIFY_CLIENT_SECRET")
-        ?: System.getProperty("SPOTIFY_CLIENT_SECRET")
-        ?: throw IllegalArgumentException("SPOTIFY_CLIENT_SECRET environment variable is missing")
+    val CLIENT_ID: String
+      get() =
+        System.getenv("SPOTIFY_CLIENT_ID")
+          ?: System.getProperty("SPOTIFY_CLIENT_ID")
+          ?: throw IllegalArgumentException("SPOTIFY_CLIENT_ID environment variable is missing")
+
+    val CLIENT_SECRET: String
+      get() =
+        System.getenv("SPOTIFY_CLIENT_SECRET")
+          ?: System.getProperty("SPOTIFY_CLIENT_SECRET")
+          ?: throw IllegalArgumentException("SPOTIFY_CLIENT_SECRET environment variable is missing")
 
     // Define the callback path and combine it with BASE_URL.
     const val CALLBACK_PATH: String = "/auth/spotify/callback"
-    val CALLBACK_URL: String = "$BASE_URL$CALLBACK_PATH"
+    val CALLBACK_URL: String
+      get() = "$BASE_URL$CALLBACK_PATH"
 
     // Spotify endpoints and scopes.
-    val AUTH_URL: String =
-      System.getenv("SPOTIFY_AUTH_URL")
-        ?: System.getProperty("SPOTIFY_AUTH_URL")
-        ?: "https://accounts.spotify.com/authorize"
-    val TOKEN_URL: String =
-      System.getenv("SPOTIFY_TOKEN_URL")
-        ?: System.getProperty("SPOTIFY_TOKEN_URL")
-        ?: "https://accounts.spotify.com/api/token"
+    val AUTH_URL: String
+      get() =
+        System.getenv("SPOTIFY_AUTH_URL")
+          ?: System.getProperty("SPOTIFY_AUTH_URL")
+          ?: "https://accounts.spotify.com/authorize"
+
+    val TOKEN_URL: String
+      get() =
+        System.getenv("SPOTIFY_TOKEN_URL")
+          ?: System.getProperty("SPOTIFY_TOKEN_URL")
+          ?: "https://accounts.spotify.com/api/token"
+
     const val SCOPES: String = "user-top-read playlist-modify-public"
   }
 
   object LastFm {
-    val API_KEY: String =
-      System.getenv("LASTFM_API_KEY")
-        ?: System.getProperty("LASTFM_API_KEY")
-        ?: throw IllegalArgumentException("LASTFM_API_KEY environment variable is missing")
-    val API_SECRET: String =
-      System.getenv("LASTFM_API_SECRET")
-        ?: System.getProperty("LASTFM_API_SECRET")
-        ?: throw IllegalArgumentException("LASTFM_API_SECRET environment variable is missing")
+    val API_KEY: String
+      get() =
+        System.getenv("LASTFM_API_KEY")
+          ?: System.getProperty("LASTFM_API_KEY")
+          ?: throw IllegalArgumentException("LASTFM_API_KEY environment variable is missing")
+
+    val API_SECRET: String
+      get() =
+        System.getenv("LASTFM_API_SECRET")
+          ?: System.getProperty("LASTFM_API_SECRET")
+          ?: throw IllegalArgumentException("LASTFM_API_SECRET environment variable is missing")
 
     // Define the callback path and combine it with BASE_URL.
     const val CALLBACK_PATH: String = "/auth/lastfm/callback"
-    val CALLBACK_URL: String = "$BASE_URL$CALLBACK_PATH"
+    val CALLBACK_URL: String
+      get() = "$BASE_URL$CALLBACK_PATH"
 
     // Last.fm endpoints.
-    val AUTHORIZE_URL: String =
-      System.getenv("LASTFM_AUTHORIZE_URL")
-        ?: System.getProperty("LASTFM_AUTHORIZE_URL")
-        ?: "http://www.last.fm/api/auth/"
-    val API_URL: String =
-      System.getenv("LASTFM_API_URL")
-        ?: System.getProperty("LASTFM_API_URL")
-        ?: "http://ws.audioscrobbler.com/2.0/"
+    val AUTHORIZE_URL: String
+      get() =
+        System.getenv("LASTFM_AUTHORIZE_URL")
+          ?: System.getProperty("LASTFM_AUTHORIZE_URL")
+          ?: "http://www.last.fm/api/auth/"
+
+    val API_URL: String
+      get() =
+        System.getenv("LASTFM_API_URL")
+          ?: System.getProperty("LASTFM_API_URL")
+          ?: "http://ws.audioscrobbler.com/2.0/"
   }
 }
 // CHANGE END

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
@@ -35,14 +35,23 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
     @JvmStatic
     @DynamicPropertySource
     fun properties(registry: DynamicPropertyRegistry) {
+      wm.start()
+      configureFor("localhost", wm.port())
+      val base = baseUrl
+      registry.add("BASE_URL") { "http://localhost" }
+      registry.add("SPOTIFY_CLIENT_ID") { "id" }
+      registry.add("SPOTIFY_CLIENT_SECRET") { "secret" }
+      registry.add("LASTFM_API_KEY") { "key" }
+      registry.add("LASTFM_API_SECRET") { "secret" }
+      registry.add("LASTFM_API_URL") { "$base/2.0/" }
+      registry.add("LASTFM_AUTHORIZE_URL") { "$base/auth" }
+      registry.add("SPOTIFY_AUTH_URL") { "$base/s-auth" }
+      registry.add("SPOTIFY_TOKEN_URL") { "$base/s-token" }
       System.setProperty("BASE_URL", "http://localhost")
       System.setProperty("SPOTIFY_CLIENT_ID", "id")
       System.setProperty("SPOTIFY_CLIENT_SECRET", "secret")
       System.setProperty("LASTFM_API_KEY", "key")
       System.setProperty("LASTFM_API_SECRET", "secret")
-      wm.start()
-      configureFor("localhost", wm.port())
-      val base = baseUrl
       System.setProperty("LASTFM_API_URL", "$base/2.0/")
       System.setProperty("LASTFM_AUTHORIZE_URL", "$base/auth")
       System.setProperty("SPOTIFY_AUTH_URL", "$base/s-auth")

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
@@ -33,14 +33,23 @@ class LastFmControllerIT @Autowired constructor(private val rest: TestRestTempla
     @JvmStatic
     @DynamicPropertySource
     fun properties(registry: DynamicPropertyRegistry) {
+      wm.start()
+      configureFor("localhost", wm.port())
+      val base = baseUrl
+      registry.add("BASE_URL") { "http://localhost" }
+      registry.add("SPOTIFY_CLIENT_ID") { "id" }
+      registry.add("SPOTIFY_CLIENT_SECRET") { "secret" }
+      registry.add("LASTFM_API_KEY") { "key" }
+      registry.add("LASTFM_API_SECRET") { "secret" }
+      registry.add("LASTFM_API_URL") { "$base/2.0/" }
+      registry.add("LASTFM_AUTHORIZE_URL") { "$base/auth" }
+      registry.add("SPOTIFY_AUTH_URL") { "$base/s-auth" }
+      registry.add("SPOTIFY_TOKEN_URL") { "$base/s-token" }
       System.setProperty("BASE_URL", "http://localhost")
       System.setProperty("SPOTIFY_CLIENT_ID", "id")
       System.setProperty("SPOTIFY_CLIENT_SECRET", "secret")
       System.setProperty("LASTFM_API_KEY", "key")
       System.setProperty("LASTFM_API_SECRET", "secret")
-      wm.start()
-      configureFor("localhost", wm.port())
-      val base = baseUrl
       System.setProperty("LASTFM_API_URL", "$base/2.0/")
       System.setProperty("LASTFM_AUTHORIZE_URL", "$base/auth")
       System.setProperty("SPOTIFY_AUTH_URL", "$base/s-auth")


### PR DESCRIPTION
## Summary
- rework Environment to read properties lazily
- ensure integration tests provide WireMock URLs via DynamicPropertySource and System properties

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687f313464808326909a90ccebc0ab2d