### PR TITLE
Improve LastFmService error handling

### DIFF
--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -4,7 +4,11 @@ import com.lis.spotify.domain.Song
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 
 class LastFmServiceTest {
@@ -26,5 +30,81 @@ class LastFmServiceTest {
     every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns map
     val songs = service.yearlyChartlist("cid", 2020, "login")
     assertEquals(listOf(Song("A", "T")), songs)
+  }
+
+  @Test
+  fun pagingReturnsAllSongs() {
+    val rest = mockk<RestTemplate>()
+    val service = LastFmService()
+    val field = LastFmService::class.java.getDeclaredField("rest")
+    field.isAccessible = true
+    field.set(service, rest)
+    val map1 =
+      mapOf(
+        "recenttracks" to
+          mapOf(
+            "totalPages" to "2",
+            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T1")),
+          )
+      )
+    val map2 =
+      mapOf(
+        "recenttracks" to
+          mapOf(
+            "totalPages" to "2",
+            "track" to listOf(mapOf("artist" to mapOf("#text" to "B"), "name" to "T2")),
+          )
+      )
+    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returnsMany listOf(map1, map2)
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+    assertEquals(listOf(Song("A", "T1"), Song("B", "T2")), songs)
+  }
+
+  @Test
+  fun missingUserThrows400() {
+    val service = LastFmService()
+    assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "") }
+  }
+
+  @Test
+  fun rateLimitExceptionParsed() {
+    val rest = mockk<RestTemplate>()
+    val service = LastFmService()
+    val field = LastFmService::class.java.getDeclaredField("rest")
+    field.isAccessible = true
+    field.set(service, rest)
+    val ex =
+      HttpClientErrorException.create(
+        HttpStatus.TOO_MANY_REQUESTS,
+        "",
+        HttpHeaders(),
+        "{\"error\":29,\"message\":\"Rate limit\"}".toByteArray(),
+        null,
+      )
+    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    val thrown =
+      assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "u") }
+    assertEquals(29, thrown.code)
+  }
+
+  @Test
+  fun invalidApiKeyExceptionParsed() {
+    val rest = mockk<RestTemplate>()
+    val service = LastFmService()
+    val field = LastFmService::class.java.getDeclaredField("rest")
+    field.isAccessible = true
+    field.set(service, rest)
+    val ex =
+      HttpClientErrorException.create(
+        HttpStatus.FORBIDDEN,
+        "",
+        HttpHeaders(),
+        "{\"error\":10,\"message\":\"Invalid API key\"}".toByteArray(),
+        null,
+      )
+    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    val thrown =
+      assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "u") }
+    assertEquals(10, thrown.code)
   }
 }


### PR DESCRIPTION
## Summary
- handle Last.fm HTTP errors with custom `LastFmException`
- centralize URL building and correct method name
- validate inputs when fetching recent tracks
- extend unit tests for paging and error cases

## Testing
- `./gradlew test`
- `./gradlew build` *(fails: instructions covered ratio is 0.50, expected minimum 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_687f4558f35c8326a8a3375e4445f747