### PR TITLE
Fix mixed content for Last.fm URLs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/Environment.kt
+++ b/src/main/kotlin/com/lis/spotify/Environment.kt
@@ -71,13 +71,13 @@ object AppEnvironment {
       get() =
         System.getenv("LASTFM_AUTHORIZE_URL")
           ?: System.getProperty("LASTFM_AUTHORIZE_URL")
-          ?: "http://www.last.fm/api/auth/"
+          ?: "https://www.last.fm/api/auth/"
 
     val API_URL: String
       get() =
         System.getenv("LASTFM_API_URL")
           ?: System.getProperty("LASTFM_API_URL")
-          ?: "http://ws.audioscrobbler.com/2.0/"
+          ?: "https://ws.audioscrobbler.com/2.0/"
   }
 }
 // CHANGE END

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -59,7 +59,7 @@ class LastFmAuthenticationService {
   /**
    * Constructs the URL that the user will be redirected to in order to grant access.
    *
-   * Format: http://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
+   * Format: https://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
    */
   fun getAuthorizationUrl(): String {
     logger.debug("getAuthorizationUrl() called")


### PR DESCRIPTION
## Summary
- default Last.fm endpoint URLs use HTTPS
- update Last.fm auth service docs

## Testing
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fd28abc748326a073ffad37c89e7c