### PR TITLE
Optimize playlist diff logic

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -99,14 +99,7 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
   }
 
   private fun getDiff(old: List<String>, new: List<String>): ArrayList<String> {
-    val ret = ArrayList<String>()
-    old.forEach {
-      if (it in new) {} else {
-
-        ret += it
-      }
-    }
-    return ret
+    return ArrayList(old.toSet() - new.toSet())
   }
 
   fun modifyPlaylist(
@@ -118,16 +111,14 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     logger.info("modifyPlaylist: {} {} {}", id, clientId, trackList.size)
 
     if (trackList.isNotEmpty()) {
-      var old = getPlaylistTrackIds(id, clientId).orEmpty()
-      val new = trackList
+      val old = getPlaylistTrackIds(id, clientId).orEmpty()
+      val oldSet = old.toSet()
+      val newSet = trackList.toSet()
 
-      val tracksToRemove = getDiff(old, new)
-
+      val tracksToRemove = (oldSet - newSet).toList()
       deleteTracksFromPlaylist(id, tracksToRemove, clientId)
 
-      old = getPlaylistTrackIds(id, clientId).orEmpty()
-
-      val tracksToAdd = getDiff(new, old)
+      val tracksToAdd = (newSet - oldSet).toList()
       addTracksToPlaylist(id, tracksToAdd, clientId)
 
       val result = mapOf("added" to tracksToAdd, "removed" to tracksToRemove)

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -60,12 +60,14 @@ class SpotifyPlaylistServiceTest {
   @Test
   fun modifyPlaylistAddsAndRemoves() {
     val spied = spyk(service)
-    every { spied.getPlaylistTrackIds("id", "cid") } returnsMany
-      listOf(listOf("1", "2"), listOf("2"))
+    every { spied.getPlaylistTrackIds("id", "cid") } returns listOf("1", "2")
     every { spied.deleteTracksFromPlaylist("id", listOf("1"), "cid") } returns Unit
     every { spied.addTracksToPlaylist("id", listOf("3"), "cid") } returns Unit
     val result = spied.modifyPlaylist("id", listOf("2", "3"), "cid")
     assertEquals(mapOf("added" to listOf("3"), "removed" to listOf("1")), result)
+    verify(exactly = 1) { spied.getPlaylistTrackIds("id", "cid") }
+    verify(exactly = 1) { spied.deleteTracksFromPlaylist("id", listOf("1"), "cid") }
+    verify(exactly = 1) { spied.addTracksToPlaylist("id", listOf("3"), "cid") }
   }
 
   @Test


### PR DESCRIPTION
## Summary
- simplify `getDiff` with set-based implementation
- avoid extra API call in `modifyPlaylist` by computing add/remove sets directly
- update unit tests for new behaviour

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa0c9dae0832697227cd3c20b11b8