### PR TITLE
Add Last.fm forgotten obsessions playlist generator

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -28,9 +28,39 @@ class JobsController(private val jobService: JobService) {
     @CookieValue("clientId") clientId: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
-    logger.info("Starting yearly job for clientId={} lastFmLogin={}", clientId, request.lastFmLogin)
-    val id = jobService.startYearlyJob(clientId, request.lastFmLogin)
+    val lastFmLogin = request.lastFmLogin.trim()
+    if (lastFmLogin.isEmpty()) {
+      logger.warn("Rejecting yearly job without Last.fm login for clientId={}", clientId)
+      return ResponseEntity.badRequest().build()
+    }
+
+    logger.info("Starting yearly job for clientId={} lastFmLogin={}", clientId, lastFmLogin)
+    val id = jobService.startYearlyJob(clientId, lastFmLogin)
     logger.info("Yearly job {} scheduled", id)
+    return ResponseEntity.accepted().body(JobId(id))
+  }
+
+  @PostMapping("/forgotten-obsessions")
+  fun startForgottenObsessions(
+    @CookieValue("clientId") clientId: String,
+    @RequestBody request: StartRequest,
+  ): ResponseEntity<JobId> {
+    val lastFmLogin = request.lastFmLogin.trim()
+    if (lastFmLogin.isEmpty()) {
+      logger.warn(
+        "Rejecting forgotten obsessions job without Last.fm login for clientId={}",
+        clientId,
+      )
+      return ResponseEntity.badRequest().build()
+    }
+
+    logger.info(
+      "Starting forgotten obsessions job for clientId={} lastFmLogin={}",
+      clientId,
+      lastFmLogin,
+    )
+    val id = jobService.startForgottenObsessionsJob(clientId, lastFmLogin)
+    logger.info("Forgotten obsessions job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
   }
 

--- a/src/main/kotlin/com/lis/spotify/domain/ApplicationDomain.kt
+++ b/src/main/kotlin/com/lis/spotify/domain/ApplicationDomain.kt
@@ -21,6 +21,6 @@ data class AuthToken(
   var clientId: String?,
 )
 
-data class Song(val artist: String, val title: String)
+data class Song(val artist: String, val title: String, val playedAtEpochSecond: Long? = null)
 
 data class BandPlaylistRequest(val bands: List<String>)

--- a/src/main/kotlin/com/lis/spotify/domain/JobDomain.kt
+++ b/src/main/kotlin/com/lis/spotify/domain/JobDomain.kt
@@ -15,4 +15,5 @@ data class JobStatus(
   val progressPercent: Int,
   val message: String,
   val redirectUrl: String? = null,
+  val playlistIds: List<String> = emptyList(),
 )

--- a/src/main/kotlin/com/lis/spotify/persistence/PersistenceDocuments.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/PersistenceDocuments.kt
@@ -15,6 +15,7 @@ data class StoredJobStatus(
   val progressPercent: Int,
   val message: String,
   val redirectUrl: String? = null,
+  val playlistIds: List<String> = emptyList(),
   val clientId: String,
   val lastFmLogin: String,
   val createdAt: Instant,
@@ -28,6 +29,7 @@ data class StoredJobStatus(
       progressPercent = progressPercent,
       message = message,
       redirectUrl = redirectUrl,
+      playlistIds = playlistIds,
     )
   }
 
@@ -45,6 +47,9 @@ data class StoredJobStatus(
         "expiresAt" to expiresAt.toFirestoreTimestamp(),
       )
     redirectUrl?.let { data["redirectUrl"] = it }
+    if (playlistIds.isNotEmpty()) {
+      data["playlistIds"] = playlistIds
+    }
     return data
   }
 
@@ -60,6 +65,9 @@ data class StoredJobStatus(
           ?: return null
       val progressPercent = document.getLong("progressPercent")?.toInt() ?: 0
       val message = document.getString("message").orEmpty()
+      @Suppress("UNCHECKED_CAST")
+      val playlistIds =
+        (document.get("playlistIds") as? List<*>)?.filterIsInstance<String>().orEmpty()
       val clientId = document.getString("clientId").orEmpty()
       val lastFmLogin = document.getString("lastFmLogin").orEmpty()
       val createdAt = document.getInstant("createdAt") ?: return null
@@ -72,6 +80,7 @@ data class StoredJobStatus(
         progressPercent = progressPercent,
         message = message,
         redirectUrl = document.getString("redirectUrl"),
+        playlistIds = playlistIds,
         clientId = clientId,
         lastFmLogin = lastFmLogin,
         createdAt = createdAt,

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -29,90 +29,51 @@ class JobService(
   }
 
   fun startYearlyJob(clientId: String, lastFmLogin: String): String {
-    val id = UUID.randomUUID().toString()
-    val createdAt = Instant.now(clock)
-    val expiresAt = createdAt.plus(JOB_TTL)
     logger.info(
       "Scheduling yearly playlist update for clientId={} lastFmLogin={}",
       clientId,
       lastFmLogin,
     )
-    updateJob(
-      jobId = id,
-      state = JobState.QUEUED,
-      progressPercent = 0,
-      message = "Queued yearly playlist refresh",
+    return scheduleJob(
       clientId = clientId,
       lastFmLogin = lastFmLogin,
-      createdAt = createdAt,
-      expiresAt = expiresAt,
+      queuedMessage = "Queued yearly playlist refresh",
+      startMessage = "Starting yearly playlist refresh",
+      failureMessage = "Yearly playlist refresh failed",
+      work = { progress ->
+        playlistService.updateYearlyPlaylists(clientId, lastFmLogin, progress)
+        JobCompletion("Yearly playlists refreshed")
+      },
     )
-    scheduler.schedule(
-      {
-        updateJob(
-          jobId = id,
-          state = JobState.RUNNING,
-          progressPercent = 0,
-          message = "Starting yearly playlist refresh",
-          clientId = clientId,
-          lastFmLogin = lastFmLogin,
-          createdAt = createdAt,
-          expiresAt = expiresAt,
-        )
-        try {
-          playlistService.updateYearlyPlaylists(clientId, lastFmLogin) { progressPercent, message ->
-            updateJob(
-              jobId = id,
-              state = JobState.RUNNING,
-              progressPercent = progressPercent,
-              message = message,
-              clientId = clientId,
-              lastFmLogin = lastFmLogin,
-              createdAt = createdAt,
-              expiresAt = expiresAt,
+  }
+
+  fun startForgottenObsessionsJob(clientId: String, lastFmLogin: String): String {
+    logger.info(
+      "Scheduling forgotten obsessions playlist update for clientId={} lastFmLogin={}",
+      clientId,
+      lastFmLogin,
+    )
+    return scheduleJob(
+      clientId = clientId,
+      lastFmLogin = lastFmLogin,
+      queuedMessage = "Queued forgotten obsessions scan",
+      startMessage = "Scanning Last.fm history for forgotten obsessions",
+      failureMessage = "Forgotten obsessions playlist refresh failed",
+      work = { progress ->
+        val result =
+          playlistService.updateForgottenObsessionsPlaylist(clientId, lastFmLogin, progress)
+        when {
+          result.playlistId != null ->
+            JobCompletion(
+              message =
+                "Forgotten obsessions playlist refreshed (${result.matchedTrackCount} tracks)",
+              playlistIds = listOf(result.playlistId),
             )
-          }
-          updateJob(
-            jobId = id,
-            state = JobState.COMPLETED,
-            progressPercent = 100,
-            message = "Yearly playlists refreshed",
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        } catch (e: AuthenticationRequiredException) {
-          logger.error("Authentication required during yearly job {}", id, e)
-          updateJob(
-            jobId = id,
-            state = JobState.FAILED,
-            progressPercent = currentProgress(id),
-            message = authenticationMessage(e.provider),
-            redirectUrl = authenticationRedirectUrl(e.provider, lastFmLogin),
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        } catch (e: Exception) {
-          logger.error("Yearly playlist update failed for job {}", id, e)
-          updateJob(
-            jobId = id,
-            state = JobState.FAILED,
-            progressPercent = currentProgress(id),
-            message = "Yearly playlist refresh failed",
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
+          result.candidateCount == 0 -> JobCompletion("No forgotten obsessions found yet")
+          else -> JobCompletion("No Spotify matches found for forgotten obsessions")
         }
       },
-      Date.from(createdAt),
     )
-    logger.info("Yearly playlist update job {} scheduled", id)
-    return id
   }
 
   private fun currentProgress(jobId: String): Int {
@@ -138,6 +99,96 @@ class JobService(
     }
   }
 
+  private fun scheduleJob(
+    clientId: String,
+    lastFmLogin: String,
+    queuedMessage: String,
+    startMessage: String,
+    failureMessage: String,
+    work: (((Int, String) -> Unit) -> JobCompletion),
+  ): String {
+    val id = UUID.randomUUID().toString()
+    val createdAt = Instant.now(clock)
+    val expiresAt = createdAt.plus(JOB_TTL)
+    updateJob(
+      jobId = id,
+      state = JobState.QUEUED,
+      progressPercent = 0,
+      message = queuedMessage,
+      clientId = clientId,
+      lastFmLogin = lastFmLogin,
+      createdAt = createdAt,
+      expiresAt = expiresAt,
+    )
+    scheduler.schedule(
+      {
+        updateJob(
+          jobId = id,
+          state = JobState.RUNNING,
+          progressPercent = 0,
+          message = startMessage,
+          clientId = clientId,
+          lastFmLogin = lastFmLogin,
+          createdAt = createdAt,
+          expiresAt = expiresAt,
+        )
+        try {
+          val completion = work { progressPercent, message ->
+            updateJob(
+              jobId = id,
+              state = JobState.RUNNING,
+              progressPercent = progressPercent,
+              message = message,
+              clientId = clientId,
+              lastFmLogin = lastFmLogin,
+              createdAt = createdAt,
+              expiresAt = expiresAt,
+            )
+          }
+          updateJob(
+            jobId = id,
+            state = JobState.COMPLETED,
+            progressPercent = 100,
+            message = completion.message,
+            playlistIds = completion.playlistIds,
+            clientId = clientId,
+            lastFmLogin = lastFmLogin,
+            createdAt = createdAt,
+            expiresAt = expiresAt,
+          )
+        } catch (e: AuthenticationRequiredException) {
+          logger.error("Authentication required during job {}", id, e)
+          updateJob(
+            jobId = id,
+            state = JobState.FAILED,
+            progressPercent = currentProgress(id),
+            message = authenticationMessage(e.provider),
+            redirectUrl = authenticationRedirectUrl(e.provider, lastFmLogin),
+            clientId = clientId,
+            lastFmLogin = lastFmLogin,
+            createdAt = createdAt,
+            expiresAt = expiresAt,
+          )
+        } catch (e: Exception) {
+          logger.error("Job {} failed", id, e)
+          updateJob(
+            jobId = id,
+            state = JobState.FAILED,
+            progressPercent = currentProgress(id),
+            message = failureMessage,
+            clientId = clientId,
+            lastFmLogin = lastFmLogin,
+            createdAt = createdAt,
+            expiresAt = expiresAt,
+          )
+        }
+      },
+      Date.from(createdAt),
+    )
+    logger.info("Job {} scheduled", id)
+    return id
+  }
+
   private fun updateJob(
     jobId: String,
     state: JobState,
@@ -148,6 +199,7 @@ class JobService(
     createdAt: Instant,
     expiresAt: Instant,
     redirectUrl: String? = null,
+    playlistIds: List<String> = emptyList(),
   ): JobStatus {
     val now = Instant.now(clock)
     val storedStatus =
@@ -157,6 +209,7 @@ class JobService(
         progressPercent = progressPercent.coerceIn(0, 100),
         message = message,
         redirectUrl = redirectUrl,
+        playlistIds = playlistIds,
         clientId = clientId,
         lastFmLogin = lastFmLogin,
         createdAt = createdAt,
@@ -177,4 +230,9 @@ class JobService(
   companion object {
     private val JOB_TTL: Duration = Duration.ofDays(7)
   }
+
+  private data class JobCompletion(
+    val message: String,
+    val playlistIds: List<String> = emptyList(),
+  )
 }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -271,12 +271,25 @@ class LastFmService(
         val artist =
           (map["artist"] as? Map<*, *>)?.get("#text") as? String ?: return@mapNotNull null
         val title = map["name"] as? String ?: return@mapNotNull null
-        Song(artist = artist, title = title)
+        Song(
+          artist = artist,
+          title = title,
+          playedAtEpochSecond = extractPlayedAtEpochSecond(map["date"]),
+        )
       }
     return CachedLastFmRecentTracksPage(
       totalPages = totalPages.coerceAtLeast(currentPage),
       songs = songs,
     )
+  }
+
+  private fun extractPlayedAtEpochSecond(value: Any?): Long? {
+    val date = value as? Map<*, *> ?: return null
+    return when (val uts = date["uts"]) {
+      is Number -> uts.toLong()
+      is String -> uts.toLongOrNull()
+      else -> null
+    }
   }
 
   private fun pagesToFetch(totalPages: Int, startPage: Int, limit: Int): List<Int> {
@@ -352,6 +365,23 @@ class LastFmService(
   ): CachedLastFmRecentTracksPage? {
     return runCatching {
         mapper.readValue(entry.payloadJson, CachedLastFmRecentTracksPage::class.java)
+      }
+      .map { page ->
+        val fallbackPlayedAtEpochSecond = entry.to.takeIf { it > 0 }
+        if (fallbackPlayedAtEpochSecond == null) {
+          page
+        } else {
+          page.copy(
+            songs =
+              page.songs.map { song ->
+                if (song.playedAtEpochSecond != null) {
+                  song
+                } else {
+                  song.copy(playedAtEpochSecond = fallbackPlayedAtEpochSecond)
+                }
+              }
+          )
+        }
       }
       .onFailure {
         logger.warn("Failed to deserialize cached Last.fm recent-tracks page {}", cacheKey, it)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -13,6 +13,7 @@
 package com.lis.spotify.service
 
 import com.lis.spotify.domain.Playlist
+import com.lis.spotify.domain.Song
 import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,6 +27,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
+data class ForgottenObsessionsPlaylistResult(
+  val playlistId: String?,
+  val matchedTrackCount: Int,
+  val candidateCount: Int,
+)
+
 @Service
 class SpotifyTopPlaylistsService(
   var spotifyPlaylistService: SpotifyPlaylistService,
@@ -37,6 +44,7 @@ class SpotifyTopPlaylistsService(
 ) {
 
   private val yearlyLimit = 250
+  private val playlistCreationLocks = ConcurrentHashMap<String, Any>()
   internal var yearlyParallelism = configuredYearlyParallelism.coerceAtLeast(1)
   internal var firstSupportedYear = FIRST_SUPPORTED_YEAR
   internal var currentYearProvider: () -> Int = { Calendar.getInstance().get(Calendar.YEAR) }
@@ -160,25 +168,236 @@ class SpotifyTopPlaylistsService(
     logger.info("updateYearlyPlaylists {} completed", clientId)
   }
 
+  fun updateForgottenObsessionsPlaylist(
+    clientId: String,
+    lastFmLogin: String,
+    progress: (Int, String) -> Unit = { _, _ -> },
+  ): ForgottenObsessionsPlaylistResult {
+    val normalizedLastFmLogin = lastFmLogin.trim()
+    require(normalizedLastFmLogin.isNotBlank()) { "lastFmLogin must not be blank" }
+
+    logger.debug("updateForgottenObsessionsPlaylist {} {}", clientId, normalizedLastFmLogin)
+    logger.info("updateForgottenObsessionsPlaylist: {}", clientId)
+
+    val years = (firstSupportedYear..getYear()).toList().sortedDescending()
+    val totalSteps = (years.size + 2).coerceAtLeast(1)
+    val completedSteps = AtomicInteger(0)
+    val progressLock = Any()
+    val yearSemaphore = Semaphore(yearlyParallelism.coerceAtLeast(1))
+    val forgottenObsessionStats =
+      ConcurrentHashMap<Pair<String, String>, ForgottenObsessionAggregate>()
+    val existingPlaylists by
+      lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        ConcurrentHashMap(
+          spotifyPlaylistService.getCurrentUserPlaylists(clientId).associateBy { it.name }
+        )
+      }
+    progress(0, "Scanning Last.fm history")
+
+    runBlocking(Dispatchers.IO) {
+      years
+        .map { year ->
+          async(Dispatchers.IO) {
+            yearSemaphore.withPermit {
+              logger.info("Scanning forgotten obsessions candidates for year {}", year)
+              val yearScrobbles =
+                lastFmService.yearlyChartlist(clientId, year, normalizedLastFmLogin, Int.MAX_VALUE)
+              accumulateForgottenObsessionStats(yearScrobbles, forgottenObsessionStats)
+              val completedPercent: Int
+              synchronized(progressLock) {
+                val completed = completedSteps.incrementAndGet()
+                completedPercent = (completed * 100) / totalSteps
+                progress(completedPercent, "Scanned $year ($completed/${years.size})")
+              }
+              logger.info(
+                "Forgotten obsessions scan for year {} completed: {}%",
+                year,
+                completedPercent,
+              )
+            }
+          }
+        }
+        .awaitAll()
+    }
+
+    val candidates = selectForgottenObsessions(forgottenObsessionStats.values)
+    if (candidates.isEmpty()) {
+      progress(100, "No forgotten obsessions found yet")
+      logger.info("No forgotten obsessions found for {}", clientId)
+      return ForgottenObsessionsPlaylistResult(
+        playlistId = null,
+        matchedTrackCount = 0,
+        candidateCount = 0,
+      )
+    }
+
+    progress(((years.size + 1) * 100) / totalSteps, "Matching forgotten obsessions on Spotify")
+    val trackIds = mutableListOf<String>()
+    var candidateOffset = 0
+    while (
+      trackIds.size < FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT && candidateOffset < candidates.size
+    ) {
+      val batch = candidates.drop(candidateOffset).take(FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE)
+      val matchedBatch =
+        runBlocking(Dispatchers.IO) { spotifySearchService.searchTrackIds(batch, clientId) }
+      val remainingCapacity = FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT - trackIds.size
+      trackIds += matchedBatch.filterNot { it in trackIds }.take(remainingCapacity)
+      candidateOffset += batch.size
+    }
+
+    if (trackIds.isEmpty()) {
+      progress(100, "No Spotify matches found for forgotten obsessions")
+      logger.info("Forgotten obsessions candidates found but no Spotify matches for {}", clientId)
+      return ForgottenObsessionsPlaylistResult(
+        playlistId = null,
+        matchedTrackCount = 0,
+        candidateCount = candidates.size,
+      )
+    }
+
+    val playlistId =
+      getOrCreatePlaylistId(FORGOTTEN_OBSESSIONS_PLAYLIST_NAME, clientId, existingPlaylists).id
+    spotifyPlaylistService.modifyPlaylist(playlistId, trackIds, clientId)
+    progress(100, "Forgotten obsessions playlist refreshed")
+    logger.info(
+      "Forgotten obsessions playlist {} refreshed with {} tracks",
+      playlistId,
+      trackIds.size,
+    )
+    return ForgottenObsessionsPlaylistResult(
+      playlistId = playlistId,
+      matchedTrackCount = trackIds.size,
+      candidateCount = candidates.size,
+    )
+  }
+
+  internal fun selectForgottenObsessions(
+    scrobbles: List<Song>,
+    nowEpochSecond: Long = System.currentTimeMillis() / 1000,
+    minimumPlayCount: Int = FORGOTTEN_OBSESSIONS_MIN_PLAY_COUNT,
+    minimumDormantDays: Long = FORGOTTEN_OBSESSIONS_MIN_DORMANT_DAYS,
+    limit: Int = Int.MAX_VALUE,
+  ): List<Song> {
+    return selectForgottenObsessions(
+      buildForgottenObsessionStats(scrobbles).values,
+      nowEpochSecond,
+      minimumPlayCount,
+      minimumDormantDays,
+      limit,
+    )
+  }
+
+  private fun selectForgottenObsessions(
+    stats: Collection<ForgottenObsessionAggregate>,
+    nowEpochSecond: Long = System.currentTimeMillis() / 1000,
+    minimumPlayCount: Int = FORGOTTEN_OBSESSIONS_MIN_PLAY_COUNT,
+    minimumDormantDays: Long = FORGOTTEN_OBSESSIONS_MIN_DORMANT_DAYS,
+    limit: Int = Int.MAX_VALUE,
+  ): List<Song> {
+    return stats
+      .asSequence()
+      .mapNotNull { stat ->
+        val dormantDays = ((nowEpochSecond - stat.lastPlayedAtEpochSecond) / SECONDS_PER_DAY)
+        if (stat.playCount < minimumPlayCount || dormantDays < minimumDormantDays) {
+          return@mapNotNull null
+        }
+
+        ForgottenObsessionCandidate(
+          song = stat.song,
+          playCount = stat.playCount,
+          lastPlayedAtEpochSecond = stat.lastPlayedAtEpochSecond,
+          score = stat.playCount.toLong() * dormantDays.coerceAtLeast(1),
+        )
+      }
+      .sortedWith(
+        compareByDescending<ForgottenObsessionCandidate> { it.score }
+          .thenByDescending { it.playCount }
+          .thenBy { it.lastPlayedAtEpochSecond }
+          .thenBy { it.song.artist.lowercase() }
+          .thenBy { it.song.title.lowercase() }
+      )
+      .take(limit)
+      .map { it.song }
+      .toList()
+  }
+
+  private fun buildForgottenObsessionStats(
+    scrobbles: List<Song>
+  ): ConcurrentHashMap<Pair<String, String>, ForgottenObsessionAggregate> {
+    val stats = ConcurrentHashMap<Pair<String, String>, ForgottenObsessionAggregate>()
+    accumulateForgottenObsessionStats(scrobbles, stats)
+    return stats
+  }
+
+  private fun accumulateForgottenObsessionStats(
+    scrobbles: List<Song>,
+    stats: ConcurrentHashMap<Pair<String, String>, ForgottenObsessionAggregate>,
+  ) {
+    scrobbles.forEach { song ->
+      val playedAtEpochSecond = song.playedAtEpochSecond ?: return@forEach
+      val key = song.normalizedKey()
+      stats.compute(key) { _, existing ->
+        if (existing == null) {
+          ForgottenObsessionAggregate(
+            song = Song(song.artist, song.title),
+            playCount = 1,
+            lastPlayedAtEpochSecond = playedAtEpochSecond,
+          )
+        } else {
+          existing.copy(
+            playCount = existing.playCount + 1,
+            lastPlayedAtEpochSecond = maxOf(existing.lastPlayedAtEpochSecond, playedAtEpochSecond),
+          )
+        }
+      }
+    }
+  }
+
   private fun getOrCreatePlaylistId(
     playlistName: String,
     clientId: String,
     existingPlaylists: ConcurrentHashMap<String, Playlist>,
   ): Playlist {
-    val existing = existingPlaylists[playlistName]
-    if (existing != null) {
-      return existing
-    }
+    val lock = playlistCreationLocks.computeIfAbsent("$clientId|$playlistName") { Any() }
+    synchronized(lock) {
+      val existing = existingPlaylists[playlistName]
+      if (existing != null) {
+        return existing
+      }
 
-    val created = spotifyPlaylistService.createPlaylist(playlistName, clientId)
-    val previous = existingPlaylists.putIfAbsent(playlistName, created)
-    return previous ?: created
+      val created = spotifyPlaylistService.createPlaylist(playlistName, clientId)
+      val previous = existingPlaylists.putIfAbsent(playlistName, created)
+      return previous ?: created
+    }
   }
 
   private fun getYear() = currentYearProvider()
 
+  private fun Song.normalizedKey(): Pair<String, String> {
+    return artist.trim().lowercase() to title.trim().lowercase()
+  }
+
   companion object {
     internal const val DEFAULT_YEARLY_PARALLELISM = 16
     private const val FIRST_SUPPORTED_YEAR = 2005
+    private const val FORGOTTEN_OBSESSIONS_PLAYLIST_NAME = "Forgotten Obsessions"
+    private const val FORGOTTEN_OBSESSIONS_MIN_PLAY_COUNT = 5
+    private const val FORGOTTEN_OBSESSIONS_MIN_DORMANT_DAYS = 180L
+    private const val FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE = 100
+    private const val FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT = 50
+    private const val SECONDS_PER_DAY = 86_400L
   }
+
+  private data class ForgottenObsessionCandidate(
+    val song: Song,
+    val playCount: Int,
+    val lastPlayedAtEpochSecond: Long,
+    val score: Long,
+  )
+
+  private data class ForgottenObsessionAggregate(
+    val song: Song,
+    val playCount: Int,
+    val lastPlayedAtEpochSecond: Long,
+  )
 }

--- a/src/main/resources/static/index.css
+++ b/src/main/resources/static/index.css
@@ -29,15 +29,30 @@ body {
 
 iframe {
   float: left;
-  width: 25%;
+  width: 100%;
+  max-width: 360px;
   height: 360px;
-  margin: 0;
+  margin: 0 0 1rem 0;
   padding: 0;
-  background: blue;
+  background: #1db954;
   border: 0;
   display: block;
 }
 
 #lastfmProgress {
   height: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  iframe {
+    width: calc(50% - 1rem);
+    margin: 0 1rem 1rem 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  iframe {
+    width: calc(25% - 1rem);
+    margin: 0 1rem 1rem 0;
+  }
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -30,15 +30,23 @@
     </button>
 </div>
 <div id="lastFmSection">
-    <button class="btn btn-secondary btn-lg" disabled id="lastfm" type="button">LAST.FM</button>
     <input class="form-control" id="lastFmId" placeholder="Enter last.fm login..." type="text"/>
-    <div class="text-muted small mt-1" id="lastfmStatus">Enter your Last.fm login to enable yearly refresh.</div>
+    <div class="row mt-2">
+        <div class="col-md-6">
+            <button class="btn btn-secondary btn-lg" disabled id="lastfm" type="button">YEARLY LAST.FM</button>
+        </div>
+        <div class="col-md-6 mt-2 mt-md-0">
+            <button class="btn btn-secondary btn-lg" disabled id="forgottenObsessions" type="button">FORGOTTEN OBSESSIONS</button>
+        </div>
+    </div>
+    <div class="text-muted small mt-1" id="lastfmStatus">Enter your Last.fm login to enable Last.fm tools.</div>
     <div class="progress mt-2 d-none" id="lastfmProgress">
         <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0"
              class="progress-bar progress-bar-striped progress-bar-animated" id="lastfmProgressBar"
              role="progressbar" style="width: 0%;">0%
         </div>
     </div>
+    <div class="mt-3" id="forgottenObsessionsPlaylists"></div>
 </div>
 
 <div class="mt-4" id="bandSection">

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -17,6 +17,7 @@ var lastFmIdValid = false;
 var lastFmJobRunning = false;
 var lastFmProgressPoll = null;
 var lastFmRedirectTimer = null;
+var lastFmPlaylistTarget = null;
 var verifyRequest;
 
 function buildPlayButtonUrl(id) {
@@ -84,9 +85,12 @@ function updateBandButtonState() {
 function updateLastfmButtonState() {
     var enabled = lastFmIdValid && !lastFmJobRunning;
     $('#lastfm').prop('disabled', !enabled);
+    $('#forgottenObsessions').prop('disabled', !enabled);
     $('#lastFmId').prop('disabled', lastFmJobRunning);
     $('#lastfm').toggleClass('btn-info', enabled);
     $('#lastfm').toggleClass('btn-secondary', !enabled);
+    $('#forgottenObsessions').toggleClass('btn-warning', enabled);
+    $('#forgottenObsessions').toggleClass('btn-secondary', !enabled);
 }
 
 function resetLastfmProgress() {
@@ -153,7 +157,7 @@ function verifyLastfmLogin(login) {
     updateLastfmButtonState();
 
     if (!login) {
-        setLastfmStatus('Enter your Last.fm login to enable yearly refresh.');
+        setLastfmStatus('Enter your Last.fm login to enable Last.fm tools.');
         return;
     }
 
@@ -220,12 +224,49 @@ function pollLastfmJob(jobId) {
         stopLastfmPolling();
         lastFmJobRunning = false;
         updateLastfmButtonState();
+        if (job.state === 'COMPLETED' && job.playlistIds && job.playlistIds.length > 0 && lastFmPlaylistTarget) {
+            $('#' + lastFmPlaylistTarget).empty();
+            appendPlayButton(lastFmPlaylistTarget, job.playlistIds[0]);
+        }
     }).fail(function () {
         stopLastfmPolling();
         lastFmJobRunning = false;
         updateLastfmButtonState();
         renderLastfmProgress({state: 'FAILED', progressPercent: currentLastfmProgress()});
         setLastfmStatus('Unable to load Last.fm refresh progress right now.');
+    });
+}
+
+function startLastfmJob(jobPath, startMessage, failureMessage, playlistTargetId) {
+    if (!lastFmIdValid || lastFmJobRunning) {
+        return;
+    }
+
+    lastFmJobRunning = true;
+    lastFmPlaylistTarget = playlistTargetId || null;
+    updateLastfmButtonState();
+    resetLastfmProgress();
+    $('#lastfmProgress').removeClass('d-none');
+    setLastfmStatus(startMessage);
+
+    $.ajax({
+        type: 'post',
+        url: URL + jobPath,
+        contentType: 'application/json',
+        data: JSON.stringify({lastFmLogin: $('#lastFmId').val().trim()}),
+        success: function (data) {
+            if (lastFmPlaylistTarget) {
+                $('#' + lastFmPlaylistTarget).empty();
+            }
+            pollLastfmJob(data.jobId);
+        },
+        error: function () {
+            lastFmJobRunning = false;
+            lastFmPlaylistTarget = null;
+            updateLastfmButtonState();
+            resetLastfmProgress();
+            setLastfmStatus(failureMessage);
+        }
     });
 }
 
@@ -248,34 +289,25 @@ $('#top').on('click', function () {
 });
 
 $('#lastfm').on('click', function () {
-    if (!lastFmIdValid || lastFmJobRunning) {
-        return;
-    }
+    startLastfmJob(
+        '/jobs',
+        'Starting yearly playlist refresh...',
+        'Unable to start Last.fm refresh right now.',
+        null
+    );
+});
 
-    lastFmJobRunning = true;
-    updateLastfmButtonState();
-    resetLastfmProgress();
-    $('#lastfmProgress').removeClass('d-none');
-    setLastfmStatus('Starting yearly playlist refresh...');
-
-    $.ajax({
-        type: 'post',
-        url: URL + '/jobs',
-        contentType: 'application/json',
-        data: JSON.stringify({lastFmLogin: $('#lastFmId').val().trim()}),
-        success: function (data) {
-            pollLastfmJob(data.jobId);
-        },
-        error: function () {
-            lastFmJobRunning = false;
-            updateLastfmButtonState();
-            resetLastfmProgress();
-            setLastfmStatus('Unable to start Last.fm refresh right now.');
-        }
-    });
+$('#forgottenObsessions').on('click', function () {
+    startLastfmJob(
+        '/jobs/forgotten-obsessions',
+        'Scanning Last.fm history for forgotten obsessions...',
+        'Unable to start forgotten obsessions scan right now.',
+        'forgottenObsessionsPlaylists'
+    );
 });
 
 $('#lastFmId').on('input', function () {
+    $('#forgottenObsessionsPlaylists').empty();
     verifyLastfmLogin($('#lastFmId').val().trim());
 });
 

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -23,6 +23,26 @@ class JobsControllerTest {
   }
 
   @Test
+  fun startForgottenObsessionsReturnsId() {
+    every { service.startForgottenObsessionsJob("c", "login") } returns "forgotten-id"
+    val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("login"))
+    assertEquals(JobId("forgotten-id"), resp.body)
+    assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
+  }
+
+  @Test
+  fun startRejectsBlankLogin() {
+    val resp = controller.start("c", JobsController.StartRequest("   "))
+    assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
+  fun startForgottenObsessionsRejectsBlankLogin() {
+    val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("   "))
+    assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
   fun getStatusReturnsJobStatus() {
     val status = JobStatus("id", JobState.RUNNING, 25, "Processing 2025 (1/21)")
     every { service.getJobStatus("id") } returns status

--- a/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
@@ -111,21 +111,25 @@ class IndexPageWorkflowIT {
 
     val login = page.getHtmlElementById("lastFmId") as HtmlInput
     val button = page.getHtmlElementById("lastfm") as HtmlButton
+    val forgottenButton = page.getHtmlElementById("forgottenObsessions") as HtmlButton
     val status = page.getHtmlElementById("lastfmStatus") as HtmlElement
 
     assertTrue(button.isDisabled)
-    assertEquals("Enter your Last.fm login to enable yearly refresh.", status.asNormalizedText())
+    assertTrue(forgottenButton.isDisabled)
+    assertEquals("Enter your Last.fm login to enable Last.fm tools.", status.asNormalizedText())
 
     setInputValue(page, login, "missing-user")
     waitForJs()
 
     assertTrue(button.isDisabled)
+    assertTrue(forgottenButton.isDisabled)
     assertEquals("Last.fm login not found.", status.asNormalizedText())
 
     setInputValue(page, login, "valid-user")
     waitForJs()
 
     assertFalse(button.isDisabled)
+    assertFalse(forgottenButton.isDisabled)
     assertEquals("", status.asNormalizedText())
   }
 
@@ -145,7 +149,7 @@ class IndexPageWorkflowIT {
           if (options.url.indexOf('/jobs/job-1') !== -1) {
             return {
               status: 200,
-              responseText: '{"jobId":"job-1","state":"COMPLETED","progressPercent":100,"message":"Yearly playlists refreshed","redirectUrl":null}'
+              responseText: '{"jobId":"job-1","state":"COMPLETED","progressPercent":100,"message":"Yearly playlists refreshed","redirectUrl":null,"playlistIds":[]}'
             };
           }
           return { status: 404, responseText: 'null' };
@@ -190,7 +194,7 @@ class IndexPageWorkflowIT {
           if (options.url.indexOf('/jobs/job-2') !== -1) {
             return {
               status: 200,
-              responseText: '{"jobId":"job-2","state":"FAILED","progressPercent":40,"message":"Last.fm authentication required","redirectUrl":"/index.html?lastFmAuth=1"}'
+              responseText: '{"jobId":"job-2","state":"FAILED","progressPercent":40,"message":"Last.fm authentication required","redirectUrl":"/index.html?lastFmAuth=1","playlistIds":[]}'
             };
           }
           return { status: 404, responseText: 'null' };
@@ -215,6 +219,53 @@ class IndexPageWorkflowIT {
     assertFalse(progressBar.getAttribute("class").contains("progress-bar-animated"))
     assertTrue(status.asNormalizedText().contains("Last.fm authentication required"))
     assertTrue(status.asNormalizedText().contains("Redirecting"))
+  }
+
+  @Test
+  fun shouldRenderForgottenObsessionsPlaylistAfterSuccessfulJob() {
+    val page = loadIndexPage()
+    installAjaxMock(
+      page,
+      """
+        window.__uiTestMockAjax = function (options) {
+          if (options.url.indexOf('/verifyLastFmId/valid-user') !== -1) {
+            return { status: 200, responseText: 'true' };
+          }
+          if (options.url.indexOf('/jobs/forgotten-obsessions') !== -1 && options.type === 'post') {
+            return { status: 202, responseText: '{"jobId":"job-3"}', json: true };
+          }
+          if (options.url.indexOf('/jobs/job-3') !== -1) {
+            return {
+              status: 200,
+              responseText: '{"jobId":"job-3","state":"COMPLETED","progressPercent":100,"message":"Forgotten obsessions playlist refreshed (12 tracks)","redirectUrl":null,"playlistIds":["playlist-1"]}'
+            };
+          }
+          return { status: 404, responseText: 'null' };
+        };
+      """,
+    )
+
+    val login = page.getHtmlElementById("lastFmId") as HtmlInput
+    val forgottenButton = page.getHtmlElementById("forgottenObsessions") as HtmlButton
+
+    setInputValue(page, login, "valid-user")
+    waitForJs()
+    assertFalse(forgottenButton.isDisabled)
+
+    triggerClick(page, "forgottenObsessions")
+    waitForJs(4000)
+
+    val status = page.getHtmlElementById("lastfmStatus") as HtmlElement
+    val iframeCount =
+      (page
+          .executeJavaScript(
+            "document.querySelectorAll('#forgottenObsessionsPlaylists iframe').length;"
+          )
+          .javaScriptResult as Number)
+        .toInt()
+
+    assertEquals("Forgotten obsessions playlist refreshed (12 tracks)", status.asNormalizedText())
+    assertEquals(1, iframeCount)
   }
 
   private fun loadIndexPage(): HtmlPage {

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.configureFor
 import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.lis.spotify.service.AuthenticationRequiredException
+import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.clearMocks
 import io.mockk.every
@@ -72,6 +73,8 @@ constructor(
     wireMockReset()
     clearMocks(playlistService)
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
+    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
+      ForgottenObsessionsPlaylistResult("playlist-1", 12, 18)
     every { playlistService.updateTopPlaylists(any()) } returns emptyList()
   }
 
@@ -109,12 +112,40 @@ constructor(
     assertEquals("/auth/lastfm?lastFmLogin=login", status.body?.get("redirectUrl"))
   }
 
+  @Test
+  fun forgottenObsessionsJobReturnsPlaylistIds() {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
+
+    val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
+    val jobId = resp.body?.get("jobId") as String
+    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+
+    assertEquals(HttpStatus.OK, status.statusCode)
+    assertEquals("COMPLETED", status.body?.get("state"))
+    assertEquals(listOf("playlist-1"), status.body?.get("playlistIds"))
+  }
+
+  @Test
+  fun forgottenObsessionsJobRejectsBlankLogin() {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
+
+    val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
+
+    assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
   class Config {
     @Bean
     @Primary
     fun playlistService(taskScheduler: TaskScheduler): SpotifyTopPlaylistsService {
       val svc = mockk<SpotifyTopPlaylistsService>(relaxed = true)
       every { svc.updateYearlyPlaylists(any(), any(), any()) } returns Unit
+      every { svc.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
+        ForgottenObsessionsPlaylistResult("playlist-1", 12, 18)
       every { svc.updateTopPlaylists(any()) } returns emptyList()
       return svc
     }

--- a/src/test/kotlin/com/lis/spotify/persistence/FirestoreAppStateStoresTest.kt
+++ b/src/test/kotlin/com/lis/spotify/persistence/FirestoreAppStateStoresTest.kt
@@ -58,6 +58,7 @@ class FirestoreAppStateStoresTest {
     every { snapshot.getLong("progressPercent") } returns 40L
     every { snapshot.getString("message") } returns "Processing 2024"
     every { snapshot.getString("redirectUrl") } returns "/auth/lastfm?lastFmLogin=login"
+    every { snapshot.get("playlistIds") } returns emptyList<String>()
     every { snapshot.getString("clientId") } returns "cid"
     every { snapshot.getString("lastFmLogin") } returns "login"
     every { snapshot.get("createdAt") } returns createdAt.toFirestoreTimestamp()

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -103,4 +103,27 @@ class JobServiceTest {
     assertEquals("lastfm-login", stored?.lastFmLogin)
     assertTrue(stored!!.expiresAt.isAfter(stored.createdAt))
   }
+
+  @Test
+  fun forgottenObsessionsJobStoresPlaylistIds() {
+    val playlistService = mockk<SpotifyTopPlaylistsService>()
+    val jobStatusStore = InMemoryJobStatusStore()
+    val scheduler = mockk<TaskScheduler>()
+    val runnable = slot<Runnable>()
+    every { scheduler.schedule(capture(runnable), any<java.util.Date>()) } answers
+      {
+        runnable.captured.run()
+        mockk(relaxed = true)
+      }
+    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
+      ForgottenObsessionsPlaylistResult("playlist-1", 12, 18)
+    val service = JobService(playlistService, jobStatusStore, scheduler)
+
+    val jobId = service.startForgottenObsessionsJob("c", "login")
+
+    val status = service.getJobStatus(jobId)
+    assertEquals(JobState.COMPLETED, status?.state)
+    assertEquals(listOf("playlist-1"), status?.playlistIds)
+    assertEquals("Forgotten obsessions playlist refreshed (12 tracks)", status?.message)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -2,14 +2,18 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Song
 import com.lis.spotify.persistence.InMemoryLastFmRecentTracksCacheStore
+import com.lis.spotify.persistence.StoredLastFmRecentTracksPage
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -37,6 +41,19 @@ class LastFmServiceTest {
     val songs = service.yearlyChartlist("cid", 2020, "login")
 
     assertEquals(listOf(Song("A", "T")), songs)
+  }
+
+  @Test
+  fun yearlyChartlistParsesPlayedAtEpochSecond() {
+    val rest = mockk<RestTemplate>()
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T", playedAtEpochSecond = 1_700_000_000))
+
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(listOf(Song("A", "T", playedAtEpochSecond = 1_700_000_000)), songs)
   }
 
   @Test
@@ -88,9 +105,35 @@ class LastFmServiceTest {
     secondService.rest = secondRest
     val cachedSongs = secondService.yearlyChartlist("cid", 2020, "login")
 
-    assertEquals(firstSongs, cachedSongs)
+    assertEquals(
+      firstSongs.map { it.copy(playedAtEpochSecond = null) },
+      cachedSongs.map { it.copy(playedAtEpochSecond = null) },
+    )
     verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
     verify(exactly = 0) { secondRest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun yearlyChartlistBackfillsPlayedAtFromLegacyCacheEntries() {
+    val store = InMemoryLastFmRecentTracksCacheStore()
+    store.save(
+      StoredLastFmRecentTracksPage(
+        cacheKey = legacyCacheKey("login", 2020),
+        login = "login",
+        from = 1_577_836_800,
+        to = 1_609_459_199,
+        page = 1,
+        sessionKey = "",
+        payloadJson = """{"totalPages":1,"songs":[{"artist":"A","title":"T1"}]}""",
+        updatedAt = Instant.parse("2026-04-08T10:00:00Z"),
+        expiresAt = Instant.parse("2026-04-15T10:00:00Z"),
+      )
+    )
+    val service = service(store = store, clock = fixedClock("2026-04-08T10:00:00Z"))
+
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(listOf(Song("A", "T1", playedAtEpochSecond = 1_609_459_199)), songs)
   }
 
   @Test
@@ -376,7 +419,11 @@ class LastFmServiceTest {
           "@attr" to mapOf("totalPages" to totalPages.toString()),
           "track" to
             songs.map { song ->
-              mapOf("artist" to mapOf("#text" to song.artist), "name" to song.title)
+              buildMap<String, Any> {
+                put("artist", mapOf("#text" to song.artist))
+                put("name", song.title)
+                song.playedAtEpochSecond?.let { put("date", mapOf("uts" to it.toString())) }
+              }
             },
         )
     )
@@ -392,5 +439,14 @@ class LastFmServiceTest {
 
   private fun fixedClock(instant: String = "2026-04-08T10:00:00Z"): Clock {
     return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC)
+  }
+
+  private fun legacyCacheKey(user: String, year: Int): String {
+    val from = LocalDate.of(year, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC)
+    val to = LocalDate.of(year, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC)
+    val digest =
+      MessageDigest.getInstance("SHA-256")
+        .digest("$user|$from|$to|1|".toByteArray(StandardCharsets.UTF_8))
+    return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -2,7 +2,9 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Album
 import com.lis.spotify.domain.Playlist
+import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -149,5 +151,88 @@ class SpotifyTopPlaylistsServiceTest {
     assertEquals(service.yearlyParallelism, maxActiveYears.get())
     verify(exactly = 4) { lastFmService.yearlyChartlist("cid", any(), "login", any()) }
     verify(exactly = 0) { playlistService.getCurrentUserPlaylists(any()) }
+  }
+
+  @Test
+  fun selectForgottenObsessionsFiltersRecentSongsAndRanksDormantFavorites() {
+    val service =
+      SpotifyTopPlaylistsService(
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+      )
+
+    val selected =
+      service.selectForgottenObsessions(
+        scrobbles =
+          listOf(
+            Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_680_000_000),
+            Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_681_000_000),
+            Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_682_000_000),
+            Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_683_000_000),
+            Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_684_000_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_000_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_100_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_200_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_300_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_400_000),
+            Song("Artist B", "Dormant Anthem", playedAtEpochSecond = 1_500_500_000),
+            Song("Artist C", "Still In Rotation", playedAtEpochSecond = 1_720_000_000),
+            Song("Artist C", "Still In Rotation", playedAtEpochSecond = 1_720_010_000),
+            Song("Artist C", "Still In Rotation", playedAtEpochSecond = 1_720_020_000),
+            Song("Artist C", "Still In Rotation", playedAtEpochSecond = 1_720_030_000),
+            Song("Artist C", "Still In Rotation", playedAtEpochSecond = 1_720_040_000),
+          ),
+        nowEpochSecond = 1_730_000_000,
+      )
+
+    assertEquals(
+      listOf(Song("Artist B", "Dormant Anthem"), Song("Artist A", "Old Favorite")),
+      selected,
+    )
+  }
+
+  @Test
+  fun updateForgottenObsessionsPlaylistCreatesPlaylistFromDormantFavorites() {
+    val playlistService = mockk<SpotifyPlaylistService>(relaxed = true)
+    val trackService = mockk<SpotifyTopTrackService>(relaxed = true)
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+    val playlist = Playlist("forgotten-id", "Forgotten Obsessions")
+    val service =
+      SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+
+    service.firstSupportedYear = 2024
+    service.currentYearProvider = { 2025 }
+    every { lastFmService.yearlyChartlist("cid", any(), "login", Int.MAX_VALUE) } answers
+      {
+        when (secondArg<Int>()) {
+          2025 ->
+            listOf(
+              Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_680_000_000),
+              Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_681_000_000),
+              Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_682_000_000),
+            )
+          else ->
+            listOf(
+              Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_600_000_000),
+              Song("Artist A", "Old Favorite", playedAtEpochSecond = 1_601_000_000),
+            )
+        }
+      }
+    coEvery {
+      searchService.searchTrackIds(listOf(Song("Artist A", "Old Favorite")), "cid")
+    } returns listOf("track-1")
+    every { playlistService.getCurrentUserPlaylists("cid") } returns mutableListOf()
+    every { playlistService.createPlaylist("Forgotten Obsessions", "cid") } returns playlist
+    every { playlistService.modifyPlaylist("forgotten-id", listOf("track-1"), "cid") } returns
+      emptyMap()
+
+    val result = service.updateForgottenObsessionsPlaylist("cid", "login")
+
+    assertEquals("forgotten-id", result.playlistId)
+    assertEquals(1, result.matchedTrackCount)
+    assertEquals(1, result.candidateCount)
   }
 }


### PR DESCRIPTION
## What changed
- added a new Last.fm-driven "Forgotten Obsessions" flow that scans historical scrobbles, scores dormant favorites, matches them on Spotify, and updates a dedicated playlist
- extended the async jobs API so forgotten-obsessions runs can be started separately and can return playlist IDs for UI embedding
- updated the frontend Last.fm section with a second action button, playlist embedding, and safer state handling for login changes and failed job starts
- widened Last.fm cached track handling to carry played-at timestamps and backfill legacy cached pages conservatively
- added tests for scoring, cache compatibility, controller validation, job status payloads, and the UI flow

## Why it changed
- users can already build yearly Last.fm playlists, but there was no way to surface tracks they used to play heavily and then stopped hearing for a long time
- the new flow turns long-tail listening history into a reusable playlist instead of only exposing recent or yearly snapshots

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test jacocoTestCoverageVerification`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LastFmServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest --tests com.lis.spotify.service.JobServiceTest --tests com.lis.spotify.controller.JobsControllerTest --tests com.lis.spotify.integration.JobsControllerIT --tests com.lis.spotify.integration.IndexPageWorkflowIT --tests com.lis.spotify.persistence.FirestoreAppStateStoresTest`

## Known limitations / follow-up work
- playlist creation is serialized within a single app instance, but duplicate Spotify playlists are still theoretically possible if multiple app instances race because Spotify does not offer an atomic create-if-absent API
- legacy cached Last.fm pages that predate played-at persistence are backfilled with a conservative year-end timestamp until those pages are naturally refreshed