### PR TITLE
Replace manual retry with RetryTemplate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("org.jsoup:jsoup:1.21.1")
   implementation("com.google.guava:guava:33.4.8-jre")
   implementation("org.apache.httpcomponents.client5:httpclient5")
+  implementation("org.springframework.retry:spring-retry")
 
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.jetbrains.kotlin:kotlin-test")


### PR DESCRIPTION
## Summary
- use `RetryTemplate` for retries in `SpotifyRestService`
- add `spring-retry` dependency

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687f6ff83dc48326a4a51aafae7b19c1