### PR TITLE
Improve logging configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ This repository uses Gradle and Kotlin.
 - Run the test suite with `./gradlew test`.
 - Run `./gradlew build` to ensure the project compiles.
 
+### Logging
+- Use SLF4J with a `private val logger` per class.
+- Default log level is INFO.
+- Use INFO for high-level events, DEBUG for details, WARN for recoverable problems, and ERROR for failures.
+
 ### Integration tests
 Integration tests live under `src/test/kotlin/.../integration`. They should start
 the application with `@SpringBootTest(webEnvironment = RANDOM_PORT)` and use

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -49,6 +49,7 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       }
       if (!name.isNullOrEmpty() && !key.isNullOrEmpty()) {
         lastFmAuthService.setSession(name, key!!)
+        logger.info("Successfully authenticated Last.fm user {}", name)
       }
       "redirect:/"
     } else {

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -28,7 +28,9 @@ class SpotifyTopPlaylistsController(
   fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
     logger.info("Updating top playlists for {}", clientId)
     logger.debug("updateTopPlaylists for {}", clientId)
-    return spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    val result = spotifyTopPlaylistsService.updateTopPlaylists(clientId)
+    logger.info("UpdateTopPlaylists result for {} -> {}", clientId, result)
+    return result
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -28,6 +28,7 @@ class LastFmAuthenticationService {
 
   fun setSession(login: String, sessionKey: String) {
     sessionCache[login] = Pair(sessionKey, System.currentTimeMillis())
+    logger.info("Stored session for {}", login)
   }
 
   internal fun isTokenExpired(timestamp: Long): Boolean {
@@ -108,6 +109,7 @@ class LastFmAuthenticationService {
       val key = session?.get("key") as? String
       if (!name.isNullOrEmpty() && !key.isNullOrEmpty()) {
         setSession(name, key)
+        logger.info("Retrieved session for {}", name)
       }
       body
     } catch (ex: Exception) {

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -88,6 +88,7 @@ class SpotifyTopPlaylistsService(
 
       val result = ids.toList()
       logger.debug("updateTopPlaylists {} -> {}", clientId, result)
+      logger.info("Updated top playlists for {} -> {}", clientId, result)
       result
     }
   }
@@ -136,7 +137,7 @@ class SpotifyTopPlaylistsService(
         }
         .awaitAll()
     }
-    logger.debug("updateYearlyPlaylists {} completed", clientId)
+    logger.info("updateYearlyPlaylists {} completed", clientId)
   }
 
   private fun getYear() = Calendar.getInstance().get(Calendar.YEAR)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
@@ -41,23 +41,29 @@ class SpotifyTopTrackService(var spotifyRestService: SpotifyRestService) {
   }
 
   fun getTopTracksLongTerm(clientId: String): List<Track> {
+    logger.info("Fetching long-term top tracks for {}", clientId)
     logger.debug("getTopTracksLongTerm {}", clientId)
     val items = getTopTracks(LONG_TERM, clientId).items
     logger.debug("getTopTracksLongTerm {} -> {} items", clientId, items.size)
+    logger.info("Fetched {} long-term tracks for {}", items.size, clientId)
     return items
   }
 
   fun getTopTracksMidTerm(clientId: String): List<Track> {
+    logger.info("Fetching mid-term top tracks for {}", clientId)
     logger.debug("getTopTracksMidTerm {}", clientId)
     val items = getTopTracks(MID_TERM, clientId).items
     logger.debug("getTopTracksMidTerm {} -> {} items", clientId, items.size)
+    logger.info("Fetched {} mid-term tracks for {}", items.size, clientId)
     return items
   }
 
   fun getTopTracksShortTerm(clientId: String): List<Track> {
+    logger.info("Fetching short-term top tracks for {}", clientId)
     logger.debug("getTopTracksShortTerm {}", clientId)
     val items = getTopTracks(SHORT_TERM, clientId).items
     logger.debug("getTopTracksShortTerm {} -> {} items", clientId, items.size)
+    logger.info("Fetched {} short-term tracks for {}", items.size, clientId)
     return items
   }
 }


### PR DESCRIPTION
## Summary
- add logging guidelines in `AGENTS.md`
- log session storage and retrieval in `LastFmAuthenticationService`
- log successful Last.fm auth callback
- log playlist update results
- log yearly playlist completion
- add information logs for fetching top tracks

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fac0975f88326a8ee9b7ae9a07ef5