### PR TITLE
Fix erratic progress bar

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -1,6 +1,7 @@
 package com.lis.spotify.service
 
 import java.util.*
+import kotlin.math.roundToInt
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
 
@@ -22,9 +23,9 @@ class JobService(
           playlistService.updateYearlyPlaylists(
             clientId,
             { (year, pct) ->
-              val base = (year - startYear) * 100 / total
-              val overall = base + pct / total
-              store.update(id, overall, "year $year")
+              val base = (year - startYear) * 100.0 / total
+              val overall = base + pct / total.toDouble()
+              store.update(id, overall.roundToInt(), "year $year")
             },
             lastFmLogin,
           )

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -49,6 +49,7 @@ $('#lastfm').on('click', function (event) {
         data: JSON.stringify({lastFmLogin: $('#lastFmId').val()}),
         success: function (data) {
             $("#progress").show();
+            $("#progressBar")[0].style.width = '0%';
             const jobId = data.jobId;
             let interval = setInterval(function () {
                 $.get(URL + '/jobs/' + jobId + '/progress', function (p) {
@@ -56,6 +57,7 @@ $('#lastfm').on('click', function (event) {
                     if (p.status !== 'RUNNING') {
                         clearInterval(interval);
                         $("#progress").hide();
+                        $("#progressBar")[0].style.width = '0%';
                         $('#lastfm').prop('disabled', false);
                         $('#lastFmId').prop('disabled', false);
                     }

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -3,6 +3,8 @@ package com.lis.spotify.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
+import kotlin.math.roundToInt
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -32,5 +34,30 @@ class JobServiceTest {
       { assertEquals(100, progress.percent) },
       { assertEquals("DONE", progress.status.name) },
     )
+  }
+
+  @Test
+  fun progressUsesDecimals() {
+    val playlistService = mockk<SpotifyTopPlaylistsService>()
+    val scheduler = mockk<TaskScheduler>()
+    val store = mockk<ProgressStore>(relaxed = true)
+    val runnable = slot<Runnable>()
+    every { scheduler.schedule(capture(runnable), any<java.util.Date>()) } answers
+      {
+        runnable.captured.run()
+        mockk<java.util.concurrent.ScheduledFuture<*>>(relaxed = true)
+      }
+    val updater = slot<(Pair<Int, Int>) -> Unit>()
+    every { playlistService.updateYearlyPlaylists(any(), capture(updater), any()) } answers
+      {
+        updater.captured(Pair(2005, 50))
+      }
+    val service = JobService(playlistService, scheduler, store)
+    service.startYearlyJob("c", "l")
+    val startYear = 2005
+    val endYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
+    val total = endYear - startYear + 1
+    val expected = (((2005 - startYear) * 100.0 / total) + 50 / total.toDouble()).roundToInt()
+    verify { store.update(any(), expected, "year 2005") }
   }
 }


### PR DESCRIPTION
## Summary
- smooth job progress calculation in `JobService`
- reset progress bar width when starting or finishing a job
- test progress calculation uses decimal percentages

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa6123e188326a80f415fc0a68232