### PR TITLE
Avoid empty deletion in playlist modification

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -137,7 +137,9 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
       val newSet = trackList.toSet()
 
       val tracksToRemove = (oldSet - newSet).toList()
-      deleteTracksFromPlaylist(id, tracksToRemove, clientId)
+      if (tracksToRemove.isNotEmpty()) {
+        deleteTracksFromPlaylist(id, tracksToRemove, clientId)
+      }
 
       val tracksToAdd = (newSet - oldSet).toList()
       addTracksToPlaylist(id, tracksToAdd, clientId)

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -100,6 +100,19 @@ class SpotifyPlaylistServiceTest {
   }
 
   @Test
+  fun modifyPlaylistNoChanges() {
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("id", "cid") } returns listOf("1", "2")
+    every { spied.addTracksToPlaylist("id", emptyList(), "cid") } returns Unit
+
+    val result = spied.modifyPlaylist("id", listOf("1", "2"), "cid")
+
+    assertEquals(emptyList<String>(), result["added"])
+    assertEquals(emptyList<String>(), result["removed"])
+    verify(exactly = 0) { spied.deleteTracksFromPlaylist(any(), any(), any()) }
+  }
+
+  @Test
   fun deduplicatePlaylistRemovesDuplicates() {
     val spied = spyk(service)
     every { spied.getPlaylistTrackIds("pl", "cid") } returns listOf("1", "1", "2")


### PR DESCRIPTION
## Summary
- skip deleteTracksFromPlaylist when there are no tracks to remove
- add unit test covering no-change playlist scenario

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_687fe287a84c8326926c9248a470b77f