### PR TITLE
Switch auth caches to ConcurrentHashMap

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.service
 import com.lis.spotify.AppEnvironment.LastFm
 import java.math.BigInteger
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -23,7 +24,7 @@ import org.springframework.web.client.RestTemplate
 class LastFmAuthenticationService {
 
   private val restTemplate = RestTemplate()
-  val sessionCache: MutableMap<String, Pair<String, Long>> = mutableMapOf()
+  val sessionCache = ConcurrentHashMap<String, Pair<String, Long>>()
 
   fun setSession(login: String, sessionKey: String) {
     sessionCache[login] = Pair(sessionKey, System.currentTimeMillis())

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -29,6 +29,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.AppEnvironment.Spotify
 import com.lis.spotify.domain.AuthToken
+import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -43,7 +44,7 @@ import org.springframework.web.util.UriComponentsBuilder
 @Service
 class SpotifyAuthenticationService(private val restTemplateBuilder: RestTemplateBuilder) {
 
-  val tokenCache: MutableMap<String, AuthToken> = mutableMapOf()
+  val tokenCache = ConcurrentHashMap<String, AuthToken>()
 
   fun getHeaders(token: AuthToken): HttpHeaders {
     logger.debug("Creating headers with Bearer token for clientId={}", token.clientId)

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -2,6 +2,10 @@ package com.lis.spotify.service
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
@@ -54,5 +58,21 @@ class LastFmAuthenticationServiceTest {
 
     assertEquals(false, service.isAuthorized("val"))
     assertEquals(null, service.getSessionKey("user"))
+  }
+
+  @Test
+  fun concurrentReadWriteDoesNotThrow() = runBlocking {
+    val service = LastFmAuthenticationService()
+    coroutineScope {
+      repeat(50) {
+        launch(Dispatchers.Default) {
+          val login = "u$it"
+          val session = "s$it"
+          service.setSession(login, session)
+          service.isAuthorized(session)
+          service.getSessionKey(login)
+        }
+      }
+    }
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -4,6 +4,10 @@ import com.lis.spotify.domain.AuthToken
 import io.mockk.every
 import io.mockk.mockk
 import java.net.URI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -58,5 +62,19 @@ class SpotifyAuthenticationServiceTest {
     service.setAuthToken(token)
     service.refreshToken("cid")
     assertEquals(token, service.getAuthToken("cid"))
+  }
+
+  @Test
+  fun concurrentReadWriteDoesNotThrow() = runBlocking {
+    coroutineScope {
+      repeat(50) {
+        launch(Dispatchers.Default) {
+          val id = "c$it"
+          val token = AuthToken("a$id", "type", "", 0, "r", id)
+          service.setAuthToken(token)
+          service.getAuthToken(id)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use `ConcurrentHashMap` for tokenCache and sessionCache
- add concurrent access tests for both authentication services

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687fa6f7f3488326888be126dc335a34