### PR TITLE
Fix playlist track deletion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("org.jsoup:jsoup:1.21.1")
   implementation("com.google.guava:guava:33.4.8-jre")
+  implementation("org.apache.httpcomponents.client5:httpclient5")
 
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
+++ b/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
@@ -1,0 +1,18 @@
+package com.lis.spotify.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class ExceptionLoggingAdvice {
+  private val logger = LoggerFactory.getLogger(ExceptionLoggingAdvice::class.java)
+
+  @ExceptionHandler(Exception::class)
+  fun handle(ex: Exception): ResponseEntity<String> {
+    logger.error("Unhandled exception", ex)
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.message)
+  }
+}

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -50,6 +50,7 @@ class SpotifyAuthenticationService(private val restTemplateBuilder: RestTemplate
     return HttpHeaders().apply {
       this[HttpHeaders.AUTHORIZATION] = "Bearer ${token.access_token}"
       this[HttpHeaders.ACCEPT] = "application/json"
+      this[HttpHeaders.CONTENT_TYPE] = MediaType.APPLICATION_JSON_VALUE
     }
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
@@ -17,6 +17,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders.RETRY_AFTER
 import org.springframework.http.HttpMethod
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
@@ -28,7 +29,8 @@ class SpotifyRestService(
   val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
 
-  val restTemplate: RestTemplate = restTemplateBuilder.build()
+  val restTemplate: RestTemplate =
+    restTemplateBuilder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java).build()
   @PublishedApi internal val logger = LoggerFactory.getLogger(SpotifyRestService::class.java)
 
   final inline fun <reified U : Any> doRequest(

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.web.client.RestTemplate
 
 class SpotifyRestServiceTest {
@@ -25,6 +26,8 @@ class SpotifyRestServiceTest {
     val restTemplate = mockk<RestTemplate>()
     val builder = mockk<RestTemplateBuilder>()
     val auth = mockk<SpotifyAuthenticationService>()
+    every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
+      builder
     every { builder.build() } returns restTemplate
     every { auth.getHeaders(any<String>()) } returns HttpHeaders()
     every {
@@ -47,6 +50,8 @@ class SpotifyRestServiceTest {
     val restTemplate = mockk<RestTemplate>()
     val builder = mockk<RestTemplateBuilder>()
     val auth = mockk<SpotifyAuthenticationService>()
+    every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
+      builder
     every { builder.build() } returns restTemplate
     every { auth.getHeaders(any<String>()) } returns HttpHeaders()
     every {


### PR DESCRIPTION
## Summary
- use Apache HttpClient to allow DELETE body
- add json content-type to headers
- validate URIs and log payload when deleting tracks
- log uncaught exceptions via `@ControllerAdvice`
- adjust tests for new requestFactory

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687f3f93bd3483269d15a95db5a1b061