### PR TITLE
Avoid creating empty playlists

### DIFF
--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -45,4 +45,23 @@ class SpotifyTopPlaylistsServiceTest {
     assertEquals(4, ids.size)
     verify(exactly = 4) { playlistService.modifyPlaylist(any(), any(), any()) }
   }
+
+  @Test
+  fun noTracksSkipsPlaylistCreation() {
+    val playlistService = mockk<SpotifyPlaylistService>(relaxed = true)
+    val trackService = mockk<SpotifyTopTrackService>()
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+
+    every { trackService.getTopTracksShortTerm(any()) } returns emptyList()
+    every { trackService.getTopTracksMidTerm(any()) } returns emptyList()
+    every { trackService.getTopTracksLongTerm(any()) } returns emptyList()
+
+    val service =
+      SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+    val ids = service.updateTopPlaylists("cid")
+    assertEquals(emptyList<String>(), ids)
+    verify(exactly = 0) { playlistService.getOrCreatePlaylist(any(), any()) }
+    verify(exactly = 0) { playlistService.modifyPlaylist(any(), any(), any()) }
+  }
 }


### PR DESCRIPTION
## Summary
- only create playlists when there are tracks to add
- update yearly playlist logic to skip empty lists
- test that playlist creation is skipped when there are no tracks

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687f9f544318832693157aa8f33d31b3