### PR TITLE
Improve logging defaults

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.controller
 
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.service.JobService
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -16,6 +17,7 @@ class JobsController(private val jobService: JobService) {
     @CookieValue("clientId") clientId: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
+    logger.info("Starting yearly job for {}", clientId)
     val id = jobService.startYearlyJob(clientId, request.lastFmLogin)
     return ResponseEntity.accepted().body(JobId(id))
   }
@@ -23,4 +25,8 @@ class JobsController(private val jobService: JobService) {
   @GetMapping("/{id}/progress")
   fun progress(@PathVariable id: String) =
     jobService.progress(id)?.let { ResponseEntity.ok(it) } ?: ResponseEntity.notFound().build()
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(JobsController::class.java)
+  }
 }

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -47,9 +47,11 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       }
       if (!name.isNullOrEmpty() && !key.isNullOrEmpty()) {
         lastFmAuthService.setSession(name, key!!)
+        logger.info("Successfully authenticated Last.fm user: {}", name)
       }
       "redirect:/"
     } else {
+      logger.error("Failed to obtain Last.fm session for token {}", token)
       "redirect:/error"
     }
   }

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmController.kt
@@ -23,7 +23,9 @@ class LastFmController(val lastFmService: LastFmService) {
   @PostMapping("/verifyLastFmId/{lastFmLogin}")
   fun verifyLastFmId(@PathVariable("lastFmLogin") lastFmLogin: String): Boolean {
     logger.debug("verifyLastFmId for {}", lastFmLogin)
-    return lastFmService.globalChartlist(lastFmLogin).isNotEmpty()
+    val valid = lastFmService.globalChartlist(lastFmLogin).isNotEmpty()
+    logger.info("Verification for Last.fm user {} -> {}", lastFmLogin, valid)
+    return valid
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -27,7 +27,9 @@ class SpotifyTopPlaylistsController(
   @PostMapping("/updateTopPlaylists")
   fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
     logger.debug("updateTopPlaylists for {}", clientId)
-    return spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    val result = spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    logger.info("Updated top playlists for {} -> {} playlists", clientId, result.size)
+    return result
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -1,6 +1,7 @@
 package com.lis.spotify.service
 
 import java.util.*
+import org.slf4j.LoggerFactory
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
 
@@ -12,6 +13,7 @@ class JobService(
 ) {
   fun startYearlyJob(clientId: String, lastFmLogin: String): String {
     val id = UUID.randomUUID().toString()
+    logger.info("Scheduled yearly playlist job {} for {}", id, clientId)
     store.create(id)
     scheduler.schedule(
       {
@@ -28,8 +30,10 @@ class JobService(
             },
             lastFmLogin,
           )
+          logger.info("Yearly playlist job {} completed", id)
           store.complete(id)
         } catch (e: Exception) {
+          logger.error("Yearly playlist job {} failed", id, e)
           store.fail(id, e.message)
         }
       },
@@ -39,4 +43,8 @@ class JobService(
   }
 
   fun progress(id: String) = store.get(id)
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(JobService::class.java)
+  }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.forward-headers-strategy=native
 logging.level.root=INFO
-logging.level.com.lis.spotify=DEBUG
+logging.level.com.lis.spotify=INFO
 logging.level.org.apache.coyote.http11.Http11Processor=WARN
 server.tomcat.keep-alive-timeout=10s
 server.tomcat.max-keep-alive-requests=1


### PR DESCRIPTION
## Summary
- default to INFO logging
- add info logs for job and authentication events
- log Last.fm ID validation results
- log playlist updates

## Testing
- `./gradlew test --no-daemon`
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687fa791e86c8326bb3f0cccbde7ceaa