### PR TITLE
Handle transient Spotify search failures

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
@@ -36,6 +36,8 @@ import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.client.ResourceAccessException
 
 @Service
 class SpotifySearchService(
@@ -50,11 +52,16 @@ class SpotifySearchService(
     val SEARCH_URL = "https://api.spotify.com/v1/search?q={q}&type={type}"
     internal const val DEFAULT_SEARCH_MAX_PARALLELISM = 64
     internal val DEFAULT_CACHE_TTL: Duration = Duration.ofDays(7)
+    internal const val SPOTIFY_SEARCH_ATTEMPTS = 3
+    internal const val SPOTIFY_SEARCH_RETRY_DELAY_MS = 250L
     private val WHITESPACE_REGEX = "\\s+".toRegex()
   }
 
   internal var maxParallelism = configuredMaxParallelism.coerceAtLeast(1)
   internal var cacheTtl = configuredCacheTtl
+  internal var sleeper: SpotifySearchSleeper = SpotifySearchSleeper { millis ->
+    Thread.sleep(millis)
+  }
 
   private val logger = LoggerFactory.getLogger(SpotifySearchService::class.java)
   private val mapper = jacksonObjectMapper()
@@ -72,12 +79,7 @@ class SpotifySearchService(
       return readCachedResult(cacheKey, cached)
     }
 
-    val result =
-      spotifyRestService.doGet<SearchResult>(
-        SEARCH_URL,
-        params = mapOf("q" to query, "type" to "track"),
-        clientId = clientId,
-      )
+    val result = fetchSearchResult(query, clientId, cacheKey) ?: return null
     saveCacheEntry(cacheKey, clientId, query, result, now)
     logger.debug("doSearch single result stored for {}", cacheKey)
     return result
@@ -156,6 +158,70 @@ class SpotifySearchService(
     searchCache.put(cacheKey, entry)
   }
 
+  private fun fetchSearchResult(query: String, clientId: String, cacheKey: String): SearchResult? {
+    var attempt = 1
+    while (true) {
+      try {
+        return spotifyRestService.doGet<SearchResult>(
+          SEARCH_URL,
+          params = mapOf("q" to query, "type" to "track"),
+          clientId = clientId,
+        )
+      } catch (ex: HttpStatusCodeException) {
+        val statusCode = ex.statusCode.value()
+        if (statusCode >= 500 && attempt < SPOTIFY_SEARCH_ATTEMPTS) {
+          val delayMs = retryDelayMs(attempt)
+          logger.warn(
+            "Spotify search transient error {} on attempt {}/{} for cache key {}, retrying in {}ms",
+            statusCode,
+            attempt,
+            SPOTIFY_SEARCH_ATTEMPTS,
+            cacheKey,
+            delayMs,
+          )
+          sleeper.sleep(delayMs)
+          attempt++
+          continue
+        }
+        if (statusCode >= 500) {
+          logger.warn(
+            "Spotify search failed with status {} after {}/{} attempts for cache key {}, skipping track",
+            statusCode,
+            attempt,
+            SPOTIFY_SEARCH_ATTEMPTS,
+            cacheKey,
+            ex,
+          )
+          return null
+        }
+        throw ex
+      } catch (ex: ResourceAccessException) {
+        if (attempt < SPOTIFY_SEARCH_ATTEMPTS) {
+          val delayMs = retryDelayMs(attempt)
+          logger.warn(
+            "Spotify search network error on attempt {}/{} for cache key {}, retrying in {}ms",
+            attempt,
+            SPOTIFY_SEARCH_ATTEMPTS,
+            cacheKey,
+            delayMs,
+            ex,
+          )
+          sleeper.sleep(delayMs)
+          attempt++
+          continue
+        }
+        logger.warn(
+          "Spotify search network error after {}/{} attempts for cache key {}, skipping track",
+          attempt,
+          SPOTIFY_SEARCH_ATTEMPTS,
+          cacheKey,
+          ex,
+        )
+        return null
+      }
+    }
+  }
+
   private fun readCachedResult(
     cacheKey: String,
     entry: StoredSpotifySearchCacheEntry,
@@ -189,4 +255,10 @@ class SpotifySearchService(
   internal fun clearCache() {
     searchCache.invalidateAll()
   }
+
+  private fun retryDelayMs(attempt: Int): Long = SPOTIFY_SEARCH_RETRY_DELAY_MS * attempt
+}
+
+fun interface SpotifySearchSleeper {
+  fun sleep(millis: Long)
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpServerErrorException
 
 class SpotifySearchServiceTest {
   @Test
@@ -159,6 +162,83 @@ class SpotifySearchServiceTest {
     }
 
     assertEquals(2, maxActiveRequests.get())
+    verify(exactly = 4) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun transientServerErrorsAreRetriedAndEventuallySucceed() {
+    val rest = mockk<SpotifyRestService>()
+    val service = SpotifySearchService(rest, InMemorySpotifySearchCacheStore(), fixedClock())
+    val sleepCalls = mutableListOf<Long>()
+    service.sleeper = SpotifySearchSleeper { millis -> sleepCalls += millis }
+    val result =
+      SearchResult(
+        SearchResultInternal(
+          listOf(Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList())))
+        )
+      )
+    val exception =
+      HttpServerErrorException.create(
+        HttpStatus.BAD_GATEWAY,
+        "",
+        HttpHeaders(),
+        "{\"error\":{\"status\":502,\"message\":\"An unexpected error occurred. Please try again later.\"}}"
+          .toByteArray(),
+        null,
+      )
+    every { rest.doRequest(any<() -> Any>()) } throws exception andThen result
+
+    val searchResult = service.doSearch(Song("artist", "title"), "cid")
+
+    assertEquals("1", searchResult?.tracks?.items?.firstOrNull()?.id)
+    assertEquals(listOf(SpotifySearchService.SPOTIFY_SEARCH_RETRY_DELAY_MS), sleepCalls)
+    verify(exactly = 2) { rest.doRequest(any<() -> Any>()) }
+  }
+
+  @Test
+  fun repeatedServerErrorsSkipOnlyFailingTrack() {
+    val rest = mockk<SpotifyRestService>()
+    val service =
+      SpotifySearchService(
+        spotifyRestService = rest,
+        spotifySearchCacheStore = InMemorySpotifySearchCacheStore(),
+        clock = fixedClock(),
+        configuredMaxParallelism = 1,
+        configuredCacheTtl = Duration.ofDays(7),
+      )
+    val sleepCalls = mutableListOf<Long>()
+    service.sleeper = SpotifySearchSleeper { millis -> sleepCalls += millis }
+    val result =
+      SearchResult(
+        SearchResultInternal(
+          listOf(Track("ok", "ok", listOf(Artist("2", "a")), Album("3", "al", emptyList())))
+        )
+      )
+    val exception =
+      HttpServerErrorException.create(
+        HttpStatus.BAD_GATEWAY,
+        "",
+        HttpHeaders(),
+        "{\"error\":{\"status\":502,\"message\":\"An unexpected error occurred. Please try again later.\"}}"
+          .toByteArray(),
+        null,
+      )
+    every { rest.doRequest(any<() -> Any>()) } throws
+      exception andThenThrows
+      exception andThenThrows
+      exception andThen
+      result
+
+    val ids = service.doSearch(listOf(Song("bad", "track"), Song("good", "track")), "cid")
+
+    assertEquals(listOf("ok"), ids)
+    assertEquals(
+      listOf(
+        SpotifySearchService.SPOTIFY_SEARCH_RETRY_DELAY_MS,
+        SpotifySearchService.SPOTIFY_SEARCH_RETRY_DELAY_MS * 2,
+      ),
+      sleepCalls,
+    )
     verify(exactly = 4) { rest.doRequest(any<() -> Any>()) }
   }
 


### PR DESCRIPTION
## What changed
- retried transient Spotify search failures on 5xx responses and transport errors with short backoff
- treated exhausted transient Spotify search failures as per-track misses instead of failing the whole yearly refresh job
- added focused tests covering successful retry and exhausted retry behavior in Spotify search

## Why it was changed
- production yearly refresh jobs were failing when Spotify search returned transient 502 responses
- a single unstable Spotify search response should not fail the entire playlist refresh run

## Validation performed
- > Task :ktfmtFormatMain UP-TO-DATE
> Task :ktfmtFormatScripts UP-TO-DATE
> Task :ktfmtFormatTest UP-TO-DATE
> Task :ktfmtFormat UP-TO-DATE
> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar SKIPPED
> Task :compileTestKotlin UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :test UP-TO-DATE
> Task :jacocoTestReport UP-TO-DATE
> Task :jacocoTestCoverageVerification UP-TO-DATE

BUILD SUCCESSFUL in 2s
10 actionable tasks: 10 up-to-date

## Known limitations / follow-up work
- skipped tracks are not cached on failed retries, so later runs will try them again
- non-transient Spotify errors still fail fast as before