### PR TITLE
Improve test coverage for services

### DIFF
--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -35,6 +36,24 @@ class SpotifyAuthenticationControllerTest {
       RuntimeException()
     val id = controller.getCurrentUserId(token)
     assertNull(id)
+  }
+
+  @Test
+  fun getCurrentUserIdReturnsId() {
+    every { builder.build() } returns restTemplate
+    val token = AuthToken("a", "b", "c", 0, null, "cid")
+    every { spotifyService.getHeaders(token) } returns HttpHeaders()
+    every {
+      restTemplate.exchange<User>(
+        any<String>(),
+        HttpMethod.GET,
+        any<HttpEntity<*>>(),
+        any<ParameterizedTypeReference<User>>(),
+      )
+    } returns ResponseEntity(User("uid"), HttpStatus.OK)
+
+    val id = controller.getCurrentUserId(token)
+    assertEquals("uid", id)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.service
 import com.lis.spotify.domain.Song
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -127,5 +128,13 @@ class LastFmServiceTest {
 
     service.yearlyChartlist("c", 2020, "login")
     assert(uriSlot.captured.query!!.contains("sk=sess"))
+  }
+
+  @Test
+  fun globalChartlistDelegates() {
+    val service = spyk(LastFmService(mockk(relaxed = true)))
+    every { service.yearlyChartlist("", 1970, "login") } returns listOf(Song("a", "b"))
+    val result = service.globalChartlist("login")
+    assertEquals(listOf(Song("a", "b")), result)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -45,4 +45,18 @@ class SpotifyAuthenticationServiceTest {
     service.refreshToken("cid")
     assertEquals(newToken, service.getAuthToken("cid"))
   }
+
+  @Test
+  fun getHeadersMissingTokenReturnsEmpty() {
+    val headers = service.getHeaders("unknown")
+    assertTrue(headers.isEmpty())
+  }
+
+  @Test
+  fun refreshTokenWithoutRefreshTokenDoesNothing() {
+    val token = AuthToken("a", "b", "c", 0, null, "cid")
+    service.setAuthToken(token)
+    service.refreshToken("cid")
+    assertEquals(token, service.getAuthToken("cid"))
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -8,6 +8,8 @@ import com.lis.spotify.domain.Playlists
 import com.lis.spotify.domain.Track
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -44,5 +46,54 @@ class SpotifyPlaylistServiceTest {
     every { rest.doRequest(any<() -> Any>()) } returns playlists
     val result = service.getOrCreatePlaylist("name", "cid")
     assertEquals("p1", result.id)
+  }
+
+  @Test
+  fun currentUserPlaylistsPaged() {
+    val p1 = Playlists(listOf(Playlist("1", "n1")), "next")
+    val p2 = Playlists(listOf(Playlist("2", "n2")), null)
+    every { rest.doRequest(any<() -> Any>()) } returnsMany listOf(p1, p2)
+    val list = service.getCurrentUserPlaylists("cid")
+    assertEquals(listOf("1", "2"), list.map { it.id })
+  }
+
+  @Test
+  fun modifyPlaylistAddsAndRemoves() {
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("id", "cid") } returnsMany
+      listOf(listOf("1", "2"), listOf("2"))
+    every { spied.deleteTracksFromPlaylist("id", listOf("1"), "cid") } returns Unit
+    every { spied.addTracksToPlaylist("id", listOf("3"), "cid") } returns Unit
+    val result = spied.modifyPlaylist("id", listOf("2", "3"), "cid")
+    assertEquals(mapOf("added" to listOf("3"), "removed" to listOf("1")), result)
+  }
+
+  @Test
+  fun createPlaylistDelegates() {
+    val playlist = Playlist("1", "n")
+    every { rest.doRequest(any<() -> Any>()) } returns playlist
+    val result = service.createPlaylist("n", "cid")
+    assertEquals("1", result.id)
+  }
+
+  @Test
+  fun addTracksChunksRequests() {
+    val tracks = (1..101).map { it.toString() }
+    service.addTracksToPlaylist("pl", tracks, "cid")
+    verify(exactly = 2) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun deleteTracksChunksRequests() {
+    val tracks = (1..150).map { it.toString() }
+    service.deleteTracksFromPlaylist("pl", tracks, "cid")
+    verify(exactly = 2) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun modifyPlaylistEmptyList() {
+    val result = service.modifyPlaylist("id", emptyList(), "cid")
+    assertEquals(emptyList<String>(), result["added"])
+    assertEquals(emptyList<String>(), result["removed"])
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 
 class SpotifyRestServiceTest {
@@ -78,5 +79,37 @@ class SpotifyRestServiceTest {
     val r2 = service.doDelete<String>("http://test", clientId = "cid")
     assertEquals("ok", r1)
     assertEquals("ok", r2)
+  }
+
+  @Test
+  fun retriesOnTooManyRequests() {
+    val restTemplate = mockk<RestTemplate>()
+    val builder = mockk<RestTemplateBuilder>()
+    val auth = mockk<SpotifyAuthenticationService>()
+    every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
+      builder
+    every { builder.build() } returns restTemplate
+    every { auth.getHeaders(any<String>()) } returns HttpHeaders()
+    val ex =
+      HttpClientErrorException.create(
+        HttpStatus.TOO_MANY_REQUESTS,
+        "",
+        HttpHeaders().apply { set("Retry-After", "0") },
+        ByteArray(0),
+        null,
+      )
+    every {
+      restTemplate.exchange<String>(
+        any(),
+        HttpMethod.GET,
+        any(),
+        any<ParameterizedTypeReference<String>>(),
+        any<Map<String, *>>(),
+      )
+    } throws ex andThen ResponseEntity("ok", HttpStatus.OK)
+
+    val service = SpotifyRestService(builder, auth)
+    val result = service.doGet<String>("http://test", clientId = "cid")
+    assertEquals("ok", result)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopArtistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopArtistServiceTest.kt
@@ -1,6 +1,10 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.domain.Artist
+import com.lis.spotify.domain.Artists
+import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
@@ -9,5 +13,22 @@ class SpotifyTopArtistServiceTest {
   fun serviceInstantiates() {
     val service = SpotifyTopArtistService(mockk(relaxed = true))
     assertNotNull(service)
+  }
+
+  @Test
+  fun allTermsReturnArtists() {
+    val rest = mockk<SpotifyRestService>()
+    val service = SpotifyTopArtistService(rest)
+    val artist = Artist("1", "n")
+    val result = Artists(listOf(artist), null)
+    every { rest.doRequest(any<() -> Any>()) } returns result
+
+    val short = service.getTopArtistsShortTerm("c")
+    val mid = service.getTopArtistsMidTerm("c")
+    val long = service.getTopArtistsLongTerm("c")
+
+    assertEquals(listOf(artist), short)
+    assertEquals(listOf(artist), mid)
+    assertEquals(listOf(artist), long)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -2,9 +2,11 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Album
 import com.lis.spotify.domain.Playlist
+import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -44,5 +46,26 @@ class SpotifyTopPlaylistsServiceTest {
     val ids = service.updateTopPlaylists("cid")
     assertEquals(4, ids.size)
     verify(exactly = 4) { playlistService.modifyPlaylist(any(), any(), any()) }
+  }
+
+  @Test
+  fun updateYearlyPlaylistsUsesServices() {
+    val playlistService = mockk<SpotifyPlaylistService>(relaxed = true)
+    val trackService = mockk<SpotifyTopTrackService>(relaxed = true)
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+
+    every { lastFmService.yearlyChartlist("cid", any(), "login") } returns listOf(Song("a", "t"))
+    every { searchService.doSearch(any(), "cid", any()) } returns listOf("1")
+    every { playlistService.getOrCreatePlaylist(any(), any()) } returns Playlist("id", "n")
+    every { playlistService.modifyPlaylist(any(), any(), any()) } returns emptyMap()
+
+    val service =
+      spyk(SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService))
+    every { service["getYear"]() } returns 2007
+
+    service.updateYearlyPlaylists("cid", {}, "login")
+
+    verify(atLeast = 3) { playlistService.modifyPlaylist("id", listOf("1"), "cid") }
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopTrackServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopTrackServiceTest.kt
@@ -1,6 +1,11 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.domain.Album
+import com.lis.spotify.domain.Track
+import com.lis.spotify.domain.Tracks
+import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
@@ -9,5 +14,22 @@ class SpotifyTopTrackServiceTest {
   fun serviceInstantiates() {
     val service = SpotifyTopTrackService(mockk(relaxed = true))
     assertNotNull(service)
+  }
+
+  @Test
+  fun allTermsReturnTracks() {
+    val rest = mockk<SpotifyRestService>()
+    val service = SpotifyTopTrackService(rest)
+    val track = Track("1", "n", emptyList(), Album("a", "n", emptyList()))
+    val result = Tracks(listOf(track))
+    every { rest.doRequest(any<() -> Any>()) } returns result
+
+    val short = service.getTopTracksShortTerm("c")
+    val mid = service.getTopTracksMidTerm("c")
+    val long = service.getTopTracksLongTerm("c")
+
+    assertEquals(listOf(track), short)
+    assertEquals(listOf(track), mid)
+    assertEquals(listOf(track), long)
   }
 }


### PR DESCRIPTION
## Summary
- add new tests for a variety of services
- expand controller test coverage
- cover retry logic in `SpotifyRestService`
- extend playlist service tests for chunking and empty cases
- improve LastFm service coverage

## Testing
- `./gradlew test` *(fails: coverage below threshold)*
- `./gradlew jacocoTestReport jacocoTestCoverageVerification` *(fails: 0.67 < 0.80)*
- `./gradlew build` *(fails due to coverage)*

------
https://chatgpt.com/codex/tasks/task_e_687f4df673d8832691eaa9c32f4c40da