### PR TITLE
Fix mixed content for Last.fm auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ credentials are available at runtime:
 - `SPOTIFY_CLIENT_SECRET` – Spotify application client secret
 - `LASTFM_API_KEY` – Last.fm API key
 - `LASTFM_API_SECRET` – Last.fm API secret
+- Last.fm endpoints default to HTTPS. Override `LASTFM_API_URL` and
+  `LASTFM_AUTHORIZE_URL` only if custom values are required.

--- a/src/main/kotlin/com/lis/spotify/Environment.kt
+++ b/src/main/kotlin/com/lis/spotify/Environment.kt
@@ -71,13 +71,13 @@ object AppEnvironment {
       get() =
         System.getenv("LASTFM_AUTHORIZE_URL")
           ?: System.getProperty("LASTFM_AUTHORIZE_URL")
-          ?: "http://www.last.fm/api/auth/"
+          ?: "https://www.last.fm/api/auth/"
 
     val API_URL: String
       get() =
         System.getenv("LASTFM_API_URL")
           ?: System.getProperty("LASTFM_API_URL")
-          ?: "http://ws.audioscrobbler.com/2.0/"
+          ?: "https://ws.audioscrobbler.com/2.0/"
   }
 }
 // CHANGE END

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -59,7 +59,7 @@ class LastFmAuthenticationService {
   /**
    * Constructs the URL that the user will be redirected to in order to grant access.
    *
-   * Format: http://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
+   * Format: https://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
    */
   fun getAuthorizationUrl(): String {
     logger.debug("getAuthorizationUrl() called")


### PR DESCRIPTION
## Summary
- switch Last.fm defaults to HTTPS
- clarify that Last.fm endpoints use HTTPS by default
- update documentation comment for Last.fm authentication service

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew build`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_687fd28abc748326a073ffad37c89e7c