### PR TITLE
Add Last.fm session caching

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -37,11 +37,16 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
     val sessionData = lastFmAuthService.getSession(token)
     logger.debug("Session data received: {}", sessionData != null)
     return if (sessionData != null) {
-      val key = ((sessionData["session"] as? Map<*, *>)?.get("key") as? String)
+      val session = sessionData["session"] as? Map<*, *>
+      val key = session?.get("key") as? String
+      val name = session?.get("name") as? String
       if (!key.isNullOrEmpty()) {
         val cookie = Cookie("lastFmToken", key)
         cookie.path = "/"
         response.addCookie(cookie)
+      }
+      if (!name.isNullOrEmpty() && !key.isNullOrEmpty()) {
+        lastFmAuthService.setSession(name, key!!)
       }
       "redirect:/"
     } else {

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -25,7 +25,7 @@ class LastFmAuthenticationServiceTest {
     val field = LastFmAuthenticationService::class.java.getDeclaredField("restTemplate")
     field.isAccessible = true
     field.set(service, rest)
-    val expected = mapOf<String, Any>("session" to mapOf("name" to "val"))
+    val expected = mapOf<String, Any>("session" to mapOf("name" to "user", "key" to "val"))
     every {
       rest.postForEntity(
         any<String>(),
@@ -35,5 +35,6 @@ class LastFmAuthenticationServiceTest {
     } returns ResponseEntity(expected, HttpStatus.OK)
     val result = service.getSession("token")
     assertEquals(expected, result)
+    assertEquals("val", service.getSessionKey("user"))
   }
 }


### PR DESCRIPTION
## Summary
- cache Last.fm session keys in `LastFmAuthenticationService`
- save session details during callback
- include session key in Last.fm requests when available
- update unit tests

## Testing
- `./gradlew test --rerun-tasks`
- `./gradlew jacocoTestCoverageVerification` *(fails: instructions covered ratio is 0.51, expected minimum 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_687f4882f1d083269b9fe769f4bb1568