### PR TITLE
Add explicit happy and sad private mood playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ playlists. The refresh runs in the background and shows progress in the UI.
 The current flow preserves the login across Last.fm auth redirects so the retry
 path can continue after the user authorizes access.
 
-Use **PRIVATE MOOD TAXONOMY** to build four private playlists from deterministic
+Use **PRIVATE MOOD TAXONOMY** to build six private playlists from deterministic
 Spotify + Last.fm listening heuristics:
 
 - `Private Mood - Anchor`
+- `Private Mood - Happy`
+- `Private Mood - Sad`
 - `Private Mood - Surge`
 - `Private Mood - Night Drift`
 - `Private Mood - Frontier`

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -409,6 +409,8 @@ class SpotifyTopPlaylistsService(
     val statsByKey = stats.associateBy { it.normalizedKey }
     val anchorCandidates = selectAnchorCandidates(stats, spotifySignals)
     val surgeCandidates = selectSurgeCandidates(stats, spotifySignals)
+    val happyCandidates = selectHappyCandidates(stats, spotifySignals)
+    val sadCandidates = selectSadCandidates(stats, spotifySignals)
     val nightDriftCandidates = selectNightDriftCandidates(stats, spotifySignals)
 
     progress(80, "Exploring frontier candidates")
@@ -423,22 +425,34 @@ class SpotifyTopPlaylistsService(
     val playlistCandidates =
       linkedMapOf(
         PrivateMoodPlaylistKind.ANCHOR to anchorCandidates,
+        PrivateMoodPlaylistKind.HAPPY to happyCandidates,
+        PrivateMoodPlaylistKind.SAD to sadCandidates,
         PrivateMoodPlaylistKind.SURGE to surgeCandidates,
         PrivateMoodPlaylistKind.NIGHT_DRIFT to nightDriftCandidates,
         PrivateMoodPlaylistKind.FRONTIER to frontierCandidates,
+      )
+    val playlistProcessingOrder =
+      listOf(
+        PrivateMoodPlaylistKind.HAPPY,
+        PrivateMoodPlaylistKind.SAD,
+        PrivateMoodPlaylistKind.NIGHT_DRIFT,
+        PrivateMoodPlaylistKind.SURGE,
+        PrivateMoodPlaylistKind.ANCHOR,
+        PrivateMoodPlaylistKind.FRONTIER,
       )
 
     val updatedPlaylistIds = mutableListOf<String>()
     val reservedCandidateKeys = mutableSetOf<Pair<String, String>>()
     val usedTrackIds = mutableSetOf<String>()
-    val playlistResults = mutableListOf<PrivateMoodPlaylistResult>()
+    val playlistResultsByKind = linkedMapOf<PrivateMoodPlaylistKind, PrivateMoodPlaylistResult>()
     val playlistProgressStart = 85
     val playlistProgressRange = 14
 
-    playlistCandidates.entries.forEachIndexed { index, (kind, candidates) ->
+    playlistProcessingOrder.forEachIndexed { index, kind ->
+      val candidates = playlistCandidates.getValue(kind)
       val filteredCandidates = candidates.filterNot { it.normalizedKey in reservedCandidateKeys }
       progress(
-        playlistProgressStart + ((index * playlistProgressRange) / playlistCandidates.size),
+        playlistProgressStart + ((index * playlistProgressRange) / playlistProcessingOrder.size),
         "Matching ${kind.label} on Spotify",
       )
       val matchedTracks =
@@ -465,7 +479,7 @@ class SpotifyTopPlaylistsService(
 
       updatedPlaylistIds += playlist.id
       usedTrackIds += matchedTracks.trackIds
-      playlistResults +=
+      playlistResultsByKind[kind] =
         PrivateMoodPlaylistResult(
           label = kind.label,
           playlistName = kind.playlistName(),
@@ -475,13 +489,16 @@ class SpotifyTopPlaylistsService(
         )
       progress(
         playlistProgressStart +
-          (((index + 1) * playlistProgressRange) / playlistCandidates.size).coerceAtMost(99),
+          (((index + 1) * playlistProgressRange) / playlistProcessingOrder.size).coerceAtMost(99),
         "${kind.label} playlist refreshed (${matchedTracks.trackIds.size} tracks)",
       )
     }
 
     progress(100, "Private mood taxonomy refreshed")
-    val result = PrivateMoodTaxonomyResult(playlistResults)
+    val result =
+      PrivateMoodTaxonomyResult(
+        PrivateMoodPlaylistKind.entries.mapNotNull { playlistResultsByKind[it] }
+      )
     logger.info(
       "Private mood taxonomy refreshed for {} -> {}",
       clientId,
@@ -607,6 +624,7 @@ class SpotifyTopPlaylistsService(
         recencySpikeRatio = recencySpikeRatio,
         stabilityScore = stabilityScore,
         noveltyScore = noveltyScore,
+        daytimePlayRatio = daytimePlayRatio(stat.hourHistogram, totalPlays),
         nightPlayRatio = stat.nightPlays / totalPlays,
         lateSessionRatio = stat.lateSessionPlays / totalPlays,
         nightPlays = stat.nightPlays,
@@ -745,6 +763,68 @@ class SpotifyTopPlaylistsService(
       .toList()
   }
 
+  private fun selectHappyCandidates(
+    stats: List<PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    limit: Int = Int.MAX_VALUE,
+  ): List<PrivateMoodCandidateSong> {
+    return stats
+      .asSequence()
+      .filter {
+        it.recentPlays90d > 0 &&
+          it.daytimePlayRatio >= PRIVATE_MOOD_HAPPY_MIN_DAYTIME_RATIO &&
+          it.nightPlayRatio <= PRIVATE_MOOD_HAPPY_MAX_NIGHT_RATIO
+      }
+      .map { stat ->
+        val score =
+          stat.daytimePlayRatio * 70.0 +
+            minOf(stat.weekendToWeekdayRatio, 3.0) * 18.0 +
+            stat.recencySpikeRatio * 14.0 +
+            stat.recentPlays30d * 5.0 +
+            stat.recentPlays90d * 2.0 +
+            stat.stabilityScore * 0.45 +
+            (if (stat.normalizedKey in spotifySignals.shortTermKeys) 30.0 else 0.0) +
+            (if (stat.normalizedKey in spotifySignals.midTermKeys) 14.0 else 0.0) -
+            stat.nightPlayRatio * 25.0
+        PrivateMoodCandidateSong(stat.song, stat.normalizedKey, score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(limit)
+      .toList()
+  }
+
+  private fun selectSadCandidates(
+    stats: List<PrivateMoodSongStats>,
+    spotifySignals: PrivateMoodSpotifySignals,
+    limit: Int = Int.MAX_VALUE,
+  ): List<PrivateMoodCandidateSong> {
+    return stats
+      .asSequence()
+      .filter {
+        it.totalPlays >= PRIVATE_MOOD_SAD_MIN_TOTAL_PLAYS &&
+          (it.activeYears >= 2 || it.normalizedKey in spotifySignals.longTermKeys) &&
+          (it.nightPlayRatio >= PRIVATE_MOOD_SAD_MIN_NIGHT_RATIO ||
+            it.lateSessionRatio >= PRIVATE_MOOD_SAD_MIN_LATE_SESSION_RATIO)
+      }
+      .map { stat ->
+        val score =
+          stat.stabilityScore * 2.6 +
+            stat.totalPlays * 1.5 +
+            stat.activeYears * 10.0 +
+            stat.nightPlayRatio * 42.0 +
+            stat.lateSessionRatio * 24.0 +
+            stat.recentPlays90d * 1.5 +
+            (if (stat.normalizedKey in spotifySignals.longTermKeys) 28.0 else 0.0) +
+            (if (stat.normalizedKey in spotifySignals.midTermKeys) 10.0 else 0.0) -
+            stat.daytimePlayRatio * 18.0 -
+            minOf(stat.weekendToWeekdayRatio, 3.0) * 5.0
+        PrivateMoodCandidateSong(stat.song, stat.normalizedKey, score)
+      }
+      .sortedWith(privateMoodCandidateComparator())
+      .take(limit)
+      .toList()
+  }
+
   private fun buildFrontierCandidates(
     statsByKey: Map<Pair<String, String>, PrivateMoodSongStats>,
     spotifySignals: PrivateMoodSpotifySignals,
@@ -845,6 +925,14 @@ class SpotifyTopPlaylistsService(
 
   private fun normalizedFrontierCandidateLimit(playlistSize: Int): Int {
     return maxOf(playlistSize * 4, PRIVATE_MOOD_FRONTIER_MIN_CANDIDATE_COUNT)
+  }
+
+  private fun daytimePlayRatio(hourHistogram: IntArray, totalPlays: Double): Double {
+    val daytimePlays =
+      (PRIVATE_MOOD_DAYTIME_START_HOUR until PRIVATE_MOOD_DAYTIME_END_HOUR).sumOf {
+        hourHistogram[it]
+      }
+    return daytimePlays / totalPlays
   }
 
   private fun matchPrivateMoodTrackIds(
@@ -1021,9 +1109,16 @@ class SpotifyTopPlaylistsService(
     private const val PRIVATE_MOOD_SEARCH_BATCH_SIZE = 100
     private const val PRIVATE_MOOD_ANCHOR_MIN_TOTAL_PLAYS = 4
     private const val PRIVATE_MOOD_SURGE_MIN_SPIKE_RATIO = 1.35
+    private const val PRIVATE_MOOD_HAPPY_MIN_DAYTIME_RATIO = 0.45
+    private const val PRIVATE_MOOD_HAPPY_MAX_NIGHT_RATIO = 0.35
+    private const val PRIVATE_MOOD_SAD_MIN_TOTAL_PLAYS = 4
+    private const val PRIVATE_MOOD_SAD_MIN_NIGHT_RATIO = 0.20
+    private const val PRIVATE_MOOD_SAD_MIN_LATE_SESSION_RATIO = 0.20
     private const val PRIVATE_MOOD_NIGHT_DRIFT_MIN_TOTAL_PLAYS = 3
     private const val PRIVATE_MOOD_NIGHT_RATIO_THRESHOLD = 0.35
     private const val PRIVATE_MOOD_LATE_SESSION_RATIO_THRESHOLD = 0.35
+    private const val PRIVATE_MOOD_DAYTIME_START_HOUR = 6
+    private const val PRIVATE_MOOD_DAYTIME_END_HOUR = 20
     private const val PRIVATE_MOOD_FRONTIER_MAX_USER_PLAYS = 5
     private const val PRIVATE_MOOD_FRONTIER_TRACK_SEED_LIMIT = 12
     private const val PRIVATE_MOOD_FRONTIER_ARTIST_SEED_LIMIT = 12
@@ -1079,6 +1174,7 @@ class SpotifyTopPlaylistsService(
     val recencySpikeRatio: Double,
     val stabilityScore: Double,
     val noveltyScore: Double,
+    val daytimePlayRatio: Double,
     val nightPlayRatio: Double,
     val lateSessionRatio: Double,
     val nightPlays: Int,
@@ -1116,6 +1212,8 @@ class SpotifyTopPlaylistsService(
 
   private enum class PrivateMoodPlaylistKind(val label: String) {
     ANCHOR("Anchor"),
+    HAPPY("Happy"),
+    SAD("Sad"),
     SURGE("Surge"),
     NIGHT_DRIFT("Night Drift"),
     FRONTIER("Frontier");

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -12,7 +12,7 @@
 
 const ORIGIN = window.location.origin;
 const URL = ORIGIN;
-const PRIVATE_MOOD_LABELS = ['Anchor', 'Surge', 'Night Drift', 'Frontier'];
+const PRIVATE_MOOD_LABELS = ['Anchor', 'Happy', 'Sad', 'Surge', 'Night Drift', 'Frontier'];
 
 var lastFmIdValid = false;
 var lastFmJobRunning = false;
@@ -116,7 +116,7 @@ function updateLastfmButtonState() {
     $('#lastfm').toggleClass('btn-secondary', !enabled);
     $('#forgottenObsessions').toggleClass('btn-warning', enabled);
     $('#forgottenObsessions').toggleClass('btn-secondary', !enabled);
-    $('#privateMoodTaxonomy').toggleClass('btn-dark', enabled);
+    $('#privateMoodTaxonomy').toggleClass('btn-primary', enabled);
     $('#privateMoodTaxonomy').toggleClass('btn-secondary', !enabled);
 }
 

--- a/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/IndexPageWorkflowIT.kt
@@ -288,7 +288,7 @@ class IndexPageWorkflowIT {
           if (options.url.indexOf('/jobs/job-4') !== -1) {
             return {
               status: 200,
-              responseText: '{"jobId":"job-4","state":"COMPLETED","progressPercent":100,"message":"Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)","redirectUrl":null,"playlistIds":["anchor-id","surge-id","night-id","frontier-id"]}'
+              responseText: '{"jobId":"job-4","state":"COMPLETED","progressPercent":100,"message":"Private mood taxonomy refreshed (Anchor 12, Happy 10, Sad 9, Surge 8, Night Drift 6, Frontier 15)","redirectUrl":null,"playlistIds":["anchor-id","happy-id","sad-id","surge-id","night-id","frontier-id"]}'
             };
           }
           return { status: 404, responseText: 'null' };
@@ -321,11 +321,11 @@ class IndexPageWorkflowIT {
         .toInt()
 
     assertEquals(
-      "Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)",
+      "Private mood taxonomy refreshed (Anchor 12, Happy 10, Sad 9, Surge 8, Night Drift 6, Frontier 15)",
       status.asNormalizedText(),
     )
-    assertEquals(4, iframeCount)
-    assertEquals(4, titleCount)
+    assertEquals(6, iframeCount)
+    assertEquals(6, titleCount)
   }
 
   private fun loadIndexPage(): HtmlPage {

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -81,6 +81,8 @@ constructor(
       PrivateMoodTaxonomyResult(
         listOf(
           PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+          PrivateMoodPlaylistResult("Happy", "Private Mood - Happy", "happy-id", 10, 16),
+          PrivateMoodPlaylistResult("Sad", "Private Mood - Sad", "sad-id", 9, 15),
           PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
           PrivateMoodPlaylistResult("Night Drift", "Private Mood - Night Drift", "night-id", 6, 9),
           PrivateMoodPlaylistResult("Frontier", "Private Mood - Frontier", "frontier-id", 15, 24),
@@ -162,7 +164,7 @@ constructor(
     assertEquals(HttpStatus.OK, status.statusCode)
     assertEquals("COMPLETED", status.body?.get("state"))
     assertEquals(
-      listOf("anchor-id", "surge-id", "night-id", "frontier-id"),
+      listOf("anchor-id", "happy-id", "sad-id", "surge-id", "night-id", "frontier-id"),
       status.body?.get("playlistIds"),
     )
   }
@@ -190,6 +192,8 @@ constructor(
         PrivateMoodTaxonomyResult(
           listOf(
             PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+            PrivateMoodPlaylistResult("Happy", "Private Mood - Happy", "happy-id", 10, 16),
+            PrivateMoodPlaylistResult("Sad", "Private Mood - Sad", "sad-id", 9, 15),
             PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
             PrivateMoodPlaylistResult(
               "Night Drift",

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -164,6 +164,8 @@ class JobServiceTest {
       PrivateMoodTaxonomyResult(
         listOf(
           PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
+          PrivateMoodPlaylistResult("Happy", "Private Mood - Happy", "happy-id", 10, 16),
+          PrivateMoodPlaylistResult("Sad", "Private Mood - Sad", "sad-id", 9, 15),
           PrivateMoodPlaylistResult("Surge", "Private Mood - Surge", "surge-id", 8, 14),
           PrivateMoodPlaylistResult("Night Drift", "Private Mood - Night Drift", "night-id", 6, 10),
           PrivateMoodPlaylistResult("Frontier", "Private Mood - Frontier", "frontier-id", 15, 24),
@@ -175,9 +177,12 @@ class JobServiceTest {
 
     val status = service.getJobStatus(jobId)
     assertEquals(JobState.COMPLETED, status?.state)
-    assertEquals(listOf("anchor-id", "surge-id", "night-id", "frontier-id"), status?.playlistIds)
     assertEquals(
-      "Private mood taxonomy refreshed (Anchor 12, Surge 8, Night Drift 6, Frontier 15)",
+      listOf("anchor-id", "happy-id", "sad-id", "surge-id", "night-id", "frontier-id"),
+      status?.playlistIds,
+    )
+    assertEquals(
+      "Private mood taxonomy refreshed (Anchor 12, Happy 10, Sad 9, Surge 8, Night Drift 6, Frontier 15)",
       status?.message,
     )
   }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -335,11 +335,20 @@ class SpotifyTopPlaylistsServiceTest {
       )
     } returns true
     every { trackService.getTopTracksShortTerm("cid") } returns
-      listOf(track("short-1", "Surge Song", "Artist Surge"))
+      listOf(
+        track("short-1", "Surge Song", "Artist Surge"),
+        track("short-2", "Happy Song", "Artist Happy"),
+      )
     every { trackService.getTopTracksMidTerm("cid") } returns
-      listOf(track("mid-1", "Anchor Song", "Artist Anchor"))
+      listOf(
+        track("mid-1", "Anchor Song", "Artist Anchor"),
+        track("mid-2", "Sad Song", "Artist Sad"),
+      )
     every { trackService.getTopTracksLongTerm("cid") } returns
-      listOf(track("long-1", "Anchor Song", "Artist Anchor"))
+      listOf(
+        track("long-1", "Anchor Song", "Artist Anchor"),
+        track("long-2", "Sad Song", "Artist Sad"),
+      )
     every { lastFmService.yearlyChartlist("cid", 2024, "login", Int.MAX_VALUE) } returns
       listOf(
         Song("Artist Anchor", "Anchor Song", 1_720_000_000),
@@ -347,6 +356,12 @@ class SpotifyTopPlaylistsServiceTest {
         Song("Artist Surge", "Surge Song", 1_730_300_000),
         Song("Artist Surge", "Surge Song", 1_730_320_000),
         Song("Artist Surge", "Surge Song", 1_730_340_000),
+        Song("Artist Happy", "Happy Song", 1_728_554_400),
+        Song("Artist Happy", "Happy Song", 1_728_741_600),
+        Song("Artist Happy", "Happy Song", 1_728_835_200),
+        Song("Artist Sad", "Sad Song", 1_728_689_400),
+        Song("Artist Sad", "Sad Song", 1_728_693_000),
+        Song("Artist Sad", "Sad Song", 1_728_696_600),
         Song("Artist Night", "Night Song", 1_730_347_200),
         Song("Artist Night", "Night Song", 1_730_350_800),
         Song("Artist Night", "Night Song", 1_730_354_400),
@@ -357,6 +372,7 @@ class SpotifyTopPlaylistsServiceTest {
         Song("Artist Anchor", "Anchor Song", 1_690_000_000),
         Song("Artist Anchor", "Anchor Song", 1_690_100_000),
         Song("Artist Surge", "Surge Song", 1_690_200_000),
+        Song("Artist Sad", "Sad Song", 1_697_067_900),
       )
     every { lastFmService.artistSimilar(any(), any()) } returns
       listOf(LastFmSimilarArtist("Artist Fresh", 0.7))
@@ -369,6 +385,8 @@ class SpotifyTopPlaylistsServiceTest {
             when (song.title) {
               "Anchor Song" -> "anchor-track"
               "Surge Song" -> "surge-track"
+              "Happy Song" -> "happy-track"
+              "Sad Song" -> "sad-track"
               "Night Song" -> "night-track"
               "Outer Edge" -> "frontier-track"
               "Fresh Cut" -> "fresh-track"
@@ -386,16 +404,18 @@ class SpotifyTopPlaylistsServiceTest {
 
     val result = service.updatePrivateMoodTaxonomyPlaylists("cid", "login")
 
-    assertEquals(4, result.playlists.size)
+    assertEquals(6, result.playlists.size)
     assertEquals(
-      listOf("Anchor", "Surge", "Night Drift", "Frontier"),
+      listOf("Anchor", "Happy", "Sad", "Surge", "Night Drift", "Frontier"),
       result.playlists.map { it.label },
     )
     assertTrue(result.playlists.all { it.playlistId.isNotBlank() })
-    verify(exactly = 4) {
+    assertTrue(result.playlists.associateBy { it.label }.getValue("Happy").trackCount > 0)
+    assertTrue(result.playlists.associateBy { it.label }.getValue("Sad").trackCount > 0)
+    verify(exactly = 6) {
       playlistService.createPlaylist(match { it.startsWith("Private Mood -") }, "cid", false)
     }
-    verify(exactly = 4) { playlistService.modifyPlaylist(any(), any(), "cid") }
+    verify(exactly = 6) { playlistService.modifyPlaylist(any(), any(), "cid") }
   }
 
   @Test


### PR DESCRIPTION
## What changed
- add explicit `Happy` and `Sad` private mood playlists alongside the existing private mood taxonomy playlists
- prioritize mood-specific playlist matching before broader buckets so cross-playlist dedupe does not starve `Happy` and `Sad`
- fix the `PRIVATE MOOD TAXONOMY` button styling so it no longer appears greyed out when enabled
- update README and tests for the expanded six-playlist taxonomy

## Why it changed
- users asked for clearer mood buckets like happy and sad rather than only the broader taxonomy buckets
- the UI suggested the private mood action was disabled even when it was available
- matching priority needed to preserve distinct tracks for the new mood playlists under aggressive dedupe

## Validation performed
- `./gradlew ktfmtFormat`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test jacocoTestCoverageVerification`

## Known limitations / follow-up work
- `Happy` and `Sad` remain deterministic heuristics based on listening patterns; they do not infer lyrical sentiment or use any ML or audio analysis
- sparse listening histories can still produce small playlists if there are not enough unique candidates after dedupe
