### PR TITLE
Encode Last.fm callback using UriComponentsBuilder

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -2,6 +2,8 @@ package com.lis.spotify.service
 
 import com.lis.spotify.AppEnvironment.LastFm
 import java.math.BigInteger
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 /**
  * LastFmAuthenticationService handles building the Last.fm authorization URL and exchanging an
@@ -60,7 +63,11 @@ class LastFmAuthenticationService {
    */
   fun getAuthorizationUrl(): String {
     logger.debug("getAuthorizationUrl() called")
-    return "${LastFm.AUTHORIZE_URL}?api_key=${LastFm.API_KEY}&cb=${LastFm.CALLBACK_URL}"
+    return UriComponentsBuilder.fromHttpUrl(LastFm.AUTHORIZE_URL)
+      .queryParam("api_key", LastFm.API_KEY)
+      .queryParam("cb", URLEncoder.encode(LastFm.CALLBACK_URL, StandardCharsets.UTF_8))
+      .build(true)
+      .toUriString()
   }
 
   /**

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -1,7 +1,10 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.AppEnvironment.LastFm
 import io.mockk.every
 import io.mockk.mockk
+import java.net.URI
+import java.nio.charset.StandardCharsets
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
@@ -9,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 class LastFmAuthenticationServiceTest {
   @Test
@@ -16,6 +20,18 @@ class LastFmAuthenticationServiceTest {
     val service = LastFmAuthenticationService()
     val url = service.getAuthorizationUrl()
     assert(url.contains("api_key"))
+  }
+
+  @Test
+  fun callbackParameterIsEncoded() {
+    val service = LastFmAuthenticationService()
+    val url = service.getAuthorizationUrl()
+    val uri = URI(url)
+    val params = UriComponentsBuilder.fromUri(uri).build().queryParams
+    val cb = params.getFirst("cb")
+    val decoded = java.net.URLDecoder.decode(cb, StandardCharsets.UTF_8)
+    assertEquals(LastFm.CALLBACK_URL, decoded)
+    assert(cb != LastFm.CALLBACK_URL)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- build the Last.fm authorization URL with `UriComponentsBuilder`
- percent-encode the callback parameter
- verify encoding in `LastFmAuthenticationServiceTest`

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fa72480a0832689fe90b450122a9a