### PR TITLE
Forward Last.fm page parameter

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -66,6 +66,7 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
     year: Int,
     lastFmLogin: String,
     limit: Int = Int.MAX_VALUE,
+    startPage: Int = 1,
   ): List<Song> {
     log.debug("yearlyChartlist {} {} {}", spotifyClientId, year, lastFmLogin)
     if (lastFmLogin.isBlank()) throw LastFmException(400, "user is required")
@@ -73,7 +74,7 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
     val to = LocalDate.of(year, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC)
 
     val result = mutableListOf<Song>()
-    var page = 1
+    var page = startPage
     var fetched = 0
     while (result.size < limit) {
       val data = fetchRecent(lastFmLogin, from, to, page++)
@@ -95,7 +96,7 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
 
   fun globalChartlist(lastFmLogin: String, page: Int = 1): List<Song> {
     log.debug("globalChartlist {} {}", lastFmLogin, page)
-    return yearlyChartlist("", 1970, lastFmLogin) // reuse; no date filter needed
+    return yearlyChartlist("", 1970, lastFmLogin, startPage = page)
   }
 }
 

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -92,7 +92,7 @@ class LastFmServiceTest {
       )
     every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns map1
 
-    val songs = service.yearlyChartlist("cid", 2020, "login", 1)
+    val songs = service.yearlyChartlist("cid", 2020, "login", limit = 1)
 
     assertEquals(listOf(Song("A", "T1")), songs)
     io.mockk.verify(exactly = 1) { rest.getForObject(any<java.net.URI>(), Map::class.java) }
@@ -169,10 +169,11 @@ class LastFmServiceTest {
   }
 
   @Test
-  fun globalChartlistDelegates() {
+  fun globalChartlistForwardsPage() {
     val service = spyk(LastFmService(mockk(relaxed = true)))
-    every { service.yearlyChartlist("", 1970, "login") } returns listOf(Song("a", "b"))
-    val result = service.globalChartlist("login")
+    every { service.yearlyChartlist("", 1970, "login", startPage = 2) } returns
+      listOf(Song("a", "b"))
+    val result = service.globalChartlist("login", 2)
     assertEquals(listOf(Song("a", "b")), result)
   }
 }


### PR DESCRIPTION
## Summary
- allow `globalChartlist` to request a specific page
- update yearly chart logic to accept a starting page
- adjust tests for the new API

## Testing
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fa70291a88326b1e9e6a8faafe9ef