### PR TITLE
Deduplicate yearly playlist tracks

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -102,6 +102,27 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     return ArrayList(old.toSet() - new.toSet())
   }
 
+  fun replacePlaylistTracks(id: String, trackList: List<String>, clientId: String) {
+    logger.debug("replacePlaylistTracks {} {} {}", id, clientId, trackList.size)
+    logger.info("replacePlaylistTracks: {} {} {}", id, clientId, trackList.size)
+
+    spotifyRestService.doPut<Any>(
+      PLAYLIST_TRACKS_URL,
+      body = mapOf("uris" to trackList.map { "spotify:track:$it" }),
+      params = mapOf("id" to id),
+      clientId = clientId,
+    )
+    logger.debug("replacePlaylistTracks {} {} -> replaced {}", id, clientId, trackList.size)
+  }
+
+  fun deduplicatePlaylist(id: String, clientId: String) {
+    val tracks = getPlaylistTrackIds(id, clientId).orEmpty()
+    val distinct = tracks.distinct()
+    if (tracks.size != distinct.size) {
+      replacePlaylistTracks(id, distinct, clientId)
+    }
+  }
+
   fun modifyPlaylist(
     id: String,
     trackList: List<String>,

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
@@ -102,4 +102,13 @@ class SpotifyRestService(
   ): U {
     return doRequest(url, HttpMethod.POST, params, body, clientId)
   }
+
+  final inline fun <reified U : Any> doPut(
+    url: String,
+    params: Map<String, Any> = HashMap(),
+    body: Any? = null,
+    clientId: String,
+  ): U {
+    return doRequest(url, HttpMethod.PUT, params, body, clientId)
+  }
 }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -128,7 +128,8 @@ class SpotifyTopPlaylistsService(
             if (trackList.isNotEmpty()) {
               val playlistId =
                 spotifyPlaylistService.getOrCreatePlaylist("LAST.FM $year", clientId).id
-              spotifyPlaylistService.modifyPlaylist(playlistId, trackList, clientId)
+              spotifyPlaylistService.modifyPlaylist(playlistId, trackList.distinct(), clientId)
+              spotifyPlaylistService.deduplicatePlaylist(playlistId, clientId)
             }
             progressUpdater(Pair(year, 100))
           }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -98,4 +98,25 @@ class SpotifyPlaylistServiceTest {
     assertEquals(emptyList<String>(), result["added"])
     assertEquals(emptyList<String>(), result["removed"])
   }
+
+  @Test
+  fun deduplicatePlaylistRemovesDuplicates() {
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("pl", "cid") } returns listOf("1", "1", "2")
+    every { spied.replacePlaylistTracks("pl", listOf("1", "2"), "cid") } returns Unit
+
+    spied.deduplicatePlaylist("pl", "cid")
+
+    verify(exactly = 1) { spied.replacePlaylistTracks("pl", listOf("1", "2"), "cid") }
+  }
+
+  @Test
+  fun deduplicatePlaylistNoDuplicates() {
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("pl", "cid") } returns listOf("1", "2")
+
+    spied.deduplicatePlaylist("pl", "cid")
+
+    verify(exactly = 0) { spied.replacePlaylistTracks(any(), any(), any()) }
+  }
 }


### PR DESCRIPTION
## Summary
- replace playlist tracks via new PUT helper
- deduplicate playlist content in SpotifyPlaylistService
- use deduplication after yearly chartlist creation
- add unit tests for deduplication logic

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa343c3148326b357cc66c4fd0edf