### PR TITLE
Ensure callback param is encoded in Last.fm auth URL

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 /**
  * LastFmAuthenticationService handles building the Last.fm authorization URL and exchanging an
@@ -62,7 +63,12 @@ class LastFmAuthenticationService {
    */
   fun getAuthorizationUrl(): String {
     logger.debug("getAuthorizationUrl() called")
-    return "${LastFm.AUTHORIZE_URL}?api_key=${LastFm.API_KEY}&cb=${LastFm.CALLBACK_URL}"
+    return UriComponentsBuilder.fromHttpUrl(LastFm.AUTHORIZE_URL)
+      .queryParam("api_key", LastFm.API_KEY)
+      .queryParam("cb", "{cb}")
+      .encode()
+      .buildAndExpand(LastFm.CALLBACK_URL)
+      .toUriString()
   }
 
   /**

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -1,7 +1,9 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.AppEnvironment
 import io.mockk.every
 import io.mockk.mockk
+import java.net.URLEncoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -20,6 +22,8 @@ class LastFmAuthenticationServiceTest {
     val service = LastFmAuthenticationService()
     val url = service.getAuthorizationUrl()
     assert(url.contains("api_key"))
+    val encoded = URLEncoder.encode(AppEnvironment.LastFm.CALLBACK_URL, "UTF-8")
+    assert(url.contains("cb=$encoded"))
   }
 
   @Test


### PR DESCRIPTION
## Summary
- build Last.fm authorization URL with `UriComponentsBuilder`
- encode callback URL as query parameter
- test that callback parameter is encoded

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fb0f75c8483268f418db2449ce093