### PR TITLE
Handle Last.fm login errors

### DIFF
--- a/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
+++ b/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
@@ -1,6 +1,8 @@
 package com.lis.spotify.config
 
+import com.lis.spotify.service.LastFmException
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
@@ -9,6 +11,18 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 @ControllerAdvice
 class ExceptionLoggingAdvice {
   private val logger = LoggerFactory.getLogger(ExceptionLoggingAdvice::class.java)
+
+  @ExceptionHandler(LastFmException::class)
+  fun handleLastFm(ex: LastFmException): ResponseEntity<Void> {
+    logger.warn("Last.fm exception {} {}", ex.code, ex.message)
+    return if (ex.code == 17) {
+      ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
+        .header(HttpHeaders.LOCATION, "/auth/lastfm")
+        .build()
+    } else {
+      ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+    }
+  }
 
   @ExceptionHandler(Exception::class)
   fun handle(ex: Exception): ResponseEntity<String> {

--- a/src/test/kotlin/com/lis/spotify/config/ExceptionLoggingAdviceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/config/ExceptionLoggingAdviceTest.kt
@@ -1,0 +1,16 @@
+package com.lis.spotify.config
+
+import com.lis.spotify.service.LastFmException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class ExceptionLoggingAdviceTest {
+  @Test
+  fun lastFmError17Redirects() {
+    val advice = ExceptionLoggingAdvice()
+    val result = advice.handleLastFm(LastFmException(17, "Login"))
+    assertEquals(HttpStatus.TEMPORARY_REDIRECT, result.statusCode)
+    assertEquals("/auth/lastfm", result.headers.location.toString())
+  }
+}

--- a/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
+++ b/src/test/kotlin/com/lis/spotify/config/WebSocketConfigTest.kt
@@ -2,6 +2,8 @@ package com.lis.spotify.config
 
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.websocket.server.HandshakeRequest
+import jakarta.websocket.server.ServerEndpointConfig
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -29,5 +31,32 @@ class WebSocketConfigTest {
     configurator.setApplicationContext(ctx)
     val result = configurator.getEndpointInstance(Dummy::class.java)
     assertSame(bean, result)
+  }
+
+  class DummyRequest(val request: jakarta.servlet.http.HttpServletRequest) : HandshakeRequest {
+    override fun getHeaders(): MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    override fun getParameterMap(): MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    override fun getQueryString(): String? = null
+
+    override fun getRequestURI(): java.net.URI? = null
+
+    override fun getUserPrincipal(): java.security.Principal? = null
+
+    override fun isUserInRole(role: String?): Boolean = false
+
+    override fun getHttpSession(): Any? = null
+  }
+
+  @Test
+  fun modifyHandshakeExtractsClientId() {
+    val httpReq = mockk<jakarta.servlet.http.HttpServletRequest>()
+    every { httpReq.cookies } returns arrayOf(jakarta.servlet.http.Cookie("clientId", "cid"))
+    val req = DummyRequest(httpReq)
+    val config = ServerEndpointConfig.Builder.create(Dummy::class.java, "/").build()
+    val configurator = WebsocketSpringConfigurator()
+    configurator.modifyHandshake(config, req, mockk())
+    assertSame("cid", config.userProperties["clientId"])
   }
 }

--- a/src/test/kotlin/com/lis/spotify/domain/DomainClassesTest.kt
+++ b/src/test/kotlin/com/lis/spotify/domain/DomainClassesTest.kt
@@ -24,4 +24,26 @@ class DomainClassesTest {
     val song = Song("artist", "title")
     assertEquals("title", song.title)
   }
+
+  @Test
+  fun allDomainClassesInstantiate() {
+    val artist = Artist("1", "a")
+    val album = Album("2", "al", listOf(artist))
+    val track = Track("3", "t", listOf(artist), album)
+    val playlist = Playlist("p", "name")
+    val playlistTrack = PlaylistTrack(track)
+    val playlistTracks = PlaylistTracks(listOf(playlistTrack), null)
+    val playlists = Playlists(listOf(playlist), null)
+    val tracks = Tracks(listOf(track))
+    val srInt = SearchResultInternal(listOf(track))
+    val sr = SearchResult(srInt)
+    val user = User("u")
+    val login = LastFmLogin("cid", "l")
+    assertEquals("u", user.id)
+    assertEquals("l", login.lastFmLogin)
+    assertEquals(listOf(track), tracks.items)
+    assertEquals(srInt, sr.tracks)
+    assertEquals(playlist, playlists.items.first())
+    assertEquals(playlistTrack, playlistTracks.items.first())
+  }
 }


### PR DESCRIPTION
## Summary
- redirect to `/auth/lastfm` when Last.fm session error 17 occurs
- test the exception advice redirect logic
- verify WebSocket handshake extracts the client id
- instantiate all domain classes in tests

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build` *(fails: instructions covered ratio is 0.69, required 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_687f5bf30e988326bb9e53357a9bf2b5