### PR TITLE
Set HttpOnly and Secure on cookies

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -43,6 +43,8 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       if (!key.isNullOrEmpty()) {
         val cookie = Cookie("lastFmToken", key)
         cookie.path = "/"
+        cookie.isHttpOnly = true
+        cookie.secure = true
         response.addCookie(cookie)
       }
       if (!name.isNullOrEmpty() && !key.isNullOrEmpty()) {

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
@@ -81,7 +81,12 @@ class SpotifyAuthenticationController(
       if (clientId != null) {
         authToken.clientId = clientId
         spotifyAuthenticationService.setAuthToken(authToken)
-        val cookie = Cookie("clientId", clientId).apply { path = "/" }
+        val cookie =
+          Cookie("clientId", clientId).apply {
+            path = "/"
+            isHttpOnly = true
+            secure = true
+          }
         response.addCookie(cookie)
         logger.info("Successfully set auth token for user: {}", clientId)
       } else {

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -52,5 +52,7 @@ class LastFmAuthenticationControllerTest {
     controller.handleCallback("tok", response)
 
     assertEquals("/", cookieSlot.captured.path)
+    assertTrue(cookieSlot.captured.isHttpOnly)
+    assertTrue(cookieSlot.captured.secure)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -94,6 +94,10 @@ class SpotifyAuthenticationControllerTest {
 
     controller.callback(request, "code", response)
 
-    verify { response.addCookie(match { it.name == "clientId" && it.path == "/" }) }
+    verify {
+      response.addCookie(
+        match { it.name == "clientId" && it.path == "/" && it.isHttpOnly && it.secure }
+      )
+    }
   }
 }


### PR DESCRIPTION
## Summary
- mark cookies as `HttpOnly` and `Secure`
- verify cookie flags in controller tests

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa7099fd483268c333268f65dd333