### PR TITLE
Implement Last.fm session expiration

### DIFF
--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -45,4 +45,14 @@ class LastFmAuthenticationServiceTest {
     assertEquals(true, service.isAuthorized("val"))
     assertEquals(false, service.isAuthorized("other"))
   }
+
+  @Test
+  fun expiredSessionIsRemoved() {
+    val service = LastFmAuthenticationService()
+    // Use a timestamp far in the past so the entry is expired
+    service.sessionCache["user"] = Pair("val", System.currentTimeMillis() - 10 * 60 * 1000L)
+
+    assertEquals(false, service.isAuthorized("val"))
+    assertEquals(null, service.getSessionKey("user"))
+  }
 }


### PR DESCRIPTION
## Summary
- store timestamps in `LastFmAuthenticationService` session cache
- purge sessions after five minutes
- respect expiration when checking authorization or retrieving keys
- test removal of expired sessions

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fa0d2be908326b39739b3d852f38a