### PR TITLE
Handle empty Spotify API responses

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
@@ -76,7 +76,15 @@ class SpotifyRestService(
         params,
       )
     logger.debug("doExchange response from {} {} -> {}", httpMethod, url, response.statusCode)
-    return response.body ?: throw Exception() // TODO:
+    val result = response.body
+    if (result != null) {
+      return result
+    }
+    if (U::class == Unit::class) {
+      @Suppress("UNCHECKED_CAST")
+      return Unit as U
+    }
+    throw IllegalStateException("Received null body for ${httpMethod.name()} $url")
   }
 
   final inline fun <reified U : Any> doGet(

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -84,6 +84,30 @@ class SpotifyRestServiceTest {
   }
 
   @Test
+  fun postReturnsUnitWhenBodyIsNull() {
+    val restTemplate = mockk<RestTemplate>()
+    val builder = mockk<RestTemplateBuilder>()
+    val auth = mockk<SpotifyAuthenticationService>()
+    every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
+      builder
+    every { builder.build() } returns restTemplate
+    every { auth.getHeaders(any<String>()) } returns HttpHeaders()
+    every {
+      restTemplate.exchange<Unit>(
+        any(),
+        HttpMethod.POST,
+        any(),
+        any<ParameterizedTypeReference<Unit>>(),
+        any<Map<String, *>>(),
+      )
+    } returns ResponseEntity(null, HttpStatus.NO_CONTENT)
+
+    val service = SpotifyRestService(builder, auth)
+    val result = service.doPost<Unit>("http://test", clientId = "cid")
+    assertEquals(Unit, result)
+  }
+
+  @Test
   fun retriesOnTooManyRequests() {
     val restTemplate = mockk<RestTemplate>()
     val builder = mockk<RestTemplateBuilder>()


### PR DESCRIPTION
## Summary
- avoid throwing if a response has no body
- add test covering the case when POST response is empty

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew build`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa71357bc832696a24a735a1625b6