### PR TITLE
Fix Last.fm callback redirect

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -4,9 +4,9 @@ import com.lis.spotify.service.LastFmAuthenticationService
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.view.RedirectView
 
 /**
@@ -16,7 +16,7 @@ import org.springframework.web.servlet.view.RedirectView
  * 1. GET /auth/lastfm - Redirects the user to Last.fm's authorization page.
  * 2. GET /auth/lastfm/callback - Receives the authentication token and exchanges it for a session.
  */
-@RestController
+@Controller
 class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthenticationService) {
 
   @GetMapping("/auth/lastfm")

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -30,6 +30,19 @@ class LastFmAuthenticationControllerTest {
   }
 
   @Test
+  fun handleCallbackMissingToken() {
+    val result = controller.handleCallback(null, mockk(relaxed = true))
+    assertEquals("redirect:/error", result)
+  }
+
+  @Test
+  fun handleCallbackNoSession() {
+    every { service.getSession("tok") } returns null
+    val result = controller.handleCallback("tok", mockk(relaxed = true))
+    assertEquals("redirect:/error", result)
+  }
+
+  @Test
   fun handleCallbackSetsCookiePath() {
     every { service.getSession("tok") } returns mapOf("session" to mapOf("key" to "v"))
     val response = mockk<HttpServletResponse>(relaxed = true)


### PR DESCRIPTION
## Summary
- return a proper redirect from the Last.fm callback
- adjust integration test to check 302 response
- cover missing branches in `LastFmAuthenticationController`

## Testing
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification` *(fails: instructions covered ratio is 0.67, but expected minimum is 0.80)*
- `./gradlew build` *(fails: instructions covered ratio is 0.67, but expected minimum is 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_687f57a7e664832689f87372cd56ef82