### PR TITLE
Implement lazy Last.fm fetching

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -26,6 +26,8 @@ class SpotifyTopPlaylistsService(
   var spotifySearchService: SpotifySearchService,
 ) {
 
+  private val YEARLY_LIMIT = 250
+
   private val logger = LoggerFactory.getLogger(SpotifyTopPlaylistsService::class.java)
 
   fun updateTopPlaylists(clientId: String): List<String> {
@@ -92,9 +94,9 @@ class SpotifyTopPlaylistsService(
       val trackList = mutableListOf<String>()
       for (song in chartlist) {
         val result = spotifySearchService.doSearch(song, clientId)
-        progressUpdater(Pair(year, progress.incrementAndGet() * 100 / chartlist.size))
+        progressUpdater(Pair(year, progress.incrementAndGet() * 100 / YEARLY_LIMIT))
         result?.tracks?.items?.stream()?.findFirst()?.orElse(null)?.let { trackList += it.id }
-        if (trackList.size >= 250) break
+        if (trackList.size >= YEARLY_LIMIT) break
       }
       progressUpdater(Pair(year, 100))
       if (trackList.isNotEmpty()) {

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmControllerIT.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.integration
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.configureFor
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
@@ -72,11 +73,17 @@ class LastFmControllerIT @Autowired constructor(private val rest: TestRestTempla
   fun verifyLoginTrue() {
     stubFor(
       get(urlPathEqualTo("/2.0/"))
+        .withQueryParam("page", equalTo("1"))
         .willReturn(
           okJson(
             """{"recenttracks":{"@attr":{"totalPages":"1"},"track":[{"artist":{"#text":"A"},"name":"B"}]}}"""
           )
         )
+    )
+    stubFor(
+      get(urlPathEqualTo("/2.0/"))
+        .withQueryParam("page", equalTo("2"))
+        .willReturn(okJson("""{"recenttracks":{"@attr":{"totalPages":"1"},"track":[]}}"""))
     )
     val resp = rest.postForEntity("/verifyLastFmId/login", null, Boolean::class.java)
     assertAll({ assertEquals(HttpStatus.OK, resp.statusCode) }, { assertEquals(true, resp.body) })
@@ -86,6 +93,7 @@ class LastFmControllerIT @Autowired constructor(private val rest: TestRestTempla
   fun verifyLoginFalse() {
     stubFor(
       get(urlPathEqualTo("/2.0/"))
+        .withQueryParam("page", equalTo("1"))
         .willReturn(okJson("""{"recenttracks":{"@attr":{"totalPages":"1"},"track":[]}}"""))
     )
     val resp = rest.postForEntity("/verifyLastFmId/login", null, Boolean::class.java)


### PR DESCRIPTION
## Summary
- make LastFmService fetch pages until it receives no songs
- update unit tests for lazy sequence behavior
- adjust LastFmController integration tests to stub sequential pages

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687f7d5f0c5c832692a3816b80631978