### PR TITLE
[codex] Add private mood taxonomy playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ credentials are available at runtime:
 - Last.fm endpoints default to HTTPS. Override `LASTFM_API_URL` and
   `LASTFM_AUTHORIZE_URL` only if custom values are required.
 
+Spotify authorization now requests these scopes:
+
+- `user-top-read`
+- `playlist-modify-public`
+- `playlist-modify-private`
+- `playlist-read-private`
+
+The private playlist scopes are required for the Private Mood Taxonomy flow so
+the app can create private playlists and find them again on later refreshes.
+
 ## Google Cloud
 
 Run the service as a single public Cloud Run service. Keep the browser UI and
@@ -182,6 +192,28 @@ Enter your Last.fm login on the main page and click **LAST.FM** to refresh yearl
 playlists. The refresh runs in the background and shows progress in the UI.
 The current flow preserves the login across Last.fm auth redirects so the retry
 path can continue after the user authorizes access.
+
+Use **PRIVATE MOOD TAXONOMY** to build four private playlists from deterministic
+Spotify + Last.fm listening heuristics:
+
+- `Private Mood - Anchor`
+- `Private Mood - Surge`
+- `Private Mood - Night Drift`
+- `Private Mood - Frontier`
+
+The app uses only listening history, Spotify top tracks, and Last.fm similar
+tracks/artists. It does not use Last.fm tags, Spotify recommendations, audio
+features, audio analysis, or any trained model. The UI reuses the background
+job polling flow and shows the resulting playlists as embedded Spotify iframes.
+
+The underlying API accepts an optional playlist size when starting the job:
+
+```shell
+curl -X POST http://localhost:8080/jobs/private-mood-taxonomy \
+  -H 'Content-Type: application/json' \
+  -H 'Cookie: clientId=your-client-id' \
+  -d '{"lastFmLogin":"your-lastfm-login","playlistSize":50}'
+```
 
 Use **BAND MIX** on the main page to generate a playlist from multiple band
 names. Enter at least two bands separated by commas, then click **BAND MIX** to

--- a/src/main/kotlin/com/lis/spotify/Environment.kt
+++ b/src/main/kotlin/com/lis/spotify/Environment.kt
@@ -54,7 +54,8 @@ object AppEnvironment {
     val USER_INFO_URL: String
       get() = "$API_BASE_URL/v1/me"
 
-    const val SCOPES: String = "user-top-read playlist-modify-public"
+    const val SCOPES: String =
+      "user-top-read playlist-modify-public playlist-modify-private playlist-read-private"
   }
 
   object LastFm {

--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -21,7 +21,7 @@ class JobsController(private val jobService: JobService) {
     private val logger = LoggerFactory.getLogger(JobsController::class.java)
   }
 
-  data class StartRequest(val lastFmLogin: String)
+  data class StartRequest(val lastFmLogin: String, val playlistSize: Int? = null)
 
   @PostMapping
   fun start(
@@ -61,6 +61,32 @@ class JobsController(private val jobService: JobService) {
     )
     val id = jobService.startForgottenObsessionsJob(clientId, lastFmLogin)
     logger.info("Forgotten obsessions job {} scheduled", id)
+    return ResponseEntity.accepted().body(JobId(id))
+  }
+
+  @PostMapping("/private-mood-taxonomy")
+  fun startPrivateMoodTaxonomy(
+    @CookieValue("clientId") clientId: String,
+    @RequestBody request: StartRequest,
+  ): ResponseEntity<JobId> {
+    val lastFmLogin = request.lastFmLogin.trim()
+    if (lastFmLogin.isEmpty()) {
+      logger.warn(
+        "Rejecting private mood taxonomy job without Last.fm login for clientId={}",
+        clientId,
+      )
+      return ResponseEntity.badRequest().build()
+    }
+
+    logger.info(
+      "Starting private mood taxonomy job for clientId={} lastFmLogin={} playlistSize={}",
+      clientId,
+      lastFmLogin,
+      request.playlistSize,
+    )
+    val id =
+      jobService.startPrivateMoodTaxonomyJob(clientId, lastFmLogin, request.playlistSize ?: 50)
+    logger.info("Private mood taxonomy job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -75,6 +75,39 @@ class JobService(
     )
   }
 
+  fun startPrivateMoodTaxonomyJob(
+    clientId: String,
+    lastFmLogin: String,
+    playlistSize: Int = 50,
+  ): String {
+    logger.info(
+      "Scheduling private mood taxonomy playlist update for clientId={} lastFmLogin={} playlistSize={}",
+      clientId,
+      lastFmLogin,
+      playlistSize,
+    )
+    return scheduleJob(
+      clientId = clientId,
+      lastFmLogin = lastFmLogin,
+      queuedMessage = "Queued private mood taxonomy refresh",
+      startMessage = "Scanning listening history for private moods",
+      failureMessage = "Private mood taxonomy refresh failed",
+      work = { progress ->
+        val result =
+          playlistService.updatePrivateMoodTaxonomyPlaylists(
+            clientId = clientId,
+            lastFmLogin = lastFmLogin,
+            playlistSize = playlistSize,
+            progress = progress,
+          )
+        JobCompletion(
+          message = privateMoodTaxonomyCompletionMessage(result),
+          playlistIds = result.playlistIds,
+        )
+      },
+    )
+  }
+
   private fun currentProgress(jobId: String): Int {
     return jobStatusStore.findById(jobId)?.progressPercent ?: 0
   }
@@ -247,6 +280,14 @@ class JobService(
     } else {
       "Forgotten obsessions playlist refreshed (${result.playlistTrackCount} tracks)"
     }
+  }
+
+  private fun privateMoodTaxonomyCompletionMessage(result: PrivateMoodTaxonomyResult): String {
+    val counts =
+      result.playlists.joinToString(separator = ", ") { playlist ->
+        "${playlist.label} ${playlist.trackCount}"
+      }
+    return "Private mood taxonomy refreshed ($counts)"
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -52,6 +52,10 @@ class LastFmService(
   private val mapper = jacksonObjectMapper()
   private val recentTracksCache: Cache<String, StoredLastFmRecentTracksPage> =
     CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
+  private val similarTracksCache: Cache<String, List<LastFmSimilarTrack>> =
+    CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
+  private val similarArtistsCache: Cache<String, List<LastFmSimilarArtist>> =
+    CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
 
   private fun buildUri(method: String, params: Map<String, Any>, sessionKey: String?): URI {
     var builder =
@@ -96,57 +100,60 @@ class LastFmService(
         ),
         sessionKey,
       )
+    val data = fetchPayload(uri, "recent tracks for user $user")
+    val recentTracksPage = parseRecentTracksPage(data, page)
+    saveRecentTracksPage(
+      cacheKey = cacheKey,
+      user = user,
+      from = from,
+      to = to,
+      page = page,
+      sessionKey = sessionKey,
+      recentTracksPage = recentTracksPage,
+      now = now,
+    )
+    return recentTracksPage
+  }
+
+  private fun fetchPayload(uri: URI, context: String): Map<String, Any?> {
     var attempt = 1
     while (true) {
       try {
-        val data =
-          (rest.getForObject(uri, Map::class.java) as? Map<*, *>)
-            ?.entries
-            ?.associate { (key, value) -> key.toString() to value }
-            .orEmpty()
-        val recentTracksPage = parseRecentTracksPage(data, page)
-        saveRecentTracksPage(
-          cacheKey = cacheKey,
-          user = user,
-          from = from,
-          to = to,
-          page = page,
-          sessionKey = sessionKey,
-          recentTracksPage = recentTracksPage,
-          now = now,
-        )
-        return recentTracksPage
+        return (rest.getForObject(uri, Map::class.java) as? Map<*, *>)
+          ?.entries
+          ?.associate { (key, value) -> key.toString() to value }
+          .orEmpty()
       } catch (ex: HttpStatusCodeException) {
         val err = parseError(ex)
         if (err.code == AUTHENTICATION_REQUIRED_CODE) {
-          logger.warn("Last.fm authentication expired for user {}", user)
+          logger.warn("Last.fm authentication expired during {}", context)
           throw AuthenticationRequiredException("LASTFM")
         }
         if (shouldRetry(err, ex.statusCode.value(), attempt)) {
           val delayMs = retryDelayMs(attempt)
           logger.warn(
-            "Last.fm transient error {} {} on attempt {}/{} for user {}, retrying in {}ms",
+            "Last.fm transient error {} {} on attempt {}/{} for {}, retrying in {}ms",
             err.code,
             err.message,
             attempt,
             LASTFM_FETCH_ATTEMPTS,
-            user,
+            context,
             delayMs,
           )
           sleeper.sleep(delayMs)
           attempt++
           continue
         }
-        logger.error("Last.fm error {} {}", err.code, err.message)
+        logger.error("Last.fm error during {}: {} {}", context, err.code, err.message)
         throw err
       } catch (ex: ResourceAccessException) {
         if (attempt < LASTFM_FETCH_ATTEMPTS) {
           val delayMs = retryDelayMs(attempt)
           logger.warn(
-            "Last.fm network error on attempt {}/{} for user {}, retrying in {}ms",
+            "Last.fm network error on attempt {}/{} for {}, retrying in {}ms",
             attempt,
             LASTFM_FETCH_ATTEMPTS,
-            user,
+            context,
             delayMs,
             ex,
           )
@@ -154,7 +161,7 @@ class LastFmService(
           attempt++
           continue
         }
-        logger.error("Last.fm network error", ex)
+        logger.error("Last.fm network error during {}", context, ex)
         throw LastFmException(503, ex.message ?: "I/O error")
       }
     }
@@ -244,6 +251,58 @@ class LastFmService(
     return yearlyChartlist("", 1970, lastFmLogin, startPage = page)
   }
 
+  fun trackSimilar(artist: String, track: String, limit: Int = 20): List<LastFmSimilarTrack> {
+    require(artist.isNotBlank()) { "artist is required" }
+    require(track.isNotBlank()) { "track is required" }
+    val normalizedLimit = limit.coerceIn(1, 100)
+    val cacheKey = sha256("track.getSimilar|${artist.trim()}|${track.trim()}|$normalizedLimit")
+    similarTracksCache.getIfPresent(cacheKey)?.let { cached ->
+      logger.debug("Last.fm similar track cache hit {}", cacheKey)
+      return cached
+    }
+
+    val payload =
+      fetchPayload(
+        buildUri(
+          "track.getSimilar",
+          mapOf(
+            "artist" to artist.trim(),
+            "track" to track.trim(),
+            "limit" to normalizedLimit,
+            "autocorrect" to 1,
+          ),
+          null,
+        ),
+        "similar tracks for $artist - $track",
+      )
+    val similarTracks = parseSimilarTracks(payload, normalizedLimit)
+    similarTracksCache.put(cacheKey, similarTracks)
+    return similarTracks
+  }
+
+  fun artistSimilar(artist: String, limit: Int = 20): List<LastFmSimilarArtist> {
+    require(artist.isNotBlank()) { "artist is required" }
+    val normalizedLimit = limit.coerceIn(1, 100)
+    val cacheKey = sha256("artist.getSimilar|${artist.trim()}|$normalizedLimit")
+    similarArtistsCache.getIfPresent(cacheKey)?.let { cached ->
+      logger.debug("Last.fm similar artist cache hit {}", cacheKey)
+      return cached
+    }
+
+    val payload =
+      fetchPayload(
+        buildUri(
+          "artist.getSimilar",
+          mapOf("artist" to artist.trim(), "limit" to normalizedLimit, "autocorrect" to 1),
+          null,
+        ),
+        "similar artists for $artist",
+      )
+    val similarArtists = parseSimilarArtists(payload, normalizedLimit)
+    similarArtistsCache.put(cacheKey, similarArtists)
+    return similarArtists
+  }
+
   private fun parseRecentTracksPage(
     payload: Map<String, Any?>,
     currentPage: Int,
@@ -281,6 +340,64 @@ class LastFmService(
       totalPages = totalPages.coerceAtLeast(currentPage),
       songs = songs,
     )
+  }
+
+  private fun parseSimilarTracks(payload: Map<String, Any?>, limit: Int): List<LastFmSimilarTrack> {
+    val similarTracks = payload["similartracks"] as? Map<*, *> ?: return emptyList()
+    val trackItems =
+      when (val tracks = similarTracks["track"]) {
+        is List<*> -> tracks
+        is Map<*, *> -> listOf(tracks)
+        else -> emptyList()
+      }
+
+    return trackItems
+      .mapNotNull { track ->
+        val map = track as? Map<*, *> ?: return@mapNotNull null
+        val artist =
+          when (val artistValue = map["artist"]) {
+            is Map<*, *> -> artistValue["name"] as? String
+            is String -> artistValue
+            else -> null
+          } ?: return@mapNotNull null
+        val title = map["name"] as? String ?: return@mapNotNull null
+        val match = parseMatchValue(map["match"])
+        LastFmSimilarTrack(song = Song(artist = artist, title = title), match = match)
+      }
+      .filter { it.song.artist.isNotBlank() && it.song.title.isNotBlank() }
+      .distinctBy { it.song.artist.trim().lowercase() to it.song.title.trim().lowercase() }
+      .take(limit)
+  }
+
+  private fun parseSimilarArtists(
+    payload: Map<String, Any?>,
+    limit: Int,
+  ): List<LastFmSimilarArtist> {
+    val similarArtists = payload["similarartists"] as? Map<*, *> ?: return emptyList()
+    val artistItems =
+      when (val artists = similarArtists["artist"]) {
+        is List<*> -> artists
+        is Map<*, *> -> listOf(artists)
+        else -> emptyList()
+      }
+
+    return artistItems
+      .mapNotNull { artist ->
+        val map = artist as? Map<*, *> ?: return@mapNotNull null
+        val name = map["name"] as? String ?: return@mapNotNull null
+        LastFmSimilarArtist(name = name, match = parseMatchValue(map["match"]))
+      }
+      .filter { it.name.isNotBlank() }
+      .distinctBy { it.name.trim().lowercase() }
+      .take(limit)
+  }
+
+  private fun parseMatchValue(value: Any?): Double {
+    return when (value) {
+      is Number -> value.toDouble()
+      is String -> value.toDoubleOrNull()
+      else -> null
+    } ?: 0.0
   }
 
   private fun extractPlayedAtEpochSecond(value: Any?): Long? {
@@ -425,3 +542,7 @@ fun interface LastFmSleeper {
 }
 
 class LastFmException(val code: Int, override val message: String) : RuntimeException(message)
+
+data class LastFmSimilarTrack(val song: Song, val match: Double)
+
+data class LastFmSimilarArtist(val name: String, val match: Double)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -136,54 +136,68 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     logger.debug("modifyPlaylist {} {} {}", id, clientId, trackList.size)
     logger.info("modifyPlaylist: {} {} {}", id, clientId, trackList.size)
 
-    if (trackList.isNotEmpty()) {
-      val old = getPlaylistTrackIds(id, clientId).orEmpty()
-      val oldSet = old.toSet()
-      val newSet = trackList.toSet()
+    val old = getPlaylistTrackIds(id, clientId).orEmpty()
+    val oldSet = old.toSet()
+    val newSet = trackList.toSet()
 
-      val tracksToRemove = (oldSet - newSet).toList()
-      if (tracksToRemove.isNotEmpty()) {
-        deleteTracksFromPlaylist(id, tracksToRemove, clientId)
-      }
-
-      val tracksToAdd = (newSet - oldSet).toList()
-      addTracksToPlaylist(id, tracksToAdd, clientId)
-
-      val result = mapOf("added" to tracksToAdd, "removed" to tracksToRemove)
-      logger.debug(
-        "modifyPlaylist {} {} -> added {} removed {}",
-        id,
-        clientId,
-        tracksToAdd.size,
-        tracksToRemove.size,
-      )
-      return result
+    val tracksToRemove = (oldSet - newSet).toList()
+    if (tracksToRemove.isNotEmpty()) {
+      deleteTracksFromPlaylist(id, tracksToRemove, clientId)
     }
 
-    return mapOf("added" to emptyList(), "removed" to emptyList())
+    val tracksToAdd = (newSet - oldSet).toList()
+    if (tracksToAdd.isNotEmpty()) {
+      addTracksToPlaylist(id, tracksToAdd, clientId)
+    }
+
+    val result = mapOf("added" to tracksToAdd, "removed" to tracksToRemove)
+    logger.debug(
+      "modifyPlaylist {} {} -> added {} removed {}",
+      id,
+      clientId,
+      tracksToAdd.size,
+      tracksToRemove.size,
+    )
+    return result
   }
 
-  fun createPlaylist(name: String, clientId: String): Playlist {
-    logger.debug("createPlaylist {} {}", name, clientId)
-    logger.info("createPlaylist: {} {}", name, clientId)
+  fun createPlaylist(name: String, clientId: String, public: Boolean = true): Playlist {
+    logger.debug("createPlaylist {} {} public={}", name, clientId, public)
+    logger.info("createPlaylist: {} {} public={}", name, clientId, public)
 
     return spotifyRestService.doPost<Playlist>(
       USER_PLAYLISTS_URL,
-      body = mapOf("name" to name),
+      body = mapOf("name" to name, "public" to public),
       clientId = clientId,
     )
   }
 
-  fun getOrCreatePlaylist(playlistName: String, clientId: String): Playlist {
-    logger.debug("getOrCreatePlaylist {} {}", playlistName, clientId)
-    logger.info("getOrCreatePlaylist: {} {}", playlistName, clientId)
+  fun getOrCreatePlaylist(
+    playlistName: String,
+    clientId: String,
+    public: Boolean = true,
+  ): Playlist {
+    logger.debug("getOrCreatePlaylist {} {} public={}", playlistName, clientId, public)
+    logger.info("getOrCreatePlaylist: {} {} public={}", playlistName, clientId, public)
 
     val findAny =
       getCurrentUserPlaylists(clientId).stream().filter { it.name == playlistName }.findAny()
     if (findAny.isPresent) {
       return findAny.get()
     }
-    return createPlaylist(playlistName, clientId)
+    return createPlaylist(playlistName, clientId, public)
+  }
+
+  fun hasRequiredScopes(clientId: String, requiredScopes: Set<String>): Boolean {
+    val grantedScopes =
+      spotifyRestService.spotifyAuthenticationService
+        .getAuthToken(clientId)
+        ?.scope
+        .orEmpty()
+        .split(" ")
+        .filter { it.isNotBlank() }
+        .toSet()
+    return requiredScopes.all { it in grantedScopes }
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -14,7 +14,13 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Playlist
 import com.lis.spotify.domain.Song
+import com.lis.spotify.domain.Track
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.Calendar
+import java.util.LinkedHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
@@ -34,6 +40,19 @@ data class ForgottenObsessionsPlaylistResult(
   val candidateCount: Int,
 )
 
+data class PrivateMoodTaxonomyResult(val playlists: List<PrivateMoodPlaylistResult>) {
+  val playlistIds: List<String>
+    get() = playlists.map { it.playlistId }
+}
+
+data class PrivateMoodPlaylistResult(
+  val label: String,
+  val playlistName: String,
+  val playlistId: String,
+  val trackCount: Int,
+  val candidateCount: Int,
+)
+
 @Service
 class SpotifyTopPlaylistsService(
   var spotifyPlaylistService: SpotifyPlaylistService,
@@ -49,6 +68,8 @@ class SpotifyTopPlaylistsService(
   internal var yearlyParallelism = configuredYearlyParallelism.coerceAtLeast(1)
   internal var firstSupportedYear = FIRST_SUPPORTED_YEAR
   internal var currentYearProvider: () -> Int = { Calendar.getInstance().get(Calendar.YEAR) }
+  internal var nowEpochSecondProvider: () -> Long = { System.currentTimeMillis() / 1000 }
+  internal var analysisZoneIdProvider: () -> ZoneId = { ZoneOffset.UTC }
 
   private val logger = LoggerFactory.getLogger(SpotifyTopPlaylistsService::class.java)
 
@@ -315,6 +336,553 @@ class SpotifyTopPlaylistsService(
     )
   }
 
+  fun updatePrivateMoodTaxonomyPlaylists(
+    clientId: String,
+    lastFmLogin: String,
+    playlistSize: Int = PRIVATE_MOOD_DEFAULT_PLAYLIST_SIZE,
+    progress: (Int, String) -> Unit = { _, _ -> },
+  ): PrivateMoodTaxonomyResult {
+    val normalizedLastFmLogin = lastFmLogin.trim()
+    require(normalizedLastFmLogin.isNotBlank()) { "lastFmLogin must not be blank" }
+    val normalizedPlaylistSize = playlistSize.coerceIn(1, PRIVATE_MOOD_MAX_PLAYLIST_SIZE)
+    requirePrivateMoodScopes(clientId)
+
+    logger.debug(
+      "updatePrivateMoodTaxonomyPlaylists {} {} {}",
+      clientId,
+      normalizedLastFmLogin,
+      normalizedPlaylistSize,
+    )
+    logger.info("updatePrivateMoodTaxonomyPlaylists: {}", clientId)
+
+    val years = (firstSupportedYear..getYear()).toList().sortedDescending()
+    val yearSemaphore = Semaphore(yearlyParallelism.coerceAtLeast(1))
+    val completedYears = AtomicInteger(0)
+    val progressLock = Any()
+    val scanProgressEnd = 60
+    val scrobbles = mutableListOf<Song>()
+    val scrobbleLock = Any()
+    val existingPlaylists by
+      lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        ConcurrentHashMap(
+          spotifyPlaylistService.getCurrentUserPlaylists(clientId).associateBy { it.name }
+        )
+      }
+
+    progress(0, "Scanning listening history for private moods")
+    runBlocking(Dispatchers.IO) {
+      years
+        .map { year ->
+          async(Dispatchers.IO) {
+            yearSemaphore.withPermit {
+              logger.info("Scanning private mood history for year {}", year)
+              val yearScrobbles =
+                lastFmService.yearlyChartlist(clientId, year, normalizedLastFmLogin, Int.MAX_VALUE)
+              synchronized(scrobbleLock) { scrobbles += yearScrobbles }
+              val completedPercent: Int
+              synchronized(progressLock) {
+                val completed = completedYears.incrementAndGet()
+                completedPercent = (completed * scanProgressEnd) / years.size.coerceAtLeast(1)
+                progress(completedPercent, "Scanned $year ($completed/${years.size})")
+              }
+              logger.info("Private mood scan for year {} completed: {}%", year, completedPercent)
+            }
+          }
+        }
+        .awaitAll()
+    }
+
+    progress(65, "Loading Spotify listening signals")
+    val shortTermTracks = spotifyTopTrackService.getTopTracksShortTerm(clientId)
+    val midTermTracks = spotifyTopTrackService.getTopTracksMidTerm(clientId)
+    val longTermTracks = spotifyTopTrackService.getTopTracksLongTerm(clientId)
+    val spotifySignals =
+      buildPrivateMoodSpotifySignals(shortTermTracks, midTermTracks, longTermTracks)
+
+    progress(72, "Analyzing listening patterns")
+    val stats =
+      buildPrivateMoodSongStats(
+        scrobbles = scrobbles,
+        nowEpochSecond = nowEpochSecondProvider(),
+        zoneId = analysisZoneIdProvider(),
+      )
+    val statsByKey = stats.associateBy { it.normalizedKey }
+    val anchorCandidates = selectAnchorCandidates(stats, spotifySignals)
+    val surgeCandidates = selectSurgeCandidates(stats, spotifySignals)
+    val nightDriftCandidates = selectNightDriftCandidates(stats, spotifySignals)
+
+    progress(80, "Exploring frontier candidates")
+    val frontierCandidates =
+      buildFrontierCandidates(
+        statsByKey = statsByKey,
+        spotifySignals = spotifySignals,
+        anchorCandidates = anchorCandidates,
+        playlistSize = normalizedPlaylistSize,
+      )
+
+    val playlistCandidates =
+      linkedMapOf(
+        PrivateMoodPlaylistKind.ANCHOR to anchorCandidates,
+        PrivateMoodPlaylistKind.SURGE to surgeCandidates,
+        PrivateMoodPlaylistKind.NIGHT_DRIFT to nightDriftCandidates,
+        PrivateMoodPlaylistKind.FRONTIER to frontierCandidates,
+      )
+
+    val updatedPlaylistIds = mutableListOf<String>()
+    val reservedCandidateKeys = mutableSetOf<Pair<String, String>>()
+    val usedTrackIds = mutableSetOf<String>()
+    val playlistResults = mutableListOf<PrivateMoodPlaylistResult>()
+    val playlistProgressStart = 85
+    val playlistProgressRange = 14
+
+    playlistCandidates.entries.forEachIndexed { index, (kind, candidates) ->
+      val filteredCandidates = candidates.filterNot { it.normalizedKey in reservedCandidateKeys }
+      progress(
+        playlistProgressStart + ((index * playlistProgressRange) / playlistCandidates.size),
+        "Matching ${kind.label} on Spotify",
+      )
+      val matchedTracks =
+        matchPrivateMoodTrackIds(
+          candidates = filteredCandidates,
+          clientId = clientId,
+          playlistSize = normalizedPlaylistSize,
+          excludedTrackIds = usedTrackIds,
+        )
+      reservedCandidateKeys += matchedTracks.attemptedKeys
+
+      val playlist =
+        getOrCreatePlaylistId(
+          playlistName = kind.playlistName(),
+          clientId = clientId,
+          existingPlaylists = existingPlaylists,
+          public = false,
+        )
+      try {
+        spotifyPlaylistService.modifyPlaylist(playlist.id, matchedTracks.trackIds, clientId)
+      } catch (ex: Exception) {
+        throw PlaylistUpdateException(updatedPlaylistIds + playlist.id, ex)
+      }
+
+      updatedPlaylistIds += playlist.id
+      usedTrackIds += matchedTracks.trackIds
+      playlistResults +=
+        PrivateMoodPlaylistResult(
+          label = kind.label,
+          playlistName = kind.playlistName(),
+          playlistId = playlist.id,
+          trackCount = matchedTracks.trackIds.size,
+          candidateCount = filteredCandidates.size,
+        )
+      progress(
+        playlistProgressStart +
+          (((index + 1) * playlistProgressRange) / playlistCandidates.size).coerceAtMost(99),
+        "${kind.label} playlist refreshed (${matchedTracks.trackIds.size} tracks)",
+      )
+    }
+
+    progress(100, "Private mood taxonomy refreshed")
+    val result = PrivateMoodTaxonomyResult(playlistResults)
+    logger.info(
+      "Private mood taxonomy refreshed for {} -> {}",
+      clientId,
+      result.playlists.associate { it.label to it.trackCount },
+    )
+    return result
+  }
+
+  private fun requirePrivateMoodScopes(clientId: String) {
+    if (!spotifyPlaylistService.hasRequiredScopes(clientId, PRIVATE_MOOD_REQUIRED_SCOPES)) {
+      logger.warn(
+        "Missing Spotify scopes {} for private mood taxonomy clientId={}",
+        PRIVATE_MOOD_REQUIRED_SCOPES,
+        clientId,
+      )
+      throw AuthenticationRequiredException("SPOTIFY")
+    }
+  }
+
+  private fun buildPrivateMoodSpotifySignals(
+    shortTermTracks: List<Track>,
+    midTermTracks: List<Track>,
+    longTermTracks: List<Track>,
+  ): PrivateMoodSpotifySignals {
+    val shortTermSongs = shortTermTracks.map { it.toSong() }
+    val midTermSongs = midTermTracks.map { it.toSong() }
+    val longTermSongs = longTermTracks.map { it.toSong() }
+    return PrivateMoodSpotifySignals(
+      shortTermSongs = shortTermSongs,
+      midTermSongs = midTermSongs,
+      longTermSongs = longTermSongs,
+      shortTermKeys = shortTermSongs.map { it.normalizedKey() }.toSet(),
+      midTermKeys = midTermSongs.map { it.normalizedKey() }.toSet(),
+      longTermKeys = longTermSongs.map { it.normalizedKey() }.toSet(),
+    )
+  }
+
+  internal fun buildPrivateMoodSongStats(
+    scrobbles: List<Song>,
+    nowEpochSecond: Long = nowEpochSecondProvider(),
+    zoneId: ZoneId = analysisZoneIdProvider(),
+  ): List<PrivateMoodSongStats> {
+    val timestampedScrobbles =
+      scrobbles.filter { it.playedAtEpochSecond != null }.sortedBy { it.playedAtEpochSecond }
+    val stats = LinkedHashMap<Pair<String, String>, MutablePrivateMoodSongStats>()
+    val recent30Cutoff = nowEpochSecond - (30 * SECONDS_PER_DAY)
+    val recent90Cutoff = nowEpochSecond - (90 * SECONDS_PER_DAY)
+
+    timestampedScrobbles.forEach { song ->
+      val playedAtEpochSecond = song.playedAtEpochSecond ?: return@forEach
+      val key = song.normalizedKey()
+      val playedAt = Instant.ofEpochSecond(playedAtEpochSecond).atZone(zoneId)
+      val stat =
+        stats.getOrPut(key) {
+          MutablePrivateMoodSongStats(
+            song = Song(song.artist, song.title),
+            normalizedKey = key,
+            firstPlayedAtEpochSecond = playedAtEpochSecond,
+            lastPlayedAtEpochSecond = playedAtEpochSecond,
+          )
+        }
+      stat.totalPlays += 1
+      stat.firstPlayedAtEpochSecond = minOf(stat.firstPlayedAtEpochSecond, playedAtEpochSecond)
+      stat.lastPlayedAtEpochSecond = maxOf(stat.lastPlayedAtEpochSecond, playedAtEpochSecond)
+      stat.activeYears += playedAt.year
+      stat.hourHistogram[playedAt.hour] += 1
+      if (playedAt.dayOfWeek == DayOfWeek.SATURDAY || playedAt.dayOfWeek == DayOfWeek.SUNDAY) {
+        stat.weekendPlays += 1
+      } else {
+        stat.weekdayPlays += 1
+      }
+      if (playedAt.hour >= 22 || playedAt.hour < 5) {
+        stat.nightPlays += 1
+      }
+      if (playedAtEpochSecond >= recent30Cutoff) {
+        stat.recentPlays30d += 1
+      }
+      if (playedAtEpochSecond >= recent90Cutoff) {
+        stat.recentPlays90d += 1
+      }
+    }
+
+    applyLateSessionMetrics(timestampedScrobbles, stats)
+
+    return stats.values.map { stat ->
+      val ageDays =
+        (((nowEpochSecond - stat.firstPlayedAtEpochSecond).coerceAtLeast(0)) / SECONDS_PER_DAY)
+          .coerceAtLeast(1)
+      val historicalWindowDays = (ageDays - 30).coerceAtLeast(30)
+      val historicalPlays = (stat.totalPlays - stat.recentPlays30d).coerceAtLeast(0)
+      val expectedRecentPlays = historicalPlays.toDouble() * 30.0 / historicalWindowDays
+      val recencySpikeRatio = (stat.recentPlays30d + 1.0) / (expectedRecentPlays + 1.0)
+      val stabilityScore =
+        (stat.activeYears.size * 10.0 +
+            minOf(stat.totalPlays.toDouble(), 60.0) +
+            minOf(stat.recentPlays90d.toDouble(), 20.0) * 2.0 +
+            (if (stat.recentPlays30d > 0) 8.0 else 0.0) -
+            kotlin.math.abs(recencySpikeRatio - 1.0) * 6.0)
+          .coerceAtLeast(0.0)
+      val noveltyScore =
+        ((32.0 - (stat.totalPlays * 4.0)).coerceAtLeast(0.0) +
+            minOf(recencySpikeRatio, 5.0) * 4.0 +
+            when {
+              ageDays <= 180 -> 18.0
+              ageDays <= 365 -> 10.0
+              else -> 0.0
+            } +
+            if (historicalPlays == 0 && stat.recentPlays90d > 0) 12.0 else 0.0)
+          .coerceAtLeast(0.0)
+      val totalPlays = stat.totalPlays.toDouble().coerceAtLeast(1.0)
+
+      PrivateMoodSongStats(
+        song = stat.song,
+        normalizedKey = stat.normalizedKey,
+        totalPlays = stat.totalPlays,
+        firstPlayedAtEpochSecond = stat.firstPlayedAtEpochSecond,
+        lastPlayedAtEpochSecond = stat.lastPlayedAtEpochSecond,
+        activeYears = stat.activeYears.size,
+        recentPlays30d = stat.recentPlays30d,
+        recentPlays90d = stat.recentPlays90d,
+        hourHistogram = stat.hourHistogram.toList(),
+        weekendToWeekdayRatio = (stat.weekendPlays + 1.0) / (stat.weekdayPlays + 1.0),
+        recencySpikeRatio = recencySpikeRatio,
+        stabilityScore = stabilityScore,
+        noveltyScore = noveltyScore,
+        nightPlayRatio = stat.nightPlays / totalPlays,
+        lateSessionRatio = stat.lateSessionPlays / totalPlays,
+        nightPlays = stat.nightPlays,
+        lateSessionPlays = stat.lateSessionPlays,
+      )
+    }
+  }
+
+  private fun applyLateSessionMetrics(
+    scrobbles: List<Song>,
+    stats: Map<Pair<String, String>, MutablePrivateMoodSongStats>,
+  ) {
+    if (scrobbles.isEmpty()) {
+      return
+    }
+
+    val currentSession = mutableListOf<Song>()
+    var previousPlayedAtEpochSecond: Long? = null
+    scrobbles.forEach { song ->
+      val playedAtEpochSecond = song.playedAtEpochSecond ?: return@forEach
+      if (
+        previousPlayedAtEpochSecond != null &&
+          playedAtEpochSecond - previousPlayedAtEpochSecond!! > PRIVATE_MOOD_SESSION_GAP_SECONDS
+      ) {
+        markLateSessionPlays(currentSession, stats)
+        currentSession.clear()
+      }
+      currentSession += song
+      previousPlayedAtEpochSecond = playedAtEpochSecond
+    }
+    markLateSessionPlays(currentSession, stats)
+  }
+
+  private fun markLateSessionPlays(
+    session: List<Song>,
+    stats: Map<Pair<String, String>, MutablePrivateMoodSongStats>,
+  ) {
+    if (session.isEmpty()) {
+      return
+    }
+
+    val lateStartIndex =
+      when {
+        session.size <= 1 -> session.size
+        session.size <= 3 -> session.size - 1
+        else -> maxOf(1, (session.size * 2) / 3)
+      }
+    session.drop(lateStartIndex).forEach { song ->
+      stats[song.normalizedKey()]?.lateSessionPlays =
+        (stats[song.normalizedKey()]?.lateSessionPlays ?: 0) + 1
+    }
+  }
+
+  private fun selectAnchorCandidates(
+    stats: List<PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    limit: Int = Int.MAX_VALUE,
+  ): List<PrivateMoodCandidateSong> {
+    return stats
+      .asSequence()
+      .filter {
+        it.totalPlays >= PRIVATE_MOOD_ANCHOR_MIN_TOTAL_PLAYS &&
+          (it.activeYears >= 2 || it.normalizedKey in spotifySignals.longTermKeys) &&
+          (it.recentPlays90d > 0 || it.normalizedKey in spotifySignals.longTermKeys)
+      }
+      .map { stat ->
+        val score =
+          stat.stabilityScore * 4.0 +
+            stat.totalPlays * 1.5 +
+            stat.activeYears * 12.0 +
+            stat.recentPlays90d * 2.0 +
+            (if (stat.normalizedKey in spotifySignals.longTermKeys) 40.0 else 0.0) +
+            (if (stat.normalizedKey in spotifySignals.midTermKeys) 18.0 else 0.0) +
+            (if (stat.normalizedKey in spotifySignals.shortTermKeys) 10.0 else 0.0) -
+            maxOf(0.0, stat.recencySpikeRatio - 2.5) * 10.0
+        PrivateMoodCandidateSong(stat.song, stat.normalizedKey, score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(limit)
+      .toList()
+  }
+
+  private fun selectSurgeCandidates(
+    stats: List<PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    limit: Int = Int.MAX_VALUE,
+  ): List<PrivateMoodCandidateSong> {
+    return stats
+      .asSequence()
+      .filter {
+        it.recentPlays30d > 0 &&
+          (it.recencySpikeRatio >= PRIVATE_MOOD_SURGE_MIN_SPIKE_RATIO ||
+            it.normalizedKey in spotifySignals.shortTermKeys)
+      }
+      .map { stat ->
+        val score =
+          stat.recencySpikeRatio * 35.0 +
+            stat.recentPlays30d * 8.0 +
+            stat.recentPlays90d * 3.0 +
+            stat.noveltyScore * 1.2 +
+            (if (stat.normalizedKey in spotifySignals.shortTermKeys) 35.0 else 0.0) +
+            (if (stat.normalizedKey in spotifySignals.midTermKeys) 12.0 else 0.0) -
+            (if (stat.normalizedKey in spotifySignals.longTermKeys) 15.0 else 0.0)
+        PrivateMoodCandidateSong(stat.song, stat.normalizedKey, score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(limit)
+      .toList()
+  }
+
+  private fun selectNightDriftCandidates(
+    stats: List<PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    limit: Int = Int.MAX_VALUE,
+  ): List<PrivateMoodCandidateSong> {
+    return stats
+      .asSequence()
+      .filter {
+        it.totalPlays >= PRIVATE_MOOD_NIGHT_DRIFT_MIN_TOTAL_PLAYS &&
+          (it.nightPlayRatio >= PRIVATE_MOOD_NIGHT_RATIO_THRESHOLD ||
+            it.lateSessionRatio >= PRIVATE_MOOD_LATE_SESSION_RATIO_THRESHOLD)
+      }
+      .map { stat ->
+        val score =
+          stat.nightPlayRatio * 70.0 +
+            stat.lateSessionRatio * 55.0 +
+            stat.nightPlays * 3.0 +
+            stat.lateSessionPlays * 2.5 +
+            stat.recentPlays90d * 1.5 +
+            stat.stabilityScore * 0.5 +
+            if (stat.normalizedKey in spotifySignals.shortTermKeys) 4.0 else 0.0
+        PrivateMoodCandidateSong(stat.song, stat.normalizedKey, score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(limit)
+      .toList()
+  }
+
+  private fun buildFrontierCandidates(
+    statsByKey: Map<Pair<String, String>, PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    anchorCandidates: List<PrivateMoodCandidateSong>,
+    playlistSize: Int,
+  ): List<PrivateMoodCandidateSong> {
+    val coreSongs =
+      buildList {
+          addAll(spotifySignals.longTermSongs)
+          addAll(anchorCandidates.map { it.song })
+          addAll(spotifySignals.midTermSongs)
+        }
+        .distinctBy { it.normalizedKey() }
+        .take(PRIVATE_MOOD_FRONTIER_TRACK_SEED_LIMIT)
+    val coreArtists =
+      buildList {
+          addAll(coreSongs.map { it.artist })
+          addAll(spotifySignals.longTermSongs.map { it.artist })
+        }
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .distinctBy { it.lowercase() }
+        .take(PRIVATE_MOOD_FRONTIER_ARTIST_SEED_LIMIT)
+
+    val similarArtistScores = LinkedHashMap<String, Double>()
+    coreArtists.forEach { artist ->
+      lastFmService.artistSimilar(artist, PRIVATE_MOOD_FRONTIER_SIMILAR_ARTIST_LIMIT).forEach {
+        similarArtist ->
+        val normalizedArtist = similarArtist.name.normalizeToken()
+        if (normalizedArtist != artist.normalizeToken()) {
+          similarArtistScores[normalizedArtist] =
+            maxOf(similarArtistScores[normalizedArtist] ?: 0.0, similarArtist.match)
+        }
+      }
+    }
+
+    val frontierCandidates = LinkedHashMap<Pair<String, String>, PrivateMoodFrontierAccumulator>()
+    coreSongs.forEach { song ->
+      lastFmService
+        .trackSimilar(song.artist, song.title, PRIVATE_MOOD_FRONTIER_SIMILAR_TRACK_LIMIT)
+        .forEach { similarTrack ->
+          val key = similarTrack.song.normalizedKey()
+          if (key == song.normalizedKey()) {
+            return@forEach
+          }
+          val accumulator =
+            frontierCandidates.getOrPut(key) { PrivateMoodFrontierAccumulator(similarTrack.song) }
+          accumulator.trackMatch += similarTrack.match.coerceAtLeast(0.0)
+          accumulator.seedCount += 1
+        }
+    }
+
+    statsByKey.values
+      .asSequence()
+      .filter {
+        it.totalPlays in 1..PRIVATE_MOOD_FRONTIER_MAX_USER_PLAYS &&
+          it.recentPlays90d > 0 &&
+          it.song.artist.normalizeToken() in similarArtistScores.keys
+      }
+      .forEach { stat ->
+        val accumulator =
+          frontierCandidates.getOrPut(stat.normalizedKey) {
+            PrivateMoodFrontierAccumulator(stat.song)
+          }
+        accumulator.artistMatch += similarArtistScores[stat.song.artist.normalizeToken()] ?: 0.0
+        accumulator.seedCount += 1
+      }
+
+    return frontierCandidates.values
+      .asSequence()
+      .mapNotNull { candidate ->
+        val stats = statsByKey[candidate.song.normalizedKey()]
+        val historyPlayCount = stats?.totalPlays ?: 0
+        if (historyPlayCount > PRIVATE_MOOD_FRONTIER_MAX_USER_PLAYS) {
+          return@mapNotNull null
+        }
+        if (candidate.song.normalizedKey() in spotifySignals.allKeys) {
+          return@mapNotNull null
+        }
+        val artistSimilarity = similarArtistScores[candidate.song.artist.normalizeToken()] ?: 0.0
+        val noveltyScore = stats?.noveltyScore ?: 45.0
+        val score =
+          candidate.trackMatch * 40.0 +
+            (candidate.artistMatch + artistSimilarity) * 25.0 +
+            noveltyScore * 1.5 +
+            (stats?.recentPlays90d ?: 0) * 3.0 -
+            historyPlayCount * 6.0 -
+            if ((stats?.recentPlays30d ?: 0) > 6) 15.0 else 0.0
+        if (score <= 0.0) {
+          return@mapNotNull null
+        }
+        PrivateMoodCandidateSong(candidate.song, candidate.song.normalizedKey(), score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(maxOf(normalizedFrontierCandidateLimit(playlistSize), playlistSize))
+      .toList()
+  }
+
+  private fun normalizedFrontierCandidateLimit(playlistSize: Int): Int {
+    return maxOf(playlistSize * 4, PRIVATE_MOOD_FRONTIER_MIN_CANDIDATE_COUNT)
+  }
+
+  private fun matchPrivateMoodTrackIds(
+    candidates: List<PrivateMoodCandidateSong>,
+    clientId: String,
+    playlistSize: Int,
+    excludedTrackIds: Set<String>,
+  ): PrivateMoodMatchResult {
+    val matchedTrackIds = mutableListOf<String>()
+    val attemptedKeys = mutableSetOf<Pair<String, String>>()
+    var candidateOffset = 0
+    while (candidateOffset < candidates.size && matchedTrackIds.size < playlistSize) {
+      val batch =
+        candidates.drop(candidateOffset).take(PRIVATE_MOOD_SEARCH_BATCH_SIZE).also {
+          attemptedKeys += it.map { candidate -> candidate.normalizedKey }
+        }
+      if (batch.isEmpty()) {
+        break
+      }
+      val matchedBatch =
+        runBlocking(Dispatchers.IO) {
+          spotifySearchService.searchTrackIds(batch.map { it.song }, clientId)
+        }
+      matchedTrackIds +=
+        matchedBatch
+          .filterNot { it in excludedTrackIds || it in matchedTrackIds }
+          .take(playlistSize - matchedTrackIds.size)
+      candidateOffset += batch.size
+    }
+    return PrivateMoodMatchResult(matchedTrackIds, attemptedKeys)
+  }
+
+  private fun privateMoodCandidateComparator(): Comparator<PrivateMoodCandidateSong> {
+    return compareByDescending<PrivateMoodCandidateSong> { it.score }
+      .thenBy { it.song.artist.lowercase() }
+      .thenBy { it.song.title.lowercase() }
+  }
+
   internal fun selectForgottenObsessions(
     scrobbles: List<Song>,
     nowEpochSecond: Long = System.currentTimeMillis() / 1000,
@@ -401,6 +969,7 @@ class SpotifyTopPlaylistsService(
     playlistName: String,
     clientId: String,
     existingPlaylists: ConcurrentHashMap<String, Playlist>,
+    public: Boolean = true,
   ): Playlist {
     val lock = playlistCreationLocks.computeIfAbsent("$clientId|$playlistName") { Any() }
     synchronized(lock) {
@@ -418,7 +987,7 @@ class SpotifyTopPlaylistsService(
         return remoteExisting
       }
 
-      val created = spotifyPlaylistService.createPlaylist(playlistName, clientId)
+      val created = spotifyPlaylistService.createPlaylist(playlistName, clientId, public)
       val previous = existingPlaylists.putIfAbsent(playlistName, created)
       return previous ?: created
     }
@@ -426,8 +995,16 @@ class SpotifyTopPlaylistsService(
 
   private fun getYear() = currentYearProvider()
 
+  private fun Track.toSong(): Song {
+    return Song(artist = artists.firstOrNull()?.name.orEmpty(), title = name)
+  }
+
+  private fun String.normalizeToken(): String {
+    return trim().lowercase().replace("\\s+".toRegex(), " ")
+  }
+
   private fun Song.normalizedKey(): Pair<String, String> {
-    return artist.trim().lowercase() to title.trim().lowercase()
+    return artist.normalizeToken() to title.normalizeToken()
   }
 
   companion object {
@@ -438,7 +1015,25 @@ class SpotifyTopPlaylistsService(
     private const val FORGOTTEN_OBSESSIONS_MIN_DORMANT_DAYS = 180L
     private const val FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE = 100
     private const val FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT = 50
+    private const val PRIVATE_MOOD_PLAYLIST_PREFIX = "Private Mood - "
+    private const val PRIVATE_MOOD_DEFAULT_PLAYLIST_SIZE = 50
+    private const val PRIVATE_MOOD_MAX_PLAYLIST_SIZE = 100
+    private const val PRIVATE_MOOD_SEARCH_BATCH_SIZE = 100
+    private const val PRIVATE_MOOD_ANCHOR_MIN_TOTAL_PLAYS = 4
+    private const val PRIVATE_MOOD_SURGE_MIN_SPIKE_RATIO = 1.35
+    private const val PRIVATE_MOOD_NIGHT_DRIFT_MIN_TOTAL_PLAYS = 3
+    private const val PRIVATE_MOOD_NIGHT_RATIO_THRESHOLD = 0.35
+    private const val PRIVATE_MOOD_LATE_SESSION_RATIO_THRESHOLD = 0.35
+    private const val PRIVATE_MOOD_FRONTIER_MAX_USER_PLAYS = 5
+    private const val PRIVATE_MOOD_FRONTIER_TRACK_SEED_LIMIT = 12
+    private const val PRIVATE_MOOD_FRONTIER_ARTIST_SEED_LIMIT = 12
+    private const val PRIVATE_MOOD_FRONTIER_SIMILAR_TRACK_LIMIT = 8
+    private const val PRIVATE_MOOD_FRONTIER_SIMILAR_ARTIST_LIMIT = 8
+    private const val PRIVATE_MOOD_FRONTIER_MIN_CANDIDATE_COUNT = 100
+    private const val PRIVATE_MOOD_SESSION_GAP_SECONDS = 7_200L
     private const val SECONDS_PER_DAY = 86_400L
+    private val PRIVATE_MOOD_REQUIRED_SCOPES =
+      setOf("playlist-modify-private", "playlist-read-private")
   }
 
   private data class ForgottenObsessionCandidate(
@@ -453,6 +1048,82 @@ class SpotifyTopPlaylistsService(
     val playCount: Int,
     val lastPlayedAtEpochSecond: Long,
   )
+
+  private data class MutablePrivateMoodSongStats(
+    val song: Song,
+    val normalizedKey: Pair<String, String>,
+    var totalPlays: Int = 0,
+    var firstPlayedAtEpochSecond: Long,
+    var lastPlayedAtEpochSecond: Long,
+    val activeYears: MutableSet<Int> = mutableSetOf(),
+    var recentPlays30d: Int = 0,
+    var recentPlays90d: Int = 0,
+    val hourHistogram: IntArray = IntArray(24),
+    var weekdayPlays: Int = 0,
+    var weekendPlays: Int = 0,
+    var nightPlays: Int = 0,
+    var lateSessionPlays: Int = 0,
+  )
+
+  internal data class PrivateMoodSongStats(
+    val song: Song,
+    val normalizedKey: Pair<String, String>,
+    val totalPlays: Int,
+    val firstPlayedAtEpochSecond: Long,
+    val lastPlayedAtEpochSecond: Long,
+    val activeYears: Int,
+    val recentPlays30d: Int,
+    val recentPlays90d: Int,
+    val hourHistogram: List<Int>,
+    val weekendToWeekdayRatio: Double,
+    val recencySpikeRatio: Double,
+    val stabilityScore: Double,
+    val noveltyScore: Double,
+    val nightPlayRatio: Double,
+    val lateSessionRatio: Double,
+    val nightPlays: Int,
+    val lateSessionPlays: Int,
+  )
+
+  internal data class PrivateMoodCandidateSong(
+    val song: Song,
+    val normalizedKey: Pair<String, String>,
+    val score: Double,
+  )
+
+  private data class PrivateMoodSpotifySignals(
+    val shortTermSongs: List<Song>,
+    val midTermSongs: List<Song>,
+    val longTermSongs: List<Song>,
+    val shortTermKeys: Set<Pair<String, String>>,
+    val midTermKeys: Set<Pair<String, String>>,
+    val longTermKeys: Set<Pair<String, String>>,
+  ) {
+    val allKeys: Set<Pair<String, String>> = shortTermKeys + midTermKeys + longTermKeys
+  }
+
+  private data class PrivateMoodFrontierAccumulator(
+    val song: Song,
+    var trackMatch: Double = 0.0,
+    var artistMatch: Double = 0.0,
+    var seedCount: Int = 0,
+  )
+
+  private data class PrivateMoodMatchResult(
+    val trackIds: List<String>,
+    val attemptedKeys: Set<Pair<String, String>>,
+  )
+
+  private enum class PrivateMoodPlaylistKind(val label: String) {
+    ANCHOR("Anchor"),
+    SURGE("Surge"),
+    NIGHT_DRIFT("Night Drift"),
+    FRONTIER("Frontier");
+
+    fun playlistName(): String {
+      return "$PRIVATE_MOOD_PLAYLIST_PREFIX$label"
+    }
+  }
 }
 
 class PlaylistUpdateException(val playlistIds: List<String>, cause: Throwable) :

--- a/src/main/resources/static/index.css
+++ b/src/main/resources/static/index.css
@@ -27,12 +27,23 @@ body {
   height: 100%;
 }
 
-iframe {
+.playlist-embed {
   float: left;
   width: 100%;
   max-width: 360px;
-  height: 360px;
   margin: 0 0 1rem 0;
+}
+
+.playlist-embed-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin: 0 0 0.5rem 0;
+}
+
+iframe {
+  width: 100%;
+  height: 360px;
   padding: 0;
   background: #1db954;
   border: 0;
@@ -44,14 +55,14 @@ iframe {
 }
 
 @media (min-width: 768px) {
-  iframe {
+  .playlist-embed {
     width: calc(50% - 1rem);
     margin: 0 1rem 1rem 0;
   }
 }
 
 @media (min-width: 1200px) {
-  iframe {
+  .playlist-embed {
     width: calc(25% - 1rem);
     margin: 0 1rem 1rem 0;
   }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -32,11 +32,14 @@
 <div id="lastFmSection">
     <input class="form-control" id="lastFmId" placeholder="Enter last.fm login..." type="text"/>
     <div class="row mt-2">
-        <div class="col-md-6">
+        <div class="col-lg-4">
             <button class="btn btn-secondary btn-lg" disabled id="lastfm" type="button">YEARLY LAST.FM</button>
         </div>
-        <div class="col-md-6 mt-2 mt-md-0">
+        <div class="col-lg-4 mt-2 mt-lg-0">
             <button class="btn btn-secondary btn-lg" disabled id="forgottenObsessions" type="button">FORGOTTEN OBSESSIONS</button>
+        </div>
+        <div class="col-lg-4 mt-2 mt-lg-0">
+            <button class="btn btn-secondary btn-lg" disabled id="privateMoodTaxonomy" type="button">PRIVATE MOOD TAXONOMY</button>
         </div>
     </div>
     <div class="text-muted small mt-1" id="lastfmStatus">Enter your Last.fm login to enable Last.fm tools.</div>
@@ -46,14 +49,15 @@
              role="progressbar" style="width: 0%;">0%
         </div>
     </div>
-    <div class="mt-3" id="forgottenObsessionsPlaylists"></div>
+    <div class="mt-3 playlist-results" id="forgottenObsessionsPlaylists"></div>
+    <div class="mt-3 playlist-results" id="privateMoodPlaylists"></div>
 </div>
 
 <div class="mt-4" id="bandSection">
     <button class="btn btn-success btn-lg" disabled id="bandPlaylist" type="button">BAND MIX</button>
     <input class="form-control" id="bandNames" placeholder="Enter band names separated by commas..." type="text"/>
     <div class="text-muted small mt-1 d-none" id="bandStatus"></div>
-    <div class="mt-3" id="bandPlaylists"></div>
+    <div class="mt-3 playlist-results" id="bandPlaylists"></div>
 </div>
 
 

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -12,22 +12,46 @@
 
 const ORIGIN = window.location.origin;
 const URL = ORIGIN;
+const PRIVATE_MOOD_LABELS = ['Anchor', 'Surge', 'Night Drift', 'Frontier'];
 
 var lastFmIdValid = false;
 var lastFmJobRunning = false;
 var lastFmProgressPoll = null;
 var lastFmRedirectTimer = null;
-var lastFmPlaylistTarget = null;
+var lastFmPlaylistConfig = null;
 var verifyRequest;
 
 function buildPlayButtonUrl(id) {
     return "https://open.spotify.com/embed/playlist/" + id;
 }
 
-function appendPlayButton(div, playlistId) {
-    $('<iframe>', {
-        src: buildPlayButtonUrl(playlistId), frameborder: 0, allow: "encrypted-media", allowtransparency: "true"
-    }).appendTo('#' + div);
+function appendPlayButton(div, playlistId, label) {
+    var container = document.getElementById(div);
+    if (!container) {
+        return;
+    }
+    var wrapper = document.createElement('div');
+    wrapper.className = 'playlist-embed';
+    if (label) {
+        var title = document.createElement('div');
+        title.className = 'playlist-embed-title';
+        title.textContent = label;
+        wrapper.appendChild(title);
+    }
+    var iframe = document.createElement('iframe');
+    iframe.src = buildPlayButtonUrl(playlistId);
+    iframe.frameBorder = '0';
+    iframe.allow = 'encrypted-media';
+    iframe.setAttribute('allowtransparency', 'true');
+    wrapper.appendChild(iframe);
+    container.appendChild(wrapper);
+}
+
+function renderPlaylistEmbeds(div, playlistIds, labels) {
+    $('#' + div).empty();
+    for (var i = 0; i < playlistIds.length; i += 1) {
+        appendPlayButton(div, playlistIds[i], labels && labels[i] ? labels[i] : null);
+    }
 }
 
 function parseBandNames() {
@@ -86,11 +110,14 @@ function updateLastfmButtonState() {
     var enabled = lastFmIdValid && !lastFmJobRunning;
     $('#lastfm').prop('disabled', !enabled);
     $('#forgottenObsessions').prop('disabled', !enabled);
+    $('#privateMoodTaxonomy').prop('disabled', !enabled);
     $('#lastFmId').prop('disabled', lastFmJobRunning);
     $('#lastfm').toggleClass('btn-info', enabled);
     $('#lastfm').toggleClass('btn-secondary', !enabled);
     $('#forgottenObsessions').toggleClass('btn-warning', enabled);
     $('#forgottenObsessions').toggleClass('btn-secondary', !enabled);
+    $('#privateMoodTaxonomy').toggleClass('btn-dark', enabled);
+    $('#privateMoodTaxonomy').toggleClass('btn-secondary', !enabled);
 }
 
 function resetLastfmProgress() {
@@ -224,26 +251,33 @@ function pollLastfmJob(jobId) {
         stopLastfmPolling();
         lastFmJobRunning = false;
         updateLastfmButtonState();
-        if (job.state === 'COMPLETED' && job.playlistIds && job.playlistIds.length > 0 && lastFmPlaylistTarget) {
-            $('#' + lastFmPlaylistTarget).empty();
-            appendPlayButton(lastFmPlaylistTarget, job.playlistIds[0]);
+        if (job.state === 'COMPLETED' && job.playlistIds && job.playlistIds.length > 0 && lastFmPlaylistConfig) {
+            renderPlaylistEmbeds(
+                lastFmPlaylistConfig.targetId,
+                job.playlistIds,
+                lastFmPlaylistConfig.labels || null
+            );
+        }
+        if (job.state === 'COMPLETED' || job.state === 'FAILED') {
+            lastFmPlaylistConfig = null;
         }
     }).fail(function () {
         stopLastfmPolling();
         lastFmJobRunning = false;
+        lastFmPlaylistConfig = null;
         updateLastfmButtonState();
         renderLastfmProgress({state: 'FAILED', progressPercent: currentLastfmProgress()});
         setLastfmStatus('Unable to load Last.fm refresh progress right now.');
     });
 }
 
-function startLastfmJob(jobPath, startMessage, failureMessage, playlistTargetId) {
+function startLastfmJob(jobPath, startMessage, failureMessage, playlistConfig) {
     if (!lastFmIdValid || lastFmJobRunning) {
         return;
     }
 
     lastFmJobRunning = true;
-    lastFmPlaylistTarget = playlistTargetId || null;
+    lastFmPlaylistConfig = playlistConfig || null;
     updateLastfmButtonState();
     resetLastfmProgress();
     $('#lastfmProgress').removeClass('d-none');
@@ -255,14 +289,14 @@ function startLastfmJob(jobPath, startMessage, failureMessage, playlistTargetId)
         contentType: 'application/json',
         data: JSON.stringify({lastFmLogin: $('#lastFmId').val().trim()}),
         success: function (data) {
-            if (lastFmPlaylistTarget) {
-                $('#' + lastFmPlaylistTarget).empty();
+            if (lastFmPlaylistConfig) {
+                $('#' + lastFmPlaylistConfig.targetId).empty();
             }
             pollLastfmJob(data.jobId);
         },
         error: function () {
             lastFmJobRunning = false;
-            lastFmPlaylistTarget = null;
+            lastFmPlaylistConfig = null;
             updateLastfmButtonState();
             resetLastfmProgress();
             setLastfmStatus(failureMessage);
@@ -276,11 +310,9 @@ $('#top').on('click', function () {
         type: 'post',
         url: URL + '/updateTopPlaylists',
         success: function (data) {
-            $('#spotifyTop iframe').remove();
+            $('#spotifyTop .playlist-embed').remove();
             $('#top').prop('disabled', false);
-            for (var i = 0; i < data.length; i += 1) {
-                appendPlayButton('spotifyTop', data[i]);
-            }
+            renderPlaylistEmbeds('spotifyTop', data, null);
         },
         error: function () {
             $('#top').prop('disabled', false);
@@ -302,12 +334,22 @@ $('#forgottenObsessions').on('click', function () {
         '/jobs/forgotten-obsessions',
         'Scanning Last.fm history for forgotten obsessions...',
         'Unable to start forgotten obsessions scan right now.',
-        'forgottenObsessionsPlaylists'
+        {targetId: 'forgottenObsessionsPlaylists'}
+    );
+});
+
+$('#privateMoodTaxonomy').on('click', function () {
+    startLastfmJob(
+        '/jobs/private-mood-taxonomy',
+        'Scanning listening history for private moods...',
+        'Unable to start private mood taxonomy right now.',
+        {targetId: 'privateMoodPlaylists', labels: PRIVATE_MOOD_LABELS}
     );
 });
 
 $('#lastFmId').on('input', function () {
     $('#forgottenObsessionsPlaylists').empty();
+    $('#privateMoodPlaylists').empty();
     verifyLastfmLogin($('#lastFmId').val().trim());
 });
 
@@ -333,8 +375,7 @@ $('#bandPlaylist').on('click', function () {
         contentType: 'application/json',
         data: JSON.stringify({bands: bands}),
         success: function (data) {
-            $('#bandPlaylists').empty();
-            appendPlayButton('bandPlaylists', data);
+            renderPlaylistEmbeds('bandPlaylists', [data], null);
             setBandStatus('Playlist ready!');
             updateBandButtonState();
         },

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -31,6 +31,16 @@ class JobsControllerTest {
   }
 
   @Test
+  fun startPrivateMoodTaxonomyReturnsId() {
+    every { service.startPrivateMoodTaxonomyJob("c", "login", 50) } returns "private-mood-id"
+
+    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("login"))
+
+    assertEquals(JobId("private-mood-id"), resp.body)
+    assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
+  }
+
+  @Test
   fun startRejectsBlankLogin() {
     val resp = controller.start("c", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
@@ -39,6 +49,12 @@ class JobsControllerTest {
   @Test
   fun startForgottenObsessionsRejectsBlankLogin() {
     val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("   "))
+    assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
+  fun startPrivateMoodTaxonomyRejectsBlankLogin() {
+    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
   }
 

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -72,6 +72,8 @@ class SpotifyAuthenticationControllerTest {
 
     assert(result.startsWith("redirect:"))
     assert(result.contains("state="))
+    assert(result.contains("playlist-modify-private"))
+    assert(result.contains("playlist-read-private"))
     verify {
       response.addCookie(
         match {

--- a/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
@@ -112,10 +112,12 @@ class IndexPageWorkflowIT {
     val login = page.getHtmlElementById("lastFmId") as HtmlInput
     val button = page.getHtmlElementById("lastfm") as HtmlButton
     val forgottenButton = page.getHtmlElementById("forgottenObsessions") as HtmlButton
+    val privateMoodButton = page.getHtmlElementById("privateMoodTaxonomy") as HtmlButton
     val status = page.getHtmlElementById("lastfmStatus") as HtmlElement
 
     assertTrue(button.isDisabled)
     assertTrue(forgottenButton.isDisabled)
+    assertTrue(privateMoodButton.isDisabled)
     assertEquals("Enter your Last.fm login to enable Last.fm tools.", status.asNormalizedText())
 
     setInputValue(page, login, "missing-user")
@@ -123,6 +125,7 @@ class IndexPageWorkflowIT {
 
     assertTrue(button.isDisabled)
     assertTrue(forgottenButton.isDisabled)
+    assertTrue(privateMoodButton.isDisabled)
     assertEquals("Last.fm login not found.", status.asNormalizedText())
 
     setInputValue(page, login, "valid-user")
@@ -130,6 +133,7 @@ class IndexPageWorkflowIT {
 
     assertFalse(button.isDisabled)
     assertFalse(forgottenButton.isDisabled)
+    assertFalse(privateMoodButton.isDisabled)
     assertEquals("", status.asNormalizedText())
   }
 
@@ -266,6 +270,62 @@ class IndexPageWorkflowIT {
 
     assertEquals("Forgotten obsessions playlist refreshed (12 tracks)", status.asNormalizedText())
     assertEquals(1, iframeCount)
+  }
+
+  @Test
+  fun shouldRenderPrivateMoodPlaylistsAfterSuccessfulJob() {
+    val page = loadIndexPage()
+    installAjaxMock(
+      page,
+      """
+        window.__uiTestMockAjax = function (options) {
+          if (options.url.indexOf('/verifyLastFmId/valid-user') !== -1) {
+            return { status: 200, responseText: 'true' };
+          }
+          if (options.url.indexOf('/jobs/private-mood-taxonomy') !== -1 && options.type === 'post') {
+            return { status: 202, responseText: '{"jobId":"job-4"}', json: true };
+          }
+          if (options.url.indexOf('/jobs/job-4') !== -1) {
+            return {
+              status: 200,
+              responseText: '{"jobId":"job-4","state":"COMPLETED","progressPercent":100,"message":"Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)","redirectUrl":null,"playlistIds":["anchor-id","surge-id","night-id","frontier-id"]}'
+            };
+          }
+          return { status: 404, responseText: 'null' };
+        };
+      """,
+    )
+
+    val login = page.getHtmlElementById("lastFmId") as HtmlInput
+    val privateMoodButton = page.getHtmlElementById("privateMoodTaxonomy") as HtmlButton
+
+    setInputValue(page, login, "valid-user")
+    waitForJs()
+    assertFalse(privateMoodButton.isDisabled)
+
+    triggerClick(page, "privateMoodTaxonomy")
+    waitForJs(4000)
+
+    val status = page.getHtmlElementById("lastfmStatus") as HtmlElement
+    val iframeCount =
+      (page
+          .executeJavaScript("document.querySelectorAll('#privateMoodPlaylists iframe').length;")
+          .javaScriptResult as Number)
+        .toInt()
+    val titleCount =
+      (page
+          .executeJavaScript(
+            "document.querySelectorAll('#privateMoodPlaylists .playlist-embed-title').length;"
+          )
+          .javaScriptResult as Number)
+        .toInt()
+
+    assertEquals(
+      "Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)",
+      status.asNormalizedText(),
+    )
+    assertEquals(4, iframeCount)
+    assertEquals(4, titleCount)
   }
 
   private fun loadIndexPage(): HtmlPage {

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -6,6 +6,8 @@ import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.lis.spotify.service.AuthenticationRequiredException
 import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
+import com.lis.spotify.service.PrivateMoodPlaylistResult
+import com.lis.spotify.service.PrivateMoodTaxonomyResult
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.clearMocks
 import io.mockk.every
@@ -75,6 +77,15 @@ constructor(
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
     every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
       ForgottenObsessionsPlaylistResult("playlist-1", 12, 12, 18)
+    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } returns
+      PrivateMoodTaxonomyResult(
+        listOf(
+          PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+          PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
+          PrivateMoodPlaylistResult("Night Drift", "Private Mood - Night Drift", "night-id", 6, 9),
+          PrivateMoodPlaylistResult("Frontier", "Private Mood - Frontier", "frontier-id", 15, 24),
+        )
+      )
     every { playlistService.updateTopPlaylists(any()) } returns emptyList()
   }
 
@@ -138,6 +149,35 @@ constructor(
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
   }
 
+  @Test
+  fun privateMoodTaxonomyJobReturnsPlaylistIds() {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
+
+    val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
+    val jobId = resp.body?.get("jobId") as String
+    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+
+    assertEquals(HttpStatus.OK, status.statusCode)
+    assertEquals("COMPLETED", status.body?.get("state"))
+    assertEquals(
+      listOf("anchor-id", "surge-id", "night-id", "frontier-id"),
+      status.body?.get("playlistIds"),
+    )
+  }
+
+  @Test
+  fun privateMoodTaxonomyJobRejectsBlankLogin() {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
+
+    val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
+
+    assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
   class Config {
     @Bean
     @Primary
@@ -146,6 +186,21 @@ constructor(
       every { svc.updateYearlyPlaylists(any(), any(), any()) } returns Unit
       every { svc.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
         ForgottenObsessionsPlaylistResult("playlist-1", 12, 12, 18)
+      every { svc.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } returns
+        PrivateMoodTaxonomyResult(
+          listOf(
+            PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+            PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
+            PrivateMoodPlaylistResult(
+              "Night Drift",
+              "Private Mood - Night Drift",
+              "night-id",
+              6,
+              9,
+            ),
+            PrivateMoodPlaylistResult("Frontier", "Private Mood - Frontier", "frontier-id", 15, 24),
+          )
+        )
       every { svc.updateTopPlaylists(any()) } returns emptyList()
       return svc
     }

--- a/src/test/kotlin/com/lis/spotify/integration/SpotifyAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/SpotifyAuthenticationControllerIT.kt
@@ -105,6 +105,8 @@ constructor(
     assertAll(
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
       { assertTrue(response.headers.location!!.toString().startsWith(baseUrl)) },
+      { assertTrue(response.headers.location!!.toString().contains("playlist-modify-private")) },
+      { assertTrue(response.headers.location!!.toString().contains("playlist-read-private")) },
       { assertNotNull(stateCookie) },
     )
   }

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -148,4 +148,59 @@ class JobServiceTest {
     assertEquals(JobState.FAILED, status?.state)
     assertEquals(listOf("playlist-1"), status?.playlistIds)
   }
+
+  @Test
+  fun privateMoodTaxonomyJobStoresPlaylistIds() {
+    val playlistService = mockk<SpotifyTopPlaylistsService>()
+    val jobStatusStore = InMemoryJobStatusStore()
+    val scheduler = mockk<TaskScheduler>()
+    val runnable = slot<Runnable>()
+    every { scheduler.schedule(capture(runnable), any<java.util.Date>()) } answers
+      {
+        runnable.captured.run()
+        mockk(relaxed = true)
+      }
+    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } returns
+      PrivateMoodTaxonomyResult(
+        listOf(
+          PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+          PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
+          PrivateMoodPlaylistResult("Night Drift", "Private Mood - Night Drift", "night-id", 6, 10),
+          PrivateMoodPlaylistResult("Frontier", "Private Mood - Frontier", "frontier-id", 15, 24),
+        )
+      )
+    val service = JobService(playlistService, jobStatusStore, scheduler)
+
+    val jobId = service.startPrivateMoodTaxonomyJob("c", "login")
+
+    val status = service.getJobStatus(jobId)
+    assertEquals(JobState.COMPLETED, status?.state)
+    assertEquals(listOf("anchor-id", "surge-id", "night-id", "frontier-id"), status?.playlistIds)
+    assertEquals(
+      "Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)",
+      status?.message,
+    )
+  }
+
+  @Test
+  fun privateMoodTaxonomyJobPreservesPlaylistIdsOnFailure() {
+    val playlistService = mockk<SpotifyTopPlaylistsService>()
+    val jobStatusStore = InMemoryJobStatusStore()
+    val scheduler = mockk<TaskScheduler>()
+    val runnable = slot<Runnable>()
+    every { scheduler.schedule(capture(runnable), any<java.util.Date>()) } answers
+      {
+        runnable.captured.run()
+        mockk(relaxed = true)
+      }
+    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } throws
+      PlaylistUpdateException(listOf("anchor-id", "surge-id"), IllegalStateException("boom"))
+    val service = JobService(playlistService, jobStatusStore, scheduler)
+
+    val jobId = service.startPrivateMoodTaxonomyJob("c", "login")
+
+    val status = service.getJobStatus(jobId)
+    assertEquals(JobState.FAILED, status?.state)
+    assertEquals(listOf("anchor-id", "surge-id"), status?.playlistIds)
+  }
 }

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -335,6 +335,59 @@ class LastFmServiceTest {
   }
 
   @Test
+  fun trackSimilarParsesSongsAndUsesCache() {
+    val rest = mockk<RestTemplate>()
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf(
+        "similartracks" to
+          mapOf(
+            "track" to
+              listOf(
+                mapOf(
+                  "name" to "Signal",
+                  "match" to "0.81",
+                  "artist" to mapOf("name" to "Artist B"),
+                )
+              )
+          )
+      )
+
+    val first = service.trackSimilar("Artist A", "Seed Song", 5)
+    val second = service.trackSimilar("Artist A", "Seed Song", 5)
+
+    assertEquals(listOf(LastFmSimilarTrack(Song("Artist B", "Signal"), 0.81)), first)
+    assertEquals(first, second)
+    verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun artistSimilarParsesArtists() {
+    val rest = mockk<RestTemplate>()
+    val service = service()
+    service.rest = rest
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf(
+        "similarartists" to
+          mapOf(
+            "artist" to
+              listOf(
+                mapOf("name" to "Night Swim", "match" to "0.55"),
+                mapOf("name" to "Afterglow", "match" to 0.42),
+              )
+          )
+      )
+
+    val result = service.artistSimilar("Artist A", 5)
+
+    assertEquals(
+      listOf(LastFmSimilarArtist("Night Swim", 0.55), LastFmSimilarArtist("Afterglow", 0.42)),
+      result,
+    )
+  }
+
+  @Test
   fun userExistsReturnsTrue() {
     val rest = mockk<RestTemplate>()
     val service = service()

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyPlaylistServiceTest.kt
@@ -1,6 +1,7 @@
 package com.lis.spotify.service
 
 import com.lis.spotify.domain.Album
+import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.domain.Playlist
 import com.lis.spotify.domain.PlaylistTrack
 import com.lis.spotify.domain.PlaylistTracks
@@ -94,9 +95,26 @@ class SpotifyPlaylistServiceTest {
 
   @Test
   fun modifyPlaylistEmptyList() {
-    val result = service.modifyPlaylist("id", emptyList(), "cid")
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("id", "cid") } returns emptyList()
+
+    val result = spied.modifyPlaylist("id", emptyList(), "cid")
+
     assertEquals(emptyList<String>(), result["added"])
     assertEquals(emptyList<String>(), result["removed"])
+  }
+
+  @Test
+  fun modifyPlaylistEmptyListClearsExistingTracks() {
+    val spied = spyk(service)
+    every { spied.getPlaylistTrackIds("id", "cid") } returns listOf("1", "2")
+    every { spied.deleteTracksFromPlaylist("id", listOf("1", "2"), "cid") } returns Unit
+
+    val result = spied.modifyPlaylist("id", emptyList(), "cid")
+
+    assertEquals(emptyList<String>(), result["added"])
+    assertEquals(listOf("1", "2"), result["removed"])
+    verify(exactly = 1) { spied.deleteTracksFromPlaylist("id", listOf("1", "2"), "cid") }
   }
 
   @Test
@@ -146,5 +164,25 @@ class SpotifyPlaylistServiceTest {
     val distinct = tracks.distinct()
     verify(exactly = 1) { spied.replacePlaylistTracks("pl", distinct.take(100), "cid") }
     verify(exactly = 1) { spied.addTracksToPlaylist("pl", distinct.drop(100), "cid") }
+  }
+
+  @Test
+  fun hasRequiredScopesChecksStoredSpotifyScopeString() {
+    val authService = mockk<SpotifyAuthenticationService>()
+    every { rest.spotifyAuthenticationService } returns authService
+    every { authService.getAuthToken("cid") } returns
+      AuthToken(
+        access_token = "access",
+        token_type = "Bearer",
+        scope = "user-top-read playlist-modify-private playlist-read-private",
+        expires_in = 3600,
+        refresh_token = "refresh",
+        clientId = "cid",
+      )
+
+    val result =
+      service.hasRequiredScopes("cid", setOf("playlist-modify-private", "playlist-read-private"))
+
+    assertEquals(true, result)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -15,7 +15,9 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -280,5 +282,146 @@ class SpotifyTopPlaylistsServiceTest {
     assertEquals(110, result.candidateCount)
     assertTrue(progressMessages.contains("Matching forgotten obsessions on Spotify (1/2)"))
     coVerify(exactly = 1) { searchService.searchTrackIds(match { it.size == 100 }, "cid") }
+  }
+
+  @Test
+  fun buildPrivateMoodSongStatsCapturesNightAndRecencySignals() {
+    val service =
+      SpotifyTopPlaylistsService(
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+      )
+
+    val stats =
+      service
+        .buildPrivateMoodSongStats(
+          scrobbles =
+            listOf(
+              Song("Artist A", "Night Song", playedAtEpochSecond = 1_730_242_800),
+              Song("Artist A", "Night Song", playedAtEpochSecond = 1_730_248_200),
+              Song("Artist A", "Night Song", playedAtEpochSecond = 1_731_626_100),
+              Song("Artist A", "Night Song", playedAtEpochSecond = 1_731_632_400),
+            ),
+          nowEpochSecond = 1_730_500_000,
+        )
+        .single()
+
+    assertEquals(4, stats.totalPlays)
+    assertEquals(4, stats.recentPlays30d)
+    assertTrue(stats.recencySpikeRatio > 1.0)
+    assertTrue(stats.nightPlayRatio >= 0.5)
+    assertFalse(stats.hourHistogram.all { it == 0 })
+  }
+
+  @Test
+  fun updatePrivateMoodTaxonomyPlaylistsCreatesPrivatePlaylists() {
+    val playlistService = mockk<SpotifyPlaylistService>()
+    val trackService = mockk<SpotifyTopTrackService>()
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+    val service =
+      SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+
+    service.firstSupportedYear = 2023
+    service.currentYearProvider = { 2024 }
+    service.nowEpochSecondProvider = { 1_730_500_000 }
+
+    every {
+      playlistService.hasRequiredScopes(
+        "cid",
+        setOf("playlist-modify-private", "playlist-read-private"),
+      )
+    } returns true
+    every { trackService.getTopTracksShortTerm("cid") } returns
+      listOf(track("short-1", "Surge Song", "Artist Surge"))
+    every { trackService.getTopTracksMidTerm("cid") } returns
+      listOf(track("mid-1", "Anchor Song", "Artist Anchor"))
+    every { trackService.getTopTracksLongTerm("cid") } returns
+      listOf(track("long-1", "Anchor Song", "Artist Anchor"))
+    every { lastFmService.yearlyChartlist("cid", 2024, "login", Int.MAX_VALUE) } returns
+      listOf(
+        Song("Artist Anchor", "Anchor Song", 1_720_000_000),
+        Song("Artist Anchor", "Anchor Song", 1_728_000_000),
+        Song("Artist Surge", "Surge Song", 1_730_300_000),
+        Song("Artist Surge", "Surge Song", 1_730_320_000),
+        Song("Artist Surge", "Surge Song", 1_730_340_000),
+        Song("Artist Night", "Night Song", 1_730_347_200),
+        Song("Artist Night", "Night Song", 1_730_350_800),
+        Song("Artist Night", "Night Song", 1_730_354_400),
+        Song("Artist Fresh", "Fresh Cut", 1_730_280_000),
+      )
+    every { lastFmService.yearlyChartlist("cid", 2023, "login", Int.MAX_VALUE) } returns
+      listOf(
+        Song("Artist Anchor", "Anchor Song", 1_690_000_000),
+        Song("Artist Anchor", "Anchor Song", 1_690_100_000),
+        Song("Artist Surge", "Surge Song", 1_690_200_000),
+      )
+    every { lastFmService.artistSimilar(any(), any()) } returns
+      listOf(LastFmSimilarArtist("Artist Fresh", 0.7))
+    every { lastFmService.trackSimilar(any(), any(), any()) } returns
+      listOf(LastFmSimilarTrack(Song("Artist Frontier", "Outer Edge"), 0.8))
+    coEvery { searchService.searchTrackIds(any(), "cid") } answers
+      {
+        firstArg<List<Song>>()
+          .mapNotNull { song ->
+            when (song.title) {
+              "Anchor Song" -> "anchor-track"
+              "Surge Song" -> "surge-track"
+              "Night Song" -> "night-track"
+              "Outer Edge" -> "frontier-track"
+              "Fresh Cut" -> "fresh-track"
+              else -> null
+            }
+          }
+          .distinct()
+      }
+    every { playlistService.getCurrentUserPlaylists("cid") } returns mutableListOf()
+    every { playlistService.createPlaylist(any(), "cid", false) } answers
+      {
+        Playlist(id = thirdArg<Boolean>().toString() + ":" + firstArg<String>(), name = firstArg())
+      }
+    every { playlistService.modifyPlaylist(any(), any(), "cid") } returns emptyMap()
+
+    val result = service.updatePrivateMoodTaxonomyPlaylists("cid", "login")
+
+    assertEquals(4, result.playlists.size)
+    assertEquals(
+      listOf("Anchor", "Surge", "Night Drift", "Frontier"),
+      result.playlists.map { it.label },
+    )
+    assertTrue(result.playlists.all { it.playlistId.isNotBlank() })
+    verify(exactly = 4) {
+      playlistService.createPlaylist(match { it.startsWith("Private Mood -") }, "cid", false)
+    }
+    verify(exactly = 4) { playlistService.modifyPlaylist(any(), any(), "cid") }
+  }
+
+  @Test
+  fun updatePrivateMoodTaxonomyPlaylistsRequiresPrivateScopes() {
+    val playlistService = mockk<SpotifyPlaylistService>()
+    val service =
+      SpotifyTopPlaylistsService(
+        playlistService,
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+        mockk(relaxed = true),
+      )
+
+    every { playlistService.hasRequiredScopes("cid", any()) } returns false
+
+    assertThrows(AuthenticationRequiredException::class.java) {
+      service.updatePrivateMoodTaxonomyPlaylists("cid", "login")
+    }
+  }
+
+  private fun track(id: String, title: String, artist: String): Track {
+    return Track(
+      id,
+      title,
+      listOf(com.lis.spotify.domain.Artist("$id-artist", artist)),
+      Album("a", "n", emptyList()),
+    )
   }
 }


### PR DESCRIPTION
## What changed
- added a new background job flow at `POST /jobs/private-mood-taxonomy` with `JobService.startPrivateMoodTaxonomyJob(...)`
- implemented deterministic private mood taxonomy scoring in `SpotifyTopPlaylistsService` to create/update four private playlists: `Private Mood - Anchor`, `Private Mood - Surge`, `Private Mood - Night Drift`, and `Private Mood - Frontier`
- added Last.fm wrappers for `track.getSimilar` and `artist.getSimilar`, plus private playlist creation and lookup support in the Spotify playlist service
- extended the main UI with a `PRIVATE MOOD TAXONOMY` button, shared polling/status handling, and labeled embedded playlist results
- updated README scope and usage docs, and added unit/integration coverage for jobs, auth scopes, playlist behavior, Last.fm wrappers, taxonomy stats, and the index workflow

## Why it changed
- the app needed a production-ready way to build personal mood playlists from existing Spotify + Last.fm behavior without using Last.fm tags, Spotify recommendations/audio features/analysis, or any ML/model training
- the feature reuses the existing job/polling architecture so long-running playlist generation stays consistent with the yearly Last.fm and forgotten-obsessions flows

## User and developer impact
- users can now generate four private Spotify playlists from the main page after authenticating Spotify and Last.fm
- Spotify auth now requests `playlist-modify-private` and `playlist-read-private` so the app can create private playlists and reuse them on later runs
- the new scoring remains deterministic and based on transparent heuristics: persistence, recent spikes, night-session bias, and Last.fm similar-track/artist neighborhoods around core favorites

## Validation
- `./gradlew ktfmtFormat`
- `./gradlew test`
- `./gradlew jacocoTestCoverageVerification`

## Known limitations / follow-up
- night-session scoring uses the app analysis timezone (UTC by default), because user-local timezone data is not currently stored
- frontier discovery is limited to Last.fm similar tracks/artists around core favorites and intentionally excludes overplayed songs rather than using broader recommendation systems