### PR TITLE
Avoid concurrent Last.fm chart fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ credentials are available at runtime:
 
 Enter your Last.fm login on the main page and click **LAST.FM** to refresh yearly
 playlists. The refresh runs in the background and logs progress to the
-application console.
+application console. To avoid overwhelming Last.fm, yearly charts are fetched
+sequentially rather than all at once.

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -100,18 +100,9 @@ class SpotifyTopPlaylistsService(
       val years = (2005..getYear()).toList().sortedDescending()
       val total = years.size
 
-      val chartlists =
-        years
-          .associateWith { year ->
-            async(Dispatchers.IO) {
-              lastFmService.yearlyChartlist(clientId, year, lastFmLogin, YEARLY_LIMIT)
-            }
-          }
-          .mapValues { it.value.await() }
-
       years.forEachIndexed { idx, year ->
         logger.info("Processing year {} ({}/{})", year, idx + 1, total)
-        val chartlist = chartlists[year].orEmpty()
+        val chartlist = lastFmService.yearlyChartlist(clientId, year, lastFmLogin, YEARLY_LIMIT)
 
         val deferred =
           chartlist.take(YEARLY_LIMIT).map { song ->


### PR DESCRIPTION
## Summary
- fetch yearly chartlists sequentially to avoid spamming Last.fm
- document sequential fetching

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_6880c60287208326a3388c58cd1dc34d