### PR TITLE
Improve playlist dedupe

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -119,7 +119,12 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     val tracks = getPlaylistTrackIds(id, clientId).orEmpty()
     val distinct = tracks.distinct()
     if (tracks.size != distinct.size) {
-      replacePlaylistTracks(id, distinct, clientId)
+      if (distinct.size <= 100) {
+        replacePlaylistTracks(id, distinct, clientId)
+      } else {
+        replacePlaylistTracks(id, distinct.take(100), clientId)
+        addTracksToPlaylist(id, distinct.drop(100), clientId)
+      }
     }
   }
 

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -132,4 +132,19 @@ class SpotifyPlaylistServiceTest {
 
     verify(exactly = 0) { spied.replacePlaylistTracks(any(), any(), any()) }
   }
+
+  @Test
+  fun deduplicatePlaylistLarge() {
+    val spied = spyk(service)
+    val tracks = (1..105).map { it.toString() } + listOf("1", "2")
+    every { spied.getPlaylistTrackIds("pl", "cid") } returns tracks
+    every { spied.replacePlaylistTracks(any(), any(), any()) } returns Unit
+    every { spied.addTracksToPlaylist(any(), any(), any()) } returns Unit
+
+    spied.deduplicatePlaylist("pl", "cid")
+
+    val distinct = tracks.distinct()
+    verify(exactly = 1) { spied.replacePlaylistTracks("pl", distinct.take(100), "cid") }
+    verify(exactly = 1) { spied.addTracksToPlaylist("pl", distinct.drop(100), "cid") }
+  }
 }


### PR DESCRIPTION
## Summary
- deduplicate playlists in batches when they exceed 100 tracks
- test deduplication for playlists over the 100 track limit

## Testing
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew build`
- `./gradlew jacocoTestCoverageVerification`


------
https://chatgpt.com/codex/tasks/task_e_6881ebb34a1c832687def3ca41e1a94a