### PR TITLE
Use IO dispatcher for year playlist updates

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -13,6 +13,7 @@
 package com.lis.spotify.service
 
 import java.util.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
@@ -94,7 +95,7 @@ class SpotifyTopPlaylistsService(
       val chartlists =
         years
           .map { year ->
-            async {
+            async(Dispatchers.IO) {
               year to lastFmService.yearlyChartlist(clientId, year, lastFmLogin, YEARLY_LIMIT)
             }
           }
@@ -103,7 +104,7 @@ class SpotifyTopPlaylistsService(
 
       years
         .map { year: Int ->
-          async {
+          async(Dispatchers.IO) {
             progressUpdater(Pair(year, 0))
             val chartlist = chartlists[year].orEmpty()
             val playlistId =


### PR DESCRIPTION
## Summary
- load yearly chartlists and playlists using `Dispatchers.IO`
- import `kotlinx.coroutines.Dispatchers`

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fa0b9d01c8326bcc82809b29f9750