### PR TITLE
Fix Last.fm chart parsing

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -72,7 +72,9 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
     do {
       val data = fetchRecent(lastFmLogin, from, to, page++)
       val recent = data["recenttracks"] as Map<*, *>
-      totalPages = (recent["totalPages"] as String).toInt()
+      val attr = recent["@attr"] as? Map<*, *>
+      val pages = (recent["totalPages"] as? String) ?: (attr?.get("totalPages") as? String) ?: "1"
+      totalPages = pages.toInt()
       val tracks = recent["track"] as List<*>
       for (t in tracks) {
         val m = t as Map<*, *>

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
@@ -74,7 +74,7 @@ class LastFmControllerIT @Autowired constructor(private val rest: TestRestTempla
       get(urlPathEqualTo("/2.0/"))
         .willReturn(
           okJson(
-            """{"recenttracks":{"totalPages":"1","track":[{"artist":{"#text":"A"},"name":"B"}]}}"""
+            """{"recenttracks":{"@attr":{"totalPages":"1"},"track":[{"artist":{"#text":"A"},"name":"B"}]}}"""
           )
         )
     )
@@ -86,7 +86,7 @@ class LastFmControllerIT @Autowired constructor(private val rest: TestRestTempla
   fun verifyLoginFalse() {
     stubFor(
       get(urlPathEqualTo("/2.0/"))
-        .willReturn(okJson("""{"recenttracks":{"totalPages":"1","track":[]}}"""))
+        .willReturn(okJson("""{"recenttracks":{"@attr":{"totalPages":"1"},"track":[]}}"""))
     )
     val resp = rest.postForEntity("/verifyLastFmId/login", null, Boolean::class.java)
     assertAll({ assertEquals(HttpStatus.OK, resp.statusCode) }, { assertEquals(false, resp.body) })

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -24,7 +24,7 @@ class LastFmServiceTest {
       mapOf(
         "recenttracks" to
           mapOf(
-            "totalPages" to "1",
+            "@attr" to mapOf("totalPages" to "1"),
             "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T")),
           )
       )
@@ -45,7 +45,7 @@ class LastFmServiceTest {
       mapOf(
         "recenttracks" to
           mapOf(
-            "totalPages" to "2",
+            "@attr" to mapOf("totalPages" to "2"),
             "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T1")),
           )
       )
@@ -53,7 +53,7 @@ class LastFmServiceTest {
       mapOf(
         "recenttracks" to
           mapOf(
-            "totalPages" to "2",
+            "@attr" to mapOf("totalPages" to "2"),
             "track" to listOf(mapOf("artist" to mapOf("#text" to "B"), "name" to "T2")),
           )
       )
@@ -123,7 +123,10 @@ class LastFmServiceTest {
     field.set(service, rest)
     val uriSlot = io.mockk.slot<java.net.URI>()
     every { rest.getForObject(capture(uriSlot), Map::class.java) } returns
-      mapOf("recenttracks" to mapOf("totalPages" to "1", "track" to emptyList<String>()))
+      mapOf(
+        "recenttracks" to
+          mapOf("@attr" to mapOf("totalPages" to "1"), "track" to emptyList<String>())
+      )
 
     service.yearlyChartlist("c", 2020, "login")
     assert(uriSlot.captured.query!!.contains("sk=sess"))


### PR DESCRIPTION
## Summary
- handle `@attr.totalPages` from Last.fm API
- update service and integration tests

## Testing
- `./gradlew test --rerun-tasks`
- `./gradlew jacocoTestReport jacocoTestCoverageVerification` *(fails: instructions covered ratio is 0.51, expected minimum 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_687f5064c5648326a3b21d0a55841b5e