### PR TITLE
Follow up forgotten obsessions playlist fixes

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -233,20 +233,53 @@ class SpotifyTopPlaylistsService(
       )
     }
 
-    progress(((years.size + 1) * 100) / totalSteps, "Matching forgotten obsessions on Spotify")
+    val matchingProgressStart = ((years.size + 1) * 100) / totalSteps
+    val totalMatchingBatches =
+      ((candidates.size + FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE - 1) /
+          FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE)
+        .coerceAtLeast(1)
+    progress(matchingProgressStart, "Matching forgotten obsessions on Spotify")
+    logger.info(
+      "Matching {} forgotten obsessions candidates on Spotify across {} batches",
+      candidates.size,
+      totalMatchingBatches,
+    )
     val trackIds = mutableListOf<String>()
     var spotifyMatchCount = 0
     var candidateOffset = 0
-    while (candidateOffset < candidates.size) {
+    var batchIndex = 0
+    while (
+      candidateOffset < candidates.size && trackIds.size < FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT
+    ) {
       val batch = candidates.drop(candidateOffset).take(FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE)
       val matchedBatch =
         runBlocking(Dispatchers.IO) { spotifySearchService.searchTrackIds(batch, clientId) }
       spotifyMatchCount += matchedBatch.size
-      if (trackIds.size < FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT) {
-        val remainingCapacity = FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT - trackIds.size
-        trackIds += matchedBatch.filterNot { it in trackIds }.take(remainingCapacity)
-      }
+      val remainingCapacity = FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT - trackIds.size
+      trackIds += matchedBatch.filterNot { it in trackIds }.take(remainingCapacity)
       candidateOffset += batch.size
+      batchIndex++
+      val matchingProgress =
+        if (
+          candidateOffset >= candidates.size ||
+            trackIds.size >= FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT
+        ) {
+          99
+        } else {
+          val matchingRange = (99 - matchingProgressStart).coerceAtLeast(1)
+          matchingProgressStart + ((batchIndex * matchingRange) / totalMatchingBatches)
+        }
+      progress(
+        matchingProgress.coerceIn(matchingProgressStart, 99),
+        "Matching forgotten obsessions on Spotify ($batchIndex/$totalMatchingBatches)",
+      )
+      logger.info(
+        "Forgotten obsessions matching batch {}/{} complete: {} playlist tracks collected from {} Spotify matches",
+        batchIndex,
+        totalMatchingBatches,
+        trackIds.size,
+        spotifyMatchCount,
+      )
     }
 
     if (trackIds.isEmpty()) {

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -5,6 +5,7 @@ import com.lis.spotify.domain.Playlist
 import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -235,5 +236,49 @@ class SpotifyTopPlaylistsServiceTest {
     assertEquals(1, result.playlistTrackCount)
     assertEquals(1, result.spotifyMatchCount)
     assertEquals(1, result.candidateCount)
+  }
+
+  @Test
+  fun updateForgottenObsessionsPlaylistStopsSearchingAfterPlaylistIsFull() {
+    val playlistService = mockk<SpotifyPlaylistService>(relaxed = true)
+    val trackService = mockk<SpotifyTopTrackService>(relaxed = true)
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+    val playlist = Playlist("forgotten-id", "Forgotten Obsessions")
+    val service =
+      SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+    val progressMessages = mutableListOf<String>()
+
+    service.firstSupportedYear = 2024
+    service.currentYearProvider = { 2024 }
+
+    every { lastFmService.yearlyChartlist("cid", 2024, "login", Int.MAX_VALUE) } returns
+      (1..110).flatMap { index ->
+        (1..5).map { play ->
+          Song(
+            artist = "Artist $index",
+            title = "Song $index",
+            playedAtEpochSecond = 1_500_000_000L + play,
+          )
+        }
+      }
+    coEvery { searchService.searchTrackIds(any(), "cid") } returns (1..50).map { "track-$it" }
+    every { playlistService.getCurrentUserPlaylists("cid") } returns mutableListOf()
+    every { playlistService.createPlaylist("Forgotten Obsessions", "cid") } returns playlist
+    every {
+      playlistService.modifyPlaylist("forgotten-id", (1..50).map { "track-$it" }, "cid")
+    } returns emptyMap()
+
+    val result =
+      service.updateForgottenObsessionsPlaylist("cid", "login") { _, message ->
+        progressMessages += message
+      }
+
+    assertEquals("forgotten-id", result.playlistId)
+    assertEquals(50, result.playlistTrackCount)
+    assertEquals(50, result.spotifyMatchCount)
+    assertEquals(110, result.candidateCount)
+    assertTrue(progressMessages.contains("Matching forgotten obsessions on Spotify (1/2)"))
+    coVerify(exactly = 1) { searchService.searchTrackIds(match { it.size == 100 }, "cid") }
   }
 }


### PR DESCRIPTION
## What changed
- fix the forgotten-obsessions Spotify matching loop so it stops once the playlist already has 50 tracks instead of continuing through every remaining candidate
- add per-batch matching progress and logging so long-running jobs no longer look stuck while the UI polls `/jobs/{id}`
- add a regression test that reproduces the cloud case with multiple candidate batches and verifies only the first batch is searched once the playlist is full
- include the existing feature-branch follow-ups that were not in `main` after PR #98 merged: closer Spotify result ranking, forgotten-obsessions job/result fixes, and the deployment URLs in `AGENTS.md`

## Why it was changed
- Cloud Run logs for revision `spotify-web-api-demo-00121-l8p` showed job `fb83160c-0b0c-48bd-8129-c25891d1270a` finishing the Last.fm scan at `2026-04-13T11:55:20Z` and then not completing until `2026-04-13T12:31:44Z`
- the deployed merge commit `3bd2f1ea22713d09b01e35aadcf45e62942daf39` was still matching every forgotten-obsessions candidate on Spotify even after collecting enough tracks for the playlist, which made the app appear hung in Cloud Run
- batch-level progress makes that phase visible in the job status and logs if external APIs are slow

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test jacocoTestCoverageVerification`
- inspected Cloud Run service config and recent logs for `spotify-web-api-demo` in project `semiotic-mender-415520`

## Known limitations / follow-up work
- the job still depends on Last.fm and Spotify API latency, so very large libraries can still take noticeable time, but the work is now bounded by playlist capacity instead of scanning every remaining match
- Cloud Run is still configured with `max instances: 1`, so a single long-running job can still monopolize the only instance if another expensive path is introduced later