### PR TITLE
Handle Retry-After on 429 responses

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/RetryAfterHeaderBackOffPolicy.kt
+++ b/src/main/kotlin/com/lis/spotify/service/RetryAfterHeaderBackOffPolicy.kt
@@ -1,0 +1,36 @@
+package com.lis.spotify.service
+
+import org.springframework.retry.RetryContext
+import org.springframework.retry.backoff.BackOffContext
+import org.springframework.retry.backoff.BackOffInterruptedException
+import org.springframework.retry.backoff.BackOffPolicy
+import org.springframework.retry.backoff.Sleeper
+import org.springframework.retry.backoff.ThreadWaitSleeper
+import org.springframework.web.client.HttpClientErrorException
+
+class RetryAfterHeaderBackOffPolicy(
+  private val sleeper: Sleeper = ThreadWaitSleeper(),
+  private val defaultBackoff: Long = 1000L,
+) : BackOffPolicy {
+
+  private class Context(val retryContext: RetryContext) : BackOffContext
+
+  override fun start(context: RetryContext): BackOffContext = Context(context)
+
+  override fun backOff(backOffContext: BackOffContext) {
+    val ctx = backOffContext as Context
+    val throwable = ctx.retryContext.lastThrowable
+    val retryAfterSeconds =
+      (throwable as? HttpClientErrorException.TooManyRequests)
+        ?.responseHeaders
+        ?.getFirst("Retry-After")
+        ?.toLongOrNull()
+    val delayMillis = retryAfterSeconds?.times(1000) ?: defaultBackoff
+    try {
+      sleeper.sleep(delayMillis)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      throw BackOffInterruptedException("Interrupted while backing off", e)
+    }
+  }
+}

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -12,6 +13,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.retry.backoff.Sleeper
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 
@@ -111,5 +113,39 @@ class SpotifyRestServiceTest {
     val service = SpotifyRestService(builder, auth)
     val result = service.doGet<String>("http://test", clientId = "cid")
     assertEquals("ok", result)
+  }
+
+  @Test
+  fun usesRetryAfterHeaderAsBackoff() {
+    val restTemplate = mockk<RestTemplate>()
+    val builder = mockk<RestTemplateBuilder>()
+    val auth = mockk<SpotifyAuthenticationService>()
+    val sleeper = mockk<Sleeper>(relaxUnitFun = true)
+    every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
+      builder
+    every { builder.build() } returns restTemplate
+    every { auth.getHeaders(any<String>()) } returns HttpHeaders()
+    val ex =
+      HttpClientErrorException.create(
+        HttpStatus.TOO_MANY_REQUESTS,
+        "",
+        HttpHeaders().apply { set("Retry-After", "2") },
+        ByteArray(0),
+        null,
+      )
+    every {
+      restTemplate.exchange<String>(
+        any(),
+        HttpMethod.GET,
+        any(),
+        any<ParameterizedTypeReference<String>>(),
+        any<Map<String, *>>(),
+      )
+    } throws ex andThen ResponseEntity("ok", HttpStatus.OK)
+
+    val service = SpotifyRestService(builder, auth, sleeper)
+    val result = service.doGet<String>("http://test", clientId = "cid")
+    assertEquals("ok", result)
+    verify(exactly = 1) { sleeper.sleep(2000L) }
   }
 }


### PR DESCRIPTION
## Summary
- add `RetryAfterHeaderBackOffPolicy` to control backoff delay
- inject `Sleeper` into `SpotifyRestService`
- use custom backoff policy that reads `Retry-After` header
- test that the new backoff uses the header value

## Testing
- `./gradlew test jacocoTestCoverageVerification --no-daemon`
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687fa1275c3883268191d354ae41e386