### PR TITLE
Add durable API caches and higher playlist parallelism

### DIFF
--- a/src/main/kotlin/com/lis/spotify/persistence/AppStateStoreConfiguration.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/AppStateStoreConfiguration.kt
@@ -87,6 +87,26 @@ class AppStateStoreConfiguration(
   }
 
   @Bean
+  @ConditionalOnProperty(
+    name = ["app.state-store.mode"],
+    havingValue = "firestore",
+    matchIfMissing = true,
+  )
+  fun firestoreSpotifySearchCacheStore(firestore: Firestore): SpotifySearchCacheStore {
+    return FirestoreSpotifySearchCacheStore(firestore)
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+    name = ["app.state-store.mode"],
+    havingValue = "firestore",
+    matchIfMissing = true,
+  )
+  fun firestoreLastFmRecentTracksCacheStore(firestore: Firestore): LastFmRecentTracksCacheStore {
+    return FirestoreLastFmRecentTracksCacheStore(firestore)
+  }
+
+  @Bean
   @ConditionalOnProperty(name = ["app.state-store.mode"], havingValue = "memory")
   fun inMemoryJobStatusStore(): JobStatusStore {
     logger.info("Initializing in-memory job status store")
@@ -112,6 +132,20 @@ class AppStateStoreConfiguration(
   fun inMemoryRefreshStateStore(): RefreshStateStore {
     logger.info("Initializing in-memory refresh state store")
     return InMemoryRefreshStateStore()
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = ["app.state-store.mode"], havingValue = "memory")
+  fun inMemorySpotifySearchCacheStore(): SpotifySearchCacheStore {
+    logger.info("Initializing in-memory Spotify search cache store")
+    return InMemorySpotifySearchCacheStore()
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = ["app.state-store.mode"], havingValue = "memory")
+  fun inMemoryLastFmRecentTracksCacheStore(): LastFmRecentTracksCacheStore {
+    logger.info("Initializing in-memory Last.fm recent-tracks cache store")
+    return InMemoryLastFmRecentTracksCacheStore()
   }
 
   private fun configuredProjectId(): String {

--- a/src/main/kotlin/com/lis/spotify/persistence/AppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/AppStateStores.kt
@@ -25,3 +25,15 @@ interface RefreshStateStore {
 
   fun getTopPlaylists(): StoredRefreshState?
 }
+
+interface SpotifySearchCacheStore {
+  fun save(entry: StoredSpotifySearchCacheEntry): StoredSpotifySearchCacheEntry
+
+  fun findByKey(cacheKey: String): StoredSpotifySearchCacheEntry?
+}
+
+interface LastFmRecentTracksCacheStore {
+  fun save(page: StoredLastFmRecentTracksPage): StoredLastFmRecentTracksPage
+
+  fun findByKey(cacheKey: String): StoredLastFmRecentTracksPage?
+}

--- a/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
@@ -8,6 +8,8 @@ private const val JOBS_COLLECTION = "jobs"
 private const val SPOTIFY_AUTH_TOKENS_COLLECTION = "spotifyAuthTokens"
 private const val LAST_FM_SESSIONS_COLLECTION = "lastFmSessions"
 private const val REFRESH_STATE_COLLECTION = "refreshState"
+private const val SPOTIFY_SEARCH_CACHE_COLLECTION = "spotifySearchCache"
+private const val LAST_FM_RECENT_TRACKS_CACHE_COLLECTION = "lastFmRecentTracksCache"
 
 abstract class FirestoreStoreSupport(protected val firestore: Firestore) {
   protected fun loadDocument(collection: String, documentId: String): DocumentSnapshot? {
@@ -97,5 +99,37 @@ class FirestoreRefreshStateStore(firestore: Firestore) :
       loadDocument(REFRESH_STATE_COLLECTION, StoredRefreshState.TOP_PLAYLISTS_DOCUMENT_ID)
         ?: return null
     return StoredRefreshState.fromDocument(document)
+  }
+}
+
+class FirestoreSpotifySearchCacheStore(firestore: Firestore) :
+  FirestoreStoreSupport(firestore), SpotifySearchCacheStore {
+  private val logger = LoggerFactory.getLogger(FirestoreSpotifySearchCacheStore::class.java)
+
+  override fun save(entry: StoredSpotifySearchCacheEntry): StoredSpotifySearchCacheEntry {
+    saveDocument(SPOTIFY_SEARCH_CACHE_COLLECTION, entry.cacheKey, entry.toFirestoreMap())
+    logger.debug("Saved Firestore Spotify search cache {}", entry.cacheKey)
+    return entry
+  }
+
+  override fun findByKey(cacheKey: String): StoredSpotifySearchCacheEntry? {
+    val document = loadDocument(SPOTIFY_SEARCH_CACHE_COLLECTION, cacheKey) ?: return null
+    return StoredSpotifySearchCacheEntry.fromDocument(document)
+  }
+}
+
+class FirestoreLastFmRecentTracksCacheStore(firestore: Firestore) :
+  FirestoreStoreSupport(firestore), LastFmRecentTracksCacheStore {
+  private val logger = LoggerFactory.getLogger(FirestoreLastFmRecentTracksCacheStore::class.java)
+
+  override fun save(page: StoredLastFmRecentTracksPage): StoredLastFmRecentTracksPage {
+    saveDocument(LAST_FM_RECENT_TRACKS_CACHE_COLLECTION, page.cacheKey, page.toFirestoreMap())
+    logger.debug("Saved Firestore Last.fm recent-tracks cache {}", page.cacheKey)
+    return page
+  }
+
+  override fun findByKey(cacheKey: String): StoredLastFmRecentTracksPage? {
+    val document = loadDocument(LAST_FM_RECENT_TRACKS_CACHE_COLLECTION, cacheKey) ?: return null
+    return StoredLastFmRecentTracksPage.fromDocument(document)
   }
 }

--- a/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
@@ -83,3 +83,41 @@ class InMemoryRefreshStateStore : RefreshStateStore {
     state.set(null)
   }
 }
+
+class InMemorySpotifySearchCacheStore : SpotifySearchCacheStore {
+  private val logger = LoggerFactory.getLogger(InMemorySpotifySearchCacheStore::class.java)
+  private val entries = ConcurrentHashMap<String, StoredSpotifySearchCacheEntry>()
+
+  override fun save(entry: StoredSpotifySearchCacheEntry): StoredSpotifySearchCacheEntry {
+    entries[entry.cacheKey] = entry
+    logger.debug("Saved in-memory Spotify search cache {}", entry.cacheKey)
+    return entry
+  }
+
+  override fun findByKey(cacheKey: String): StoredSpotifySearchCacheEntry? {
+    return entries[cacheKey]
+  }
+
+  fun clear() {
+    entries.clear()
+  }
+}
+
+class InMemoryLastFmRecentTracksCacheStore : LastFmRecentTracksCacheStore {
+  private val logger = LoggerFactory.getLogger(InMemoryLastFmRecentTracksCacheStore::class.java)
+  private val pages = ConcurrentHashMap<String, StoredLastFmRecentTracksPage>()
+
+  override fun save(page: StoredLastFmRecentTracksPage): StoredLastFmRecentTracksPage {
+    pages[page.cacheKey] = page
+    logger.debug("Saved in-memory Last.fm recent-tracks cache {}", page.cacheKey)
+    return page
+  }
+
+  override fun findByKey(cacheKey: String): StoredLastFmRecentTracksPage? {
+    return pages[cacheKey]
+  }
+
+  fun clear() {
+    pages.clear()
+  }
+}

--- a/src/main/kotlin/com/lis/spotify/persistence/PersistenceDocuments.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/PersistenceDocuments.kt
@@ -5,6 +5,7 @@ import com.google.cloud.firestore.DocumentSnapshot
 import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
+import com.lis.spotify.domain.Song
 import java.time.Duration
 import java.time.Instant
 
@@ -212,6 +213,109 @@ data class StoredRefreshState(
         lastPlaylistIds =
           (document.get("lastPlaylistIds") as? List<*>)?.filterIsInstance<String>().orEmpty(),
         updatedAt = document.getInstant("updatedAt") ?: Instant.EPOCH,
+      )
+    }
+  }
+}
+
+data class StoredSpotifySearchCacheEntry(
+  val cacheKey: String,
+  val clientId: String,
+  val query: String,
+  val payloadJson: String,
+  val updatedAt: Instant,
+  val expiresAt: Instant,
+) {
+  fun isFresh(now: Instant): Boolean {
+    return expiresAt.isAfter(now)
+  }
+
+  fun toFirestoreMap(): Map<String, Any> {
+    return mapOf(
+      "cacheKey" to cacheKey,
+      "clientId" to clientId,
+      "query" to query,
+      "payloadJson" to payloadJson,
+      "updatedAt" to updatedAt.toFirestoreTimestamp(),
+      "expiresAt" to expiresAt.toFirestoreTimestamp(),
+    )
+  }
+
+  companion object {
+    fun fromDocument(document: DocumentSnapshot): StoredSpotifySearchCacheEntry? {
+      if (!document.exists()) {
+        return null
+      }
+
+      val cacheKey = document.getString("cacheKey") ?: document.id
+      val payloadJson = document.getString("payloadJson") ?: return null
+      val updatedAt = document.getInstant("updatedAt") ?: Instant.EPOCH
+      val expiresAt = document.getInstant("expiresAt") ?: updatedAt
+      return StoredSpotifySearchCacheEntry(
+        cacheKey = cacheKey,
+        clientId = document.getString("clientId").orEmpty(),
+        query = document.getString("query").orEmpty(),
+        payloadJson = payloadJson,
+        updatedAt = updatedAt,
+        expiresAt = expiresAt,
+      )
+    }
+  }
+}
+
+data class CachedLastFmRecentTracksPage(val totalPages: Int, val songs: List<Song>)
+
+data class StoredLastFmRecentTracksPage(
+  val cacheKey: String,
+  val login: String,
+  val from: Long,
+  val to: Long,
+  val page: Int,
+  val sessionKey: String?,
+  val payloadJson: String,
+  val updatedAt: Instant,
+  val expiresAt: Instant,
+) {
+  fun isFresh(now: Instant): Boolean {
+    return expiresAt.isAfter(now)
+  }
+
+  fun toFirestoreMap(): Map<String, Any> {
+    val data =
+      mutableMapOf<String, Any>(
+        "cacheKey" to cacheKey,
+        "login" to login,
+        "from" to from,
+        "to" to to,
+        "page" to page,
+        "payloadJson" to payloadJson,
+        "updatedAt" to updatedAt.toFirestoreTimestamp(),
+        "expiresAt" to expiresAt.toFirestoreTimestamp(),
+      )
+    sessionKey?.let { data["sessionKey"] = it }
+    return data
+  }
+
+  companion object {
+    fun fromDocument(document: DocumentSnapshot): StoredLastFmRecentTracksPage? {
+      if (!document.exists()) {
+        return null
+      }
+
+      val cacheKey = document.getString("cacheKey") ?: document.id
+      val payloadJson = document.getString("payloadJson") ?: return null
+      val updatedAt = document.getInstant("updatedAt") ?: Instant.EPOCH
+      val expiresAt = document.getInstant("expiresAt") ?: updatedAt
+      return StoredLastFmRecentTracksPage(
+        cacheKey = cacheKey,
+        login = document.getString("login").orEmpty(),
+        from = document.getLong("from") ?: 0L,
+        to = document.getLong("to") ?: 0L,
+        page = document.getLong("page")?.toInt() ?: 1,
+        sessionKey = document.getString("sessionKey"),
+        payloadJson = payloadJson,
+        updatedAt = updatedAt,
+        expiresAt = expiresAt,
       )
     }
   }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -1,12 +1,31 @@
 package com.lis.spotify.service
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.google.common.cache.Cache
+import com.google.common.cache.CacheBuilder
 import com.lis.spotify.AppEnvironment.LastFm
 import com.lis.spotify.domain.Song
+import com.lis.spotify.persistence.CachedLastFmRecentTracksPage
+import com.lis.spotify.persistence.LastFmRecentTracksCacheStore
+import com.lis.spotify.persistence.StoredLastFmRecentTracksPage
 import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.ResourceAccessException
@@ -14,39 +33,89 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 
 @Service
-class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) {
+class LastFmService(
+  private val lastFmAuthService: LastFmAuthenticationService,
+  private val lastFmRecentTracksCacheStore: LastFmRecentTracksCacheStore,
+  private val clock: Clock,
+  @Value("\${lastfm.recent-tracks.max-parallelism:16}")
+  configuredRecentTracksParallelism: Int = DEFAULT_RECENT_TRACKS_MAX_PARALLELISM,
+  @Value("\${lastfm.recent-tracks.cache-ttl:PT168H}")
+  configuredCacheTtl: Duration = DEFAULT_CACHE_TTL,
+) {
 
   internal var rest = RestTemplate()
   internal var sleeper: LastFmSleeper = LastFmSleeper { millis -> Thread.sleep(millis) }
+  internal var recentTracksParallelism = configuredRecentTracksParallelism.coerceAtLeast(1)
+  internal var cacheTtl = configuredCacheTtl
+
   private val logger = LoggerFactory.getLogger(LastFmService::class.java)
   private val mapper = jacksonObjectMapper()
+  private val recentTracksCache: Cache<String, StoredLastFmRecentTracksPage> =
+    CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
 
   private fun buildUri(method: String, params: Map<String, Any>, sessionKey: String?): URI {
-    var b =
-      UriComponentsBuilder.fromHttpUrl(LastFm.API_URL)
+    var builder =
+      UriComponentsBuilder.fromUriString(LastFm.API_URL)
         .queryParam("method", method)
         .queryParam("api_key", LastFm.API_KEY)
         .queryParam("format", "json")
     if (!sessionKey.isNullOrBlank()) {
-      b = b.queryParam("sk", sessionKey)
+      builder = builder.queryParam("sk", sessionKey)
     }
-    params.forEach { (k, v) -> b = b.queryParam(k, v) }
-    return b.build().toUri()
+    params.forEach { (key, value) -> builder = builder.queryParam(key, value) }
+    return builder.build().toUri()
   }
 
-  private fun fetchRecent(user: String, from: Long, to: Long, page: Int): Map<String, Any> {
+  private fun fetchRecent(
+    user: String,
+    from: Long,
+    to: Long,
+    page: Int,
+    sessionKey: String?,
+  ): CachedLastFmRecentTracksPage {
     if (user.isBlank()) throw LastFmException(400, "user is required")
     require(from <= to) { "from must be <= to" }
+    val cacheKey = cacheKey(user, from, to, page, sessionKey)
+    val now = clock.instant()
+    findFreshRecentTracksPage(cacheKey, now)?.let { cached ->
+      readCachedRecentTracksPage(cacheKey, cached)?.let {
+        logger.debug("Last.fm recent tracks cache hit {}", cacheKey)
+        return it
+      }
+    }
+
     val uri =
       buildUri(
         "user.getRecentTracks",
-        mapOf("user" to user, "from" to from, "to" to to, "page" to page, "limit" to 200),
-        lastFmAuthService.getSessionKey(user),
+        mapOf(
+          "user" to user,
+          "from" to from,
+          "to" to to,
+          "page" to page,
+          "limit" to RECENT_TRACKS_PAGE_SIZE,
+        ),
+        sessionKey,
       )
     var attempt = 1
     while (true) {
       try {
-        return rest.getForObject(uri, Map::class.java) as Map<String, Any>
+        val data =
+          (rest.getForObject(uri, Map::class.java) as? Map<*, *>)
+            ?.entries
+            ?.associate { (key, value) -> key.toString() to value }
+            .orEmpty()
+        val recentTracksPage = parseRecentTracksPage(data, page)
+        saveRecentTracksPage(
+          cacheKey = cacheKey,
+          user = user,
+          from = from,
+          to = to,
+          page = page,
+          sessionKey = sessionKey,
+          recentTracksPage = recentTracksPage,
+          now = now,
+        )
+        return recentTracksPage
       } catch (ex: HttpStatusCodeException) {
         val err = parseError(ex)
         if (err.code == AUTHENTICATION_REQUIRED_CODE) {
@@ -97,7 +166,7 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
       val code = (body["error"] as? Int) ?: ex.statusCode.value()
       val msg = body["message"] as? String ?: ex.message
       LastFmException(code, msg ?: "error")
-    } catch (e: Exception) {
+    } catch (_: Exception) {
       LastFmException(ex.statusCode.value(), ex.message ?: "error")
     }
   }
@@ -137,32 +206,168 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
     if (lastFmLogin.isBlank()) throw LastFmException(400, "user is required")
     val from = LocalDate.of(year, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC)
     val to = LocalDate.of(year, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC)
+    val sessionKey = lastFmAuthService.getSessionKey(lastFmLogin)
 
-    val result = mutableListOf<Song>()
-    var page = startPage
-    var fetched = 0
-    while (result.size < limit) {
-      val data = fetchRecent(lastFmLogin, from, to, page++)
-      val recent = data["recenttracks"] as Map<*, *>
-      val tracks = recent["track"] as List<*>
-      if (tracks.isEmpty()) break
-      for (t in tracks) {
-        val m = t as Map<*, *>
-        val artist = (m["artist"] as Map<*, *>)["#text"] as String
-        val title = m["name"] as String
-        result += Song(artist = artist, title = title)
-        if (result.size >= limit) break
+    return runBlocking(Dispatchers.IO) {
+      val firstPage = fetchRecent(lastFmLogin, from, to, startPage, sessionKey)
+      if (firstPage.songs.isEmpty()) {
+        return@runBlocking emptyList()
       }
-      fetched++
+
+      val pagesToFetch = pagesToFetch(firstPage.totalPages, startPage, limit)
+      val pageResults = mutableListOf(startPage to firstPage)
+      if (pagesToFetch.isNotEmpty()) {
+        val semaphore = Semaphore(recentTracksParallelism.coerceAtLeast(1))
+        pageResults += coroutineScope {
+          pagesToFetch
+            .map { page ->
+              async(Dispatchers.IO) {
+                semaphore.withPermit {
+                  page to fetchRecent(lastFmLogin, from, to, page, sessionKey)
+                }
+              }
+            }
+            .awaitAll()
+        }
+      }
+
+      val songs = pageResults.sortedBy { it.first }.flatMap { it.second.songs }
+      val result = if (limit == Int.MAX_VALUE) songs else songs.take(limit)
+      logger.debug("yearlyChartlist {} {} fetched {} pages", lastFmLogin, year, pageResults.size)
+      result
     }
-    logger.debug("yearlyChartlist {} {} fetched {} pages", lastFmLogin, year, fetched)
-    return result
   }
 
   fun globalChartlist(lastFmLogin: String, page: Int = 1): List<Song> {
     logger.info("Fetching global chartlist for user {}", lastFmLogin)
     logger.debug("globalChartlist {} {}", lastFmLogin, page)
     return yearlyChartlist("", 1970, lastFmLogin, startPage = page)
+  }
+
+  private fun parseRecentTracksPage(
+    payload: Map<String, Any?>,
+    currentPage: Int,
+  ): CachedLastFmRecentTracksPage {
+    val recentTracks =
+      payload["recenttracks"] as? Map<*, *> ?: return CachedLastFmRecentTracksPage(1, emptyList())
+    val attr = recentTracks["@attr"] as? Map<*, *>
+    val totalPages =
+      when (val value = attr?.get("totalPages")) {
+        is Number -> value.toInt()
+        is String -> value.toIntOrNull()
+        else -> null
+      } ?: currentPage
+
+    val trackItems =
+      when (val tracks = recentTracks["track"]) {
+        is List<*> -> tracks
+        is Map<*, *> -> listOf(tracks)
+        else -> emptyList()
+      }
+
+    val songs =
+      trackItems.mapNotNull { track ->
+        val map = track as? Map<*, *> ?: return@mapNotNull null
+        val artist =
+          (map["artist"] as? Map<*, *>)?.get("#text") as? String ?: return@mapNotNull null
+        val title = map["name"] as? String ?: return@mapNotNull null
+        Song(artist = artist, title = title)
+      }
+    return CachedLastFmRecentTracksPage(
+      totalPages = totalPages.coerceAtLeast(currentPage),
+      songs = songs,
+    )
+  }
+
+  private fun pagesToFetch(totalPages: Int, startPage: Int, limit: Int): List<Int> {
+    val availableLastPage = totalPages.coerceAtLeast(startPage)
+    val maxPagesForLimit =
+      if (limit == Int.MAX_VALUE) {
+        Int.MAX_VALUE
+      } else {
+        ((limit - 1) / RECENT_TRACKS_PAGE_SIZE) + 1
+      }
+    val lastPage =
+      if (maxPagesForLimit == Int.MAX_VALUE) {
+        availableLastPage
+      } else {
+        minOf(availableLastPage, startPage + maxPagesForLimit - 1)
+      }
+    if (lastPage <= startPage) {
+      return emptyList()
+    }
+    return (startPage + 1..lastPage).toList()
+  }
+
+  private fun saveRecentTracksPage(
+    cacheKey: String,
+    user: String,
+    from: Long,
+    to: Long,
+    page: Int,
+    sessionKey: String?,
+    recentTracksPage: CachedLastFmRecentTracksPage,
+    now: Instant,
+  ) {
+    val entry =
+      StoredLastFmRecentTracksPage(
+        cacheKey = cacheKey,
+        login = user,
+        from = from,
+        to = to,
+        page = page,
+        sessionKey = sessionKey,
+        payloadJson = mapper.writeValueAsString(recentTracksPage),
+        updatedAt = now,
+        expiresAt = now.plus(cacheTtl),
+      )
+    lastFmRecentTracksCacheStore.save(entry)
+    recentTracksCache.put(cacheKey, entry)
+  }
+
+  private fun findFreshRecentTracksPage(
+    cacheKey: String,
+    now: Instant,
+  ): StoredLastFmRecentTracksPage? {
+    val memoryEntry = recentTracksCache.getIfPresent(cacheKey)
+    if (memoryEntry != null) {
+      return memoryEntry.takeIf { it.isFresh(now) }
+        ?: run {
+          recentTracksCache.invalidate(cacheKey)
+          null
+        }
+    }
+
+    val storedEntry = lastFmRecentTracksCacheStore.findByKey(cacheKey) ?: return null
+    if (!storedEntry.isFresh(now)) {
+      return null
+    }
+    recentTracksCache.put(cacheKey, storedEntry)
+    return storedEntry
+  }
+
+  private fun readCachedRecentTracksPage(
+    cacheKey: String,
+    entry: StoredLastFmRecentTracksPage,
+  ): CachedLastFmRecentTracksPage? {
+    return runCatching {
+        mapper.readValue(entry.payloadJson, CachedLastFmRecentTracksPage::class.java)
+      }
+      .onFailure {
+        logger.warn("Failed to deserialize cached Last.fm recent-tracks page {}", cacheKey, it)
+        recentTracksCache.invalidate(cacheKey)
+      }
+      .getOrNull()
+  }
+
+  private fun cacheKey(user: String, from: Long, to: Long, page: Int, sessionKey: String?): String {
+    return sha256("$user|$from|$to|$page|${sessionKey.orEmpty()}")
+  }
+
+  private fun sha256(value: String): String {
+    val digest =
+      MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+    return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
   }
 
   private fun shouldRetry(error: LastFmException, statusCode: Int, attempt: Int): Boolean {
@@ -177,8 +382,11 @@ class LastFmService(private val lastFmAuthService: LastFmAuthenticationService) 
   companion object {
     internal const val LASTFM_FETCH_ATTEMPTS = 3
     internal const val LASTFM_RETRY_DELAY_MS = 250L
+    internal const val DEFAULT_RECENT_TRACKS_MAX_PARALLELISM = 16
+    internal val DEFAULT_CACHE_TTL: Duration = Duration.ofDays(7)
     private const val AUTHENTICATION_REQUIRED_CODE = 17
     private const val TRANSIENT_BACKEND_ERROR_CODE = 8
+    private const val RECENT_TRACKS_PAGE_SIZE = 200
   }
 }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2019 Andrzej Lis
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  *
@@ -12,41 +12,74 @@
 
 package com.lis.spotify.service
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.lis.spotify.domain.SearchResult
 import com.lis.spotify.domain.Song
+import com.lis.spotify.persistence.SpotifySearchCacheStore
+import com.lis.spotify.persistence.StoredSpotifySearchCacheEntry
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
-class SpotifySearchService(val spotifyRestService: SpotifyRestService) {
+class SpotifySearchService(
+  val spotifyRestService: SpotifyRestService,
+  private val spotifySearchCacheStore: SpotifySearchCacheStore,
+  private val clock: Clock,
+  @Value("\${spotify.search.max-parallelism:64}")
+  configuredMaxParallelism: Int = DEFAULT_SEARCH_MAX_PARALLELISM,
+  @Value("\${spotify.search.cache-ttl:PT168H}") configuredCacheTtl: Duration = DEFAULT_CACHE_TTL,
+) {
   companion object {
     val SEARCH_URL = "https://api.spotify.com/v1/search?q={q}&type={type}"
+    internal const val DEFAULT_SEARCH_MAX_PARALLELISM = 64
+    internal val DEFAULT_CACHE_TTL: Duration = Duration.ofDays(7)
+    private val WHITESPACE_REGEX = "\\s+".toRegex()
   }
 
+  internal var maxParallelism = configuredMaxParallelism.coerceAtLeast(1)
+  internal var cacheTtl = configuredCacheTtl
+
   private val logger = LoggerFactory.getLogger(SpotifySearchService::class.java)
-  private val searchCache: Cache<Song, SearchResult> =
-    CacheBuilder.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).build()
+  private val mapper = jacksonObjectMapper()
+  private val searchCache: Cache<String, StoredSpotifySearchCacheEntry> =
+    CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
 
   fun doSearch(song: Song, clientId: String): SearchResult? {
     logger.debug("doSearch single {} {}", song, clientId)
-    val cached = searchCache.getIfPresent(song)
+    val query = buildQuery(song)
+    val cacheKey = cacheKey(clientId, query)
+    val now = clock.instant()
+    val cached = findFreshCacheEntry(cacheKey, now)
     if (cached != null) {
-      logger.debug("doSearch cache hit {} {}", song, clientId)
-      return cached
+      logger.debug("doSearch persistent cache hit {}", cacheKey)
+      return readCachedResult(cacheKey, cached)
     }
 
     val result =
       spotifyRestService.doGet<SearchResult>(
         SEARCH_URL,
-        params = mapOf("q" to "track:${song.title} artist:${song.artist}", "type" to "track"),
+        params = mapOf("q" to query, "type" to "track"),
         clientId = clientId,
       )
-    searchCache.put(song, result)
-    logger.debug("doSearch single result {}", result != null)
+    saveCacheEntry(cacheKey, clientId, query, result, now)
+    logger.debug("doSearch single result stored for {}", cacheKey)
     return result
   }
 
@@ -55,21 +88,105 @@ class SpotifySearchService(val spotifyRestService: SpotifyRestService) {
     logger.info("doSearch: {} {}", clientId, values.size)
     lateinit var retVal: List<String>
     val time = measureTimeMillis {
-      retVal =
-        values
-          .map {
-            val doSearch = doSearch(it, clientId)
-            progress()
-            doSearch
-          }
-          .mapNotNull { it }
-          .map { it.tracks.items }
-          .mapNotNull { it.stream().findFirst().orElse(null) }
-          .map { it.id }
-          .distinct()
+      retVal = runBlocking(Dispatchers.IO) { searchTrackIds(values, clientId, progress) }
     }
     logger.debug("doSearch batch result {} items", retVal.size)
     logger.info("doSearch: {} {} took: {}", clientId, values.size, time)
     return retVal
+  }
+
+  internal suspend fun searchTrackIds(
+    values: List<Song>,
+    clientId: String,
+    progress: () -> Unit = {},
+  ): List<String> {
+    val semaphore = Semaphore(maxParallelism.coerceAtLeast(1))
+    return coroutineScope {
+      values
+        .map { song ->
+          async(Dispatchers.IO) {
+            semaphore.withPermit {
+              val result = doSearch(song, clientId)
+              progress()
+              result?.tracks?.items?.firstOrNull()?.id
+            }
+          }
+        }
+        .awaitAll()
+        .filterNotNull()
+        .distinct()
+    }
+  }
+
+  private fun findFreshCacheEntry(cacheKey: String, now: Instant): StoredSpotifySearchCacheEntry? {
+    val memoryEntry = searchCache.getIfPresent(cacheKey)
+    if (memoryEntry != null) {
+      return memoryEntry.takeIf { it.isFresh(now) }
+        ?: run {
+          searchCache.invalidate(cacheKey)
+          null
+        }
+    }
+
+    val storedEntry = spotifySearchCacheStore.findByKey(cacheKey) ?: return null
+    if (!storedEntry.isFresh(now)) {
+      return null
+    }
+    searchCache.put(cacheKey, storedEntry)
+    return storedEntry
+  }
+
+  private fun saveCacheEntry(
+    cacheKey: String,
+    clientId: String,
+    query: String,
+    result: SearchResult,
+    now: Instant,
+  ) {
+    val entry =
+      StoredSpotifySearchCacheEntry(
+        cacheKey = cacheKey,
+        clientId = clientId,
+        query = query,
+        payloadJson = mapper.writeValueAsString(result),
+        updatedAt = now,
+        expiresAt = now.plus(cacheTtl),
+      )
+    spotifySearchCacheStore.save(entry)
+    searchCache.put(cacheKey, entry)
+  }
+
+  private fun readCachedResult(
+    cacheKey: String,
+    entry: StoredSpotifySearchCacheEntry,
+  ): SearchResult? {
+    return runCatching { mapper.readValue(entry.payloadJson, SearchResult::class.java) }
+      .onFailure {
+        logger.warn("Failed to deserialize cached Spotify search result {}", cacheKey, it)
+        searchCache.invalidate(cacheKey)
+      }
+      .getOrNull()
+  }
+
+  private fun buildQuery(song: Song): String {
+    return "track:${song.title.normalizeForQuery()} artist:${song.artist.normalizeForQuery()}"
+  }
+
+  private fun cacheKey(clientId: String, query: String): String {
+    return sha256("$clientId|$query")
+  }
+
+  private fun sha256(value: String): String {
+    val digest =
+      MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+    return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+  }
+
+  private fun String.normalizeForQuery(): String {
+    return trim().replace(WHITESPACE_REGEX, " ")
+  }
+
+  internal fun clearCache() {
+    searchCache.invalidateAll()
   }
 }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
@@ -31,11 +32,12 @@ class SpotifyTopPlaylistsService(
   var spotifyTopTrackService: SpotifyTopTrackService,
   var lastFmService: LastFmService,
   var spotifySearchService: SpotifySearchService,
+  @Value("\${lastfm.jobs.max-parallelism:16}")
+  configuredYearlyParallelism: Int = DEFAULT_YEARLY_PARALLELISM,
 ) {
 
   private val yearlyLimit = 250
-  internal var yearlyParallelism = DEFAULT_YEARLY_PARALLELISM
-  internal var searchParallelism = DEFAULT_SEARCH_PARALLELISM
+  internal var yearlyParallelism = configuredYearlyParallelism.coerceAtLeast(1)
   internal var firstSupportedYear = FIRST_SUPPORTED_YEAR
   internal var currentYearProvider: () -> Int = { Calendar.getInstance().get(Calendar.YEAR) }
 
@@ -115,7 +117,6 @@ class SpotifyTopPlaylistsService(
       val completedYears = AtomicInteger(0)
       val progressLock = Any()
       val yearSemaphore = Semaphore(yearlyParallelism.coerceAtLeast(1))
-      val searchSemaphore = Semaphore(searchParallelism.coerceAtLeast(1))
       val existingPlaylists by
         lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
           ConcurrentHashMap(
@@ -130,26 +131,12 @@ class SpotifyTopPlaylistsService(
             yearSemaphore.withPermit {
               logger.info("Processing year {}", year)
               val trackList =
-                lastFmService
-                  .yearlyChartlist(clientId, year, lastFmLogin, yearlyLimit)
-                  .take(yearlyLimit)
-                  .map { song ->
-                    async(Dispatchers.IO) {
-                      searchSemaphore.withPermit {
-                        spotifySearchService
-                          .doSearch(song, clientId)
-                          ?.tracks
-                          ?.items
-                          ?.stream()
-                          ?.findFirst()
-                          ?.orElse(null)
-                          ?.id
-                      }
-                    }
-                  }
-                  .awaitAll()
-                  .filterNotNull()
-                  .distinct()
+                spotifySearchService.searchTrackIds(
+                  lastFmService
+                    .yearlyChartlist(clientId, year, lastFmLogin, yearlyLimit)
+                    .take(yearlyLimit),
+                  clientId,
+                )
 
               if (trackList.isNotEmpty()) {
                 val playlistId =
@@ -191,8 +178,7 @@ class SpotifyTopPlaylistsService(
   private fun getYear() = currentYearProvider()
 
   companion object {
-    internal const val DEFAULT_YEARLY_PARALLELISM = 4
-    internal const val DEFAULT_SEARCH_PARALLELISM = 24
+    internal const val DEFAULT_YEARLY_PARALLELISM = 16
     private const val FIRST_SUPPORTED_YEAR = 2005
   }
 }

--- a/src/test/kotlin/com/lis/spotify/persistence/FirestoreAppStateStoresTest.kt
+++ b/src/test/kotlin/com/lis/spotify/persistence/FirestoreAppStateStoresTest.kt
@@ -180,4 +180,99 @@ class FirestoreAppStateStoresTest {
     assertEquals(listOf("p1", "p2"), loaded?.lastPlaylistIds)
     assertEquals("COMPLETED", loaded?.lastStatus)
   }
+
+  @Test
+  fun firestoreSpotifySearchCacheStoreUsesSpotifySearchCacheCollection() {
+    val firestore = mockk<Firestore>()
+    val collection = mockk<CollectionReference>()
+    val document = mockk<DocumentReference>()
+    val writeFuture = mockk<ApiFuture<WriteResult>>()
+    val readFuture = mockk<ApiFuture<DocumentSnapshot>>()
+    val snapshot = mockk<DocumentSnapshot>()
+    val updatedAt = Instant.parse("2026-04-08T07:00:00Z")
+    val expiresAt = Instant.parse("2026-04-15T07:00:00Z")
+    val store = FirestoreSpotifySearchCacheStore(firestore)
+    val entry =
+      StoredSpotifySearchCacheEntry(
+        cacheKey = "search-key",
+        clientId = "client-id",
+        query = "track:title artist:artist",
+        payloadJson = "{\"tracks\":{\"items\":[]}}",
+        updatedAt = updatedAt,
+        expiresAt = expiresAt,
+      )
+
+    every { firestore.collection("spotifySearchCache") } returns collection
+    every { collection.document("search-key") } returns document
+    every { document.set(any<Map<String, Any>>()) } returns writeFuture
+    every { writeFuture.get() } returns mockk()
+    every { document.get() } returns readFuture
+    every { readFuture.get() } returns snapshot
+    every { snapshot.exists() } returns true
+    every { snapshot.getString("cacheKey") } returns "search-key"
+    every { snapshot.getString("clientId") } returns "client-id"
+    every { snapshot.getString("query") } returns "track:title artist:artist"
+    every { snapshot.getString("payloadJson") } returns "{\"tracks\":{\"items\":[]}}"
+    every { snapshot.get("updatedAt") } returns updatedAt.toFirestoreTimestamp()
+    every { snapshot.get("expiresAt") } returns expiresAt.toFirestoreTimestamp()
+
+    store.save(entry)
+    val loaded = store.findByKey("search-key")
+
+    verify { firestore.collection("spotifySearchCache") }
+    assertNotNull(loaded)
+    assertEquals("client-id", loaded?.clientId)
+    assertEquals(expiresAt, loaded?.expiresAt)
+  }
+
+  @Test
+  fun firestoreLastFmRecentTracksCacheStoreUsesLastFmRecentTracksCacheCollection() {
+    val firestore = mockk<Firestore>()
+    val collection = mockk<CollectionReference>()
+    val document = mockk<DocumentReference>()
+    val writeFuture = mockk<ApiFuture<WriteResult>>()
+    val readFuture = mockk<ApiFuture<DocumentSnapshot>>()
+    val snapshot = mockk<DocumentSnapshot>()
+    val updatedAt = Instant.parse("2026-04-08T07:00:00Z")
+    val expiresAt = Instant.parse("2026-04-15T07:00:00Z")
+    val store = FirestoreLastFmRecentTracksCacheStore(firestore)
+    val entry =
+      StoredLastFmRecentTracksPage(
+        cacheKey = "recent-key",
+        login = "login",
+        from = 1L,
+        to = 2L,
+        page = 3,
+        sessionKey = "session",
+        payloadJson = "{\"totalPages\":5,\"songs\":[]}",
+        updatedAt = updatedAt,
+        expiresAt = expiresAt,
+      )
+
+    every { firestore.collection("lastFmRecentTracksCache") } returns collection
+    every { collection.document("recent-key") } returns document
+    every { document.set(any<Map<String, Any>>()) } returns writeFuture
+    every { writeFuture.get() } returns mockk()
+    every { document.get() } returns readFuture
+    every { readFuture.get() } returns snapshot
+    every { snapshot.exists() } returns true
+    every { snapshot.getString("cacheKey") } returns "recent-key"
+    every { snapshot.getString("login") } returns "login"
+    every { snapshot.getLong("from") } returns 1L
+    every { snapshot.getLong("to") } returns 2L
+    every { snapshot.getLong("page") } returns 3L
+    every { snapshot.getString("sessionKey") } returns "session"
+    every { snapshot.getString("payloadJson") } returns "{\"totalPages\":5,\"songs\":[]}"
+    every { snapshot.get("updatedAt") } returns updatedAt.toFirestoreTimestamp()
+    every { snapshot.get("expiresAt") } returns expiresAt.toFirestoreTimestamp()
+
+    store.save(entry)
+    val loaded = store.findByKey("recent-key")
+
+    verify { firestore.collection("lastFmRecentTracksCache") }
+    assertNotNull(loaded)
+    assertEquals("login", loaded?.login)
+    assertEquals(3, loaded?.page)
+    assertEquals(expiresAt, loaded?.expiresAt)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -1,11 +1,22 @@
 package com.lis.spotify.service
 
 import com.lis.spotify.domain.Song
+import com.lis.spotify.persistence.InMemoryLastFmRecentTracksCacheStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
+import java.net.URI
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -18,102 +29,147 @@ class LastFmServiceTest {
   @Test
   fun yearlyChartlistParsesSongs() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    val map1 =
-      mapOf(
-        "recenttracks" to
-          mapOf(
-            "@attr" to mapOf("totalPages" to "1"),
-            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T")),
-          )
-      )
-    val map2 =
-      mapOf(
-        "recenttracks" to
-          mapOf("@attr" to mapOf("totalPages" to "1"), "track" to emptyList<String>())
-      )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returnsMany listOf(map1, map2)
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T"))
+
     val songs = service.yearlyChartlist("cid", 2020, "login")
+
     assertEquals(listOf(Song("A", "T")), songs)
   }
 
   @Test
   fun pagingReturnsAllSongs() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    val map1 =
-      mapOf(
-        "recenttracks" to
-          mapOf(
-            "@attr" to mapOf("totalPages" to "2"),
-            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T1")),
-          )
-      )
-    val map2 =
-      mapOf(
-        "recenttracks" to
-          mapOf(
-            "@attr" to mapOf("totalPages" to "2"),
-            "track" to listOf(mapOf("artist" to mapOf("#text" to "B"), "name" to "T2")),
-          )
-      )
-    val map3 =
-      mapOf(
-        "recenttracks" to
-          mapOf("@attr" to mapOf("totalPages" to "2"), "track" to emptyList<String>())
-      )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returnsMany
-      listOf(map1, map2, map3)
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        when (page(firstArg())) {
+          1 -> recentTracksPage(3, Song("A", "T1"))
+          2 -> recentTracksPage(3, Song("B", "T2"))
+          else -> recentTracksPage(3)
+        }
+      }
+
     val songs = service.yearlyChartlist("cid", 2020, "login")
+
     assertEquals(listOf(Song("A", "T1"), Song("B", "T2")), songs)
   }
 
   @Test
   fun limitStopsPaging() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    val map1 =
-      mapOf(
-        "recenttracks" to
-          mapOf(
-            "@attr" to mapOf("totalPages" to "2"),
-            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T1")),
-          )
-      )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns map1
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(3, Song("A", "T1"))
 
     val songs = service.yearlyChartlist("cid", 2020, "login", limit = 1)
 
     assertEquals(listOf(Song("A", "T1")), songs)
-    io.mockk.verify(exactly = 1) { rest.getForObject(any<java.net.URI>(), Map::class.java) }
+    verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun yearlyChartlistUsesPersistentCacheAcrossServiceInstances() {
+    val store = InMemoryLastFmRecentTracksCacheStore()
+    val rest = mockk<RestTemplate>()
+    val firstService = service(store = store)
+    firstService.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+
+    val firstSongs = firstService.yearlyChartlist("cid", 2020, "login")
+
+    val secondRest = mockk<RestTemplate>(relaxed = true)
+    val secondService = service(store = store)
+    secondService.rest = secondRest
+    val cachedSongs = secondService.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(firstSongs, cachedSongs)
+    verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
+    verify(exactly = 0) { secondRest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun yearlyChartlistRefreshesExpiredPersistentCache() {
+    val store = InMemoryLastFmRecentTracksCacheStore()
+    val rest = mockk<RestTemplate>()
+    val firstService = service(store = store, clock = fixedClock("2026-04-08T10:00:00Z"))
+    firstService.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+
+    firstService.yearlyChartlist("cid", 2020, "login")
+
+    val expiredRest = mockk<RestTemplate>()
+    every { expiredRest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+    val secondService = service(store = store, clock = fixedClock("2026-04-16T10:00:01Z"))
+    secondService.rest = expiredRest
+
+    secondService.yearlyChartlist("cid", 2020, "login")
+
+    verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
+    verify(exactly = 1) { expiredRest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun yearlyChartlistFetchesRemainingPagesInParallelUpToConfiguredLimit() {
+    val rest = mockk<RestTemplate>()
+    val service = service(recentTracksParallelism = 2)
+    val activeRequests = AtomicInteger()
+    val maxActiveRequests = AtomicInteger()
+    val startedRequests = CountDownLatch(2)
+    val releaseRequests = CountDownLatch(1)
+    service.rest = rest
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        when (page(firstArg())) {
+          1 -> recentTracksPage(3, Song("A", "T1"))
+          else -> {
+            val active = activeRequests.incrementAndGet()
+            maxActiveRequests.accumulateAndGet(active, ::maxOf)
+            startedRequests.countDown()
+            startedRequests.await(2, TimeUnit.SECONDS)
+            releaseRequests.await(2, TimeUnit.SECONDS)
+            activeRequests.decrementAndGet()
+            recentTracksPage(3, Song("B${page(firstArg())}", "T${page(firstArg())}"))
+          }
+        }
+      }
+
+    val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit<List<Song>> { service.yearlyChartlist("cid", 2020, "login") }
+
+      assertTrue(startedRequests.await(2, TimeUnit.SECONDS))
+      releaseRequests.countDown()
+      val songs = future.get(5, TimeUnit.SECONDS)
+
+      assertEquals(3, songs.size)
+    } finally {
+      releaseRequests.countDown()
+      executor.shutdownNow()
+    }
+
+    assertEquals(2, maxActiveRequests.get())
   }
 
   @Test
   fun missingUserThrows400() {
-    val service = LastFmService(mockk(relaxed = true))
+    val service = service()
     assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "") }
   }
 
   @Test
   fun rateLimitExceptionParsed() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
+    val service = service()
+    service.rest = rest
     val ex =
       HttpClientErrorException.create(
         HttpStatus.TOO_MANY_REQUESTS,
@@ -122,20 +178,19 @@ class LastFmServiceTest {
         "{\"error\":29,\"message\":\"Rate limit\"}".toByteArray(),
         null,
       )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ex
+
     val thrown =
       assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "u").first() }
+
     assertEquals(29, thrown.code)
   }
 
   @Test
   fun invalidApiKeyExceptionParsed() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
+    val service = service()
+    service.rest = rest
     val ex =
       HttpClientErrorException.create(
         HttpStatus.FORBIDDEN,
@@ -144,17 +199,18 @@ class LastFmServiceTest {
         "{\"error\":10,\"message\":\"Invalid API key\"}".toByteArray(),
         null,
       )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ex
+
     val thrown =
       assertThrows(LastFmException::class.java) { service.yearlyChartlist("c", 2020, "u").first() }
+
     assertEquals(10, thrown.code)
   }
 
   @Test
   fun transientBackendFailuresAreRetried() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
+    val service = service()
     service.rest = rest
     val sleepCalls = mutableListOf<Long>()
     service.sleeper = LastFmSleeper { millis -> sleepCalls += millis }
@@ -167,36 +223,21 @@ class LastFmServiceTest {
           .toByteArray(),
         null,
       )
-    val map1 =
-      mapOf(
-        "recenttracks" to
-          mapOf(
-            "@attr" to mapOf("totalPages" to "1"),
-            "track" to listOf(mapOf("artist" to mapOf("#text" to "A"), "name" to "T")),
-          )
-      )
-    val map2 =
-      mapOf(
-        "recenttracks" to
-          mapOf("@attr" to mapOf("totalPages" to "1"), "track" to emptyList<String>())
-      )
-
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws
-      ex andThenMany
-      listOf(map1, map2)
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws
+      ex andThen
+      recentTracksPage(1, Song("A", "T"))
 
     val songs = service.yearlyChartlist("cid", 2020, "login")
 
     assertEquals(listOf(Song("A", "T")), songs)
     assertEquals(listOf(LastFmService.LASTFM_RETRY_DELAY_MS), sleepCalls)
-    io.mockk.verify(exactly = 3) { rest.getForObject(any<java.net.URI>(), Map::class.java) }
+    verify(exactly = 2) { rest.getForObject(any<URI>(), Map::class.java) }
   }
 
   @Test
   fun transientBackendFailuresStopAfterRetryBudget() {
     val rest = mockk<RestTemplate>()
-    val auth = mockk<LastFmAuthenticationService>(relaxed = true)
-    val service = LastFmService(auth)
+    val service = service()
     service.rest = rest
     val sleepCalls = mutableListOf<Long>()
     service.sleeper = LastFmSleeper { millis -> sleepCalls += millis }
@@ -209,7 +250,7 @@ class LastFmServiceTest {
           .toByteArray(),
         null,
       )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ex
 
     val thrown =
       assertThrows(LastFmException::class.java) { service.yearlyChartlist("cid", 2020, "login") }
@@ -219,8 +260,8 @@ class LastFmServiceTest {
       listOf(LastFmService.LASTFM_RETRY_DELAY_MS, LastFmService.LASTFM_RETRY_DELAY_MS * 2),
       sleepCalls,
     )
-    io.mockk.verify(exactly = LastFmService.LASTFM_FETCH_ATTEMPTS) {
-      rest.getForObject(any<java.net.URI>(), Map::class.java)
+    verify(exactly = LastFmService.LASTFM_FETCH_ATTEMPTS) {
+      rest.getForObject(any<URI>(), Map::class.java)
     }
   }
 
@@ -229,50 +270,44 @@ class LastFmServiceTest {
     val rest = mockk<RestTemplate>()
     val auth = mockk<LastFmAuthenticationService>()
     every { auth.getSessionKey("login") } returns "sess"
-    val service = LastFmService(auth)
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    val uriSlot = io.mockk.slot<java.net.URI>()
-    every { rest.getForObject(capture(uriSlot), Map::class.java) } returns
-      mapOf(
-        "recenttracks" to
-          mapOf("@attr" to mapOf("totalPages" to "1"), "track" to emptyList<String>())
-      )
+    val service = service(auth = auth)
+    service.rest = rest
+    val uriSlot = io.mockk.slot<URI>()
+    every { rest.getForObject(capture(uriSlot), Map::class.java) } returns recentTracksPage(1)
 
     service.yearlyChartlist("c", 2020, "login")
-    assert(uriSlot.captured.query!!.contains("sk=sess"))
+
+    assertTrue(uriSlot.captured.query!!.contains("sk=sess"))
   }
 
   @Test
   fun globalChartlistForwardsPage() {
-    val service = spyk(LastFmService(mockk(relaxed = true)))
+    val service = spyk(service())
     every { service.yearlyChartlist("", 1970, "login", startPage = 2) } returns
       listOf(Song("a", "b"))
+
     val result = service.globalChartlist("login", 2)
+
     assertEquals(listOf(Song("a", "b")), result)
   }
 
   @Test
   fun userExistsReturnsTrue() {
     val rest = mockk<RestTemplate>()
-    val service = LastFmService(mockk(relaxed = true))
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } returns
-      emptyMap<String, Any>()
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns emptyMap<String, Any>()
+
     val result = service.userExists("login")
+
     assertEquals(true, result)
   }
 
   @Test
   fun userExistsReturnsFalseOnNotFound() {
     val rest = mockk<RestTemplate>()
-    val service = LastFmService(mockk(relaxed = true))
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
+    val service = service()
+    service.rest = rest
     val ex =
       HttpClientErrorException.create(
         HttpStatus.NOT_FOUND,
@@ -281,18 +316,18 @@ class LastFmServiceTest {
         "{\"error\":6,\"message\":\"Not found\"}".toByteArray(),
         null,
       )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ex
+
     val result = service.userExists("login")
+
     assertEquals(false, result)
   }
 
   @Test
   fun userExistsThrowsOtherErrors() {
     val rest = mockk<RestTemplate>()
-    val service = LastFmService(mockk(relaxed = true))
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
+    val service = service()
+    service.rest = rest
     val ex =
       HttpClientErrorException.create(
         HttpStatus.UNAUTHORIZED,
@@ -301,21 +336,61 @@ class LastFmServiceTest {
         "{\"error\":17,\"message\":\"Login\"}".toByteArray(),
         null,
       )
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws ex
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ex
+
     assertThrows(LastFmException::class.java) { service.userExists("login") }
   }
 
   @Test
   fun networkErrorsAreWrapped() {
     val rest = mockk<RestTemplate>()
-    val service = LastFmService(mockk(relaxed = true))
-    val field = LastFmService::class.java.getDeclaredField("rest")
-    field.isAccessible = true
-    field.set(service, rest)
-    every { rest.getForObject(any<java.net.URI>(), Map::class.java) } throws
-      ResourceAccessException("boom")
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } throws ResourceAccessException("boom")
 
     val ex = assertThrows(LastFmException::class.java) { service.userExists("u") }
+
     assertEquals(503, ex.code)
+  }
+
+  private fun service(
+    auth: LastFmAuthenticationService = mockk(relaxed = true),
+    store: InMemoryLastFmRecentTracksCacheStore = InMemoryLastFmRecentTracksCacheStore(),
+    clock: Clock = fixedClock(),
+    recentTracksParallelism: Int = LastFmService.DEFAULT_RECENT_TRACKS_MAX_PARALLELISM,
+    cacheTtl: Duration = LastFmService.DEFAULT_CACHE_TTL,
+  ): LastFmService {
+    return LastFmService(
+      lastFmAuthService = auth,
+      lastFmRecentTracksCacheStore = store,
+      clock = clock,
+      configuredRecentTracksParallelism = recentTracksParallelism,
+      configuredCacheTtl = cacheTtl,
+    )
+  }
+
+  private fun recentTracksPage(totalPages: Int, vararg songs: Song): Map<String, Any> {
+    return mapOf(
+      "recenttracks" to
+        mapOf(
+          "@attr" to mapOf("totalPages" to totalPages.toString()),
+          "track" to
+            songs.map { song ->
+              mapOf("artist" to mapOf("#text" to song.artist), "name" to song.title)
+            },
+        )
+    )
+  }
+
+  private fun page(uri: URI): Int {
+    return uri.query
+      ?.split("&")
+      ?.firstOrNull { it.startsWith("page=") }
+      ?.substringAfter("=")
+      ?.toInt() ?: 1
+  }
+
+  private fun fixedClock(instant: String = "2026-04-08T10:00:00Z"): Clock {
+    return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
@@ -6,35 +6,48 @@ import com.lis.spotify.domain.SearchResult
 import com.lis.spotify.domain.SearchResultInternal
 import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
+import com.lis.spotify.persistence.InMemorySpotifySearchCacheStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SpotifySearchServiceTest {
   @Test
   fun serviceInstantiates() {
-    val service = SpotifySearchService(mockk(relaxed = true))
+    val service =
+      SpotifySearchService(mockk(relaxed = true), InMemorySpotifySearchCacheStore(), fixedClock())
     assertNotNull(service)
   }
 
   @Test
   fun searchListReturnsIds() {
     val rest = mockk<SpotifyRestService>()
-    val service = SpotifySearchService(rest)
+    val service = SpotifySearchService(rest, InMemorySpotifySearchCacheStore(), fixedClock())
     val track = Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList()))
     val result = SearchResult(SearchResultInternal(listOf(track)))
     every { rest.doRequest(any<() -> Any>()) } returns result
+
     val ids = service.doSearch(listOf(Song("a", "t")), "cid")
+
     assertEquals(listOf("1"), ids)
   }
 
   @Test
-  fun searchUsesCache() {
+  fun searchCacheIsScopedByClientId() {
     val rest = mockk<SpotifyRestService>()
-    val service = SpotifySearchService(rest)
+    val service = SpotifySearchService(rest, InMemorySpotifySearchCacheStore(), fixedClock())
     val track = Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList()))
     val result = SearchResult(SearchResultInternal(listOf(track)))
     every { rest.doRequest(any<() -> Any>()) } returns result
@@ -42,6 +55,114 @@ class SpotifySearchServiceTest {
     val song = Song("a", "t")
     service.doSearch(song, "cid1")
     service.doSearch(song, "cid2")
+
+    verify(exactly = 2) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun searchUsesPersistentCacheAcrossServiceInstances() {
+    val store = InMemorySpotifySearchCacheStore()
+    val rest = mockk<SpotifyRestService>()
+    val firstService = SpotifySearchService(rest, store, fixedClock())
+    val track = Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList()))
+    val result = SearchResult(SearchResultInternal(listOf(track)))
+    every { rest.doRequest(any<() -> Any>()) } returns result
+
+    val song = Song("artist", "title")
+    val firstResult = firstService.doSearch(song, "cid")
+    val secondRest = mockk<SpotifyRestService>(relaxed = true)
+    val secondService = SpotifySearchService(secondRest, store, fixedClock())
+    val secondResult = secondService.doSearch(song, "cid")
+
+    assertEquals("1", firstResult?.tracks?.items?.firstOrNull()?.id)
+    assertEquals("1", secondResult?.tracks?.items?.firstOrNull()?.id)
     verify(exactly = 1) { rest.doRequest(any<() -> Any>()) }
+    verify(exactly = 0) { secondRest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun expiredPersistentCacheIsRefreshed() {
+    val store = InMemorySpotifySearchCacheStore()
+    val firstClock = fixedClock("2026-04-08T10:00:00Z")
+    val rest = mockk<SpotifyRestService>()
+    val firstService = SpotifySearchService(rest, store, firstClock)
+    val track = Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList()))
+    val result = SearchResult(SearchResultInternal(listOf(track)))
+    every { rest.doRequest(any<() -> Any>()) } returns result
+
+    val song = Song("artist", "title")
+    firstService.doSearch(song, "cid")
+
+    val secondRest = mockk<SpotifyRestService>()
+    every { secondRest.doRequest(any<() -> Any>()) } returns result
+    val expiredClock = fixedClock("2026-04-16T10:00:01Z")
+    val secondService = SpotifySearchService(secondRest, store, expiredClock)
+    secondService.doSearch(song, "cid")
+
+    verify(exactly = 1) { rest.doRequest(any<() -> Any>()) }
+    verify(exactly = 1) { secondRest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun batchSearchUsesConfiguredParallelism() {
+    val rest = mockk<SpotifyRestService>()
+    val service =
+      SpotifySearchService(
+        spotifyRestService = rest,
+        spotifySearchCacheStore = InMemorySpotifySearchCacheStore(),
+        clock = fixedClock(),
+        configuredMaxParallelism = 2,
+        configuredCacheTtl = Duration.ofDays(7),
+      )
+    val activeRequests = AtomicInteger()
+    val maxActiveRequests = AtomicInteger()
+    val startedRequests = CountDownLatch(2)
+    val releaseRequests = CountDownLatch(1)
+    val ids = AtomicInteger()
+
+    every { rest.doRequest(any<() -> Any>()) } answers
+      {
+        val active = activeRequests.incrementAndGet()
+        maxActiveRequests.accumulateAndGet(active, ::maxOf)
+        startedRequests.countDown()
+        startedRequests.await(2, TimeUnit.SECONDS)
+        releaseRequests.await(2, TimeUnit.SECONDS)
+        activeRequests.decrementAndGet()
+        val id = ids.incrementAndGet().toString()
+        SearchResult(
+          SearchResultInternal(
+            listOf(
+              Track(
+                id,
+                "track-$id",
+                listOf(Artist("artist-$id", "artist-$id")),
+                Album("album-$id", "album-$id", emptyList()),
+              )
+            )
+          )
+        )
+      }
+
+    val songs = (1..4).map { Song("artist-$it", "title-$it") }
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val future = executor.submit<List<String>> { service.doSearch(songs, "cid") }
+
+      assertTrue(startedRequests.await(2, TimeUnit.SECONDS))
+      releaseRequests.countDown()
+      val resultIds = future.get(5, TimeUnit.SECONDS)
+
+      assertEquals(4, resultIds.size)
+    } finally {
+      releaseRequests.countDown()
+      executor.shutdownNow()
+    }
+
+    assertEquals(2, maxActiveRequests.get())
+    verify(exactly = 4) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  private fun fixedClock(instant: String = "2026-04-08T10:00:00Z"): Clock {
+    return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -121,7 +121,6 @@ class SpotifyTopPlaylistsServiceTest {
     service.firstSupportedYear = 2005
     service.currentYearProvider = { 2008 }
     service.yearlyParallelism = 2
-    service.searchParallelism = 1
 
     val executor = Executors.newSingleThreadExecutor()
     try {


### PR DESCRIPTION
## What changed
- added Firestore-backed and in-memory persistent cache stores for Spotify search responses and Last.fm recent-tracks pages
- changed SpotifySearchService to use a 7-day persistent client-scoped cache and bounded batch parallelism for search jobs
- changed LastFmService to use a 7-day persistent cache for user.getRecentTracks pages and bounded parallel fetching of remaining pages
- updated yearly playlist refresh to use the new higher parallelism defaults and centralized Spotify search batching
- added tests for the new Firestore cache stores, persistent-cache TTL behavior, client-scoped Spotify cache keys, and bounded concurrency

## Why it changed
- Spotify search and Last.fm recent-track requests were being recomputed after process restarts even though the app already has Firestore-backed durable state
- Spotify search results are user-market sensitive, so the cache must be scoped by client/account rather than shared globally
- the playlist refresh path still left substantial concurrency on the table for Last.fm page fetches and batched Spotify searches
- a 7-day TTL keeps expensive API lookups durable across Cloud Run restarts while still expiring old data predictably

## Validation performed
- GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test --tests com.lis.spotify.persistence.FirestoreAppStateStoresTest --tests com.lis.spotify.service.SpotifySearchServiceTest --tests com.lis.spotify.service.LastFmServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest
- GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test jacocoTestCoverageVerification

## Docs consulted
- Spotify Search reference: https://developer.spotify.com/documentation/web-api/reference/search
- Spotify rate limits: https://developer.spotify.com/documentation/web-api/concepts/rate-limits
- Last.fm user.getRecentTracks: https://www.last.fm/api/show/user.getRecentTracks
- Last.fm API error codes: https://www.last.fm/api/errorcodes

## Known limitations / follow-up
- the new caches honor a 7-day TTL in application code, but Firestore TTL cleanup is not configured for these new cache collections yet
- the parallelism defaults are higher and configurable, but they may still need production tuning if either upstream tightens rate limits