### PR TITLE
Reduce private mood taxonomy memory pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ Recommended runtime inputs:
 - `SPOTIFY_TOP_PLAYLISTS_REFRESH_ON_STARTUP`
 - `SPOTIFY_TOP_PLAYLISTS_REFRESH_INTERVAL_MS`
 - `SPOTIFY_TOP_PLAYLISTS_REFRESH_TRIGGER_TOKEN`
+- `LASTFM_JOBS_MAX_PARALLELISM`
+- `LASTFM_RECENT_TRACKS_MAX_PARALLELISM`
+- `LASTFM_RECENT_TRACKS_PERSISTENT_CACHE_ENABLED`
+
+For Cloud Run, the Last.fm job fan-out defaults are intentionally conservative:
+
+- `LASTFM_JOBS_MAX_PARALLELISM=4`
+- `LASTFM_RECENT_TRACKS_MAX_PARALLELISM=4`
+- `LASTFM_RECENT_TRACKS_PERSISTENT_CACHE_ENABLED=false`
+
+The recent-tracks Firestore cache is disabled by default to avoid large document
+reads during full-history scans such as Private Mood Taxonomy. The app still
+keeps an in-memory cache per instance.
 
 Cloud Scheduler should invoke `POST /refreshConfiguredTopPlaylists` with
 `X-Refresh-Token` set to the configured trigger token. Keep the existing startup

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -37,16 +37,20 @@ class LastFmService(
   private val lastFmAuthService: LastFmAuthenticationService,
   private val lastFmRecentTracksCacheStore: LastFmRecentTracksCacheStore,
   private val clock: Clock,
-  @Value("\${lastfm.recent-tracks.max-parallelism:16}")
+  @Value("\${lastfm.recent-tracks.max-parallelism:4}")
   configuredRecentTracksParallelism: Int = DEFAULT_RECENT_TRACKS_MAX_PARALLELISM,
   @Value("\${lastfm.recent-tracks.cache-ttl:PT168H}")
   configuredCacheTtl: Duration = DEFAULT_CACHE_TTL,
+  @Value("\${lastfm.recent-tracks.persistent-cache.enabled:false}")
+  configuredPersistentRecentTracksCacheEnabled: Boolean =
+    DEFAULT_PERSISTENT_RECENT_TRACKS_CACHE_ENABLED,
 ) {
 
   internal var rest = RestTemplate()
   internal var sleeper: LastFmSleeper = LastFmSleeper { millis -> Thread.sleep(millis) }
   internal var recentTracksParallelism = configuredRecentTracksParallelism.coerceAtLeast(1)
   internal var cacheTtl = configuredCacheTtl
+  internal var persistentRecentTracksCacheEnabled = configuredPersistentRecentTracksCacheEnabled
 
   private val logger = LoggerFactory.getLogger(LastFmService::class.java)
   private val mapper = jacksonObjectMapper()
@@ -451,8 +455,16 @@ class LastFmService(
         updatedAt = now,
         expiresAt = now.plus(cacheTtl),
       )
-    lastFmRecentTracksCacheStore.save(entry)
     recentTracksCache.put(cacheKey, entry)
+    if (!persistentRecentTracksCacheEnabled) {
+      return
+    }
+
+    try {
+      lastFmRecentTracksCacheStore.save(entry)
+    } catch (ex: Exception) {
+      logger.warn("Failed to persist Last.fm recent-tracks cache {}", cacheKey, ex)
+    }
   }
 
   private fun findFreshRecentTracksPage(
@@ -468,7 +480,17 @@ class LastFmService(
         }
     }
 
-    val storedEntry = lastFmRecentTracksCacheStore.findByKey(cacheKey) ?: return null
+    if (!persistentRecentTracksCacheEnabled) {
+      return null
+    }
+
+    val storedEntry =
+      try {
+        lastFmRecentTracksCacheStore.findByKey(cacheKey)
+      } catch (ex: Exception) {
+        logger.warn("Failed to load cached Last.fm recent-tracks page {}", cacheKey, ex)
+        null
+      } ?: return null
     if (!storedEntry.isFresh(now)) {
       return null
     }
@@ -529,8 +551,9 @@ class LastFmService(
   companion object {
     internal const val LASTFM_FETCH_ATTEMPTS = 3
     internal const val LASTFM_RETRY_DELAY_MS = 250L
-    internal const val DEFAULT_RECENT_TRACKS_MAX_PARALLELISM = 16
+    internal const val DEFAULT_RECENT_TRACKS_MAX_PARALLELISM = 4
     internal val DEFAULT_CACHE_TTL: Duration = Duration.ofDays(7)
+    internal const val DEFAULT_PERSISTENT_RECENT_TRACKS_CACHE_ENABLED = false
     private const val AUTHENTICATION_REQUIRED_CODE = 17
     private const val TRANSIENT_BACKEND_ERROR_CODE = 8
     private const val RECENT_TRACKS_PAGE_SIZE = 200

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -59,7 +59,7 @@ class SpotifyTopPlaylistsService(
   var spotifyTopTrackService: SpotifyTopTrackService,
   var lastFmService: LastFmService,
   var spotifySearchService: SpotifySearchService,
-  @Value("\${lastfm.jobs.max-parallelism:16}")
+  @Value("\${lastfm.jobs.max-parallelism:4}")
   configuredYearlyParallelism: Int = DEFAULT_YEARLY_PARALLELISM,
 ) {
 
@@ -1096,7 +1096,7 @@ class SpotifyTopPlaylistsService(
   }
 
   companion object {
-    internal const val DEFAULT_YEARLY_PARALLELISM = 16
+    internal const val DEFAULT_YEARLY_PARALLELISM = 4
     private const val FIRST_SUPPORTED_YEAR = 2005
     private const val FORGOTTEN_OBSESSIONS_PLAYLIST_NAME = "Forgotten Obsessions"
     private const val FORGOTTEN_OBSESSIONS_MIN_PLAY_COUNT = 5

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Song
 import com.lis.spotify.persistence.InMemoryLastFmRecentTracksCacheStore
+import com.lis.spotify.persistence.LastFmRecentTracksCacheStore
 import com.lis.spotify.persistence.StoredLastFmRecentTracksPage
 import io.mockk.every
 import io.mockk.mockk
@@ -93,7 +94,7 @@ class LastFmServiceTest {
   fun yearlyChartlistUsesPersistentCacheAcrossServiceInstances() {
     val store = InMemoryLastFmRecentTracksCacheStore()
     val rest = mockk<RestTemplate>()
-    val firstService = service(store = store)
+    val firstService = service(store = store, persistentRecentTracksCacheEnabled = true)
     firstService.rest = rest
     every { rest.getForObject(any<URI>(), Map::class.java) } returns
       recentTracksPage(1, Song("A", "T1"))
@@ -101,7 +102,7 @@ class LastFmServiceTest {
     val firstSongs = firstService.yearlyChartlist("cid", 2020, "login")
 
     val secondRest = mockk<RestTemplate>(relaxed = true)
-    val secondService = service(store = store)
+    val secondService = service(store = store, persistentRecentTracksCacheEnabled = true)
     secondService.rest = secondRest
     val cachedSongs = secondService.yearlyChartlist("cid", 2020, "login")
 
@@ -111,6 +112,28 @@ class LastFmServiceTest {
     )
     verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
     verify(exactly = 0) { secondRest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
+  fun yearlyChartlistSkipsPersistentCacheAcrossServiceInstancesWhenDisabled() {
+    val store = InMemoryLastFmRecentTracksCacheStore()
+    val firstRest = mockk<RestTemplate>()
+    val secondRest = mockk<RestTemplate>()
+    val firstService = service(store = store)
+    val secondService = service(store = store)
+    firstService.rest = firstRest
+    secondService.rest = secondRest
+    every { firstRest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+    every { secondRest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+
+    val firstSongs = firstService.yearlyChartlist("cid", 2020, "login")
+    val secondSongs = secondService.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(firstSongs, secondSongs)
+    verify(exactly = 1) { firstRest.getForObject(any<URI>(), Map::class.java) }
+    verify(exactly = 1) { secondRest.getForObject(any<URI>(), Map::class.java) }
   }
 
   @Test
@@ -129,7 +152,12 @@ class LastFmServiceTest {
         expiresAt = Instant.parse("2026-04-15T10:00:00Z"),
       )
     )
-    val service = service(store = store, clock = fixedClock("2026-04-08T10:00:00Z"))
+    val service =
+      service(
+        store = store,
+        clock = fixedClock("2026-04-08T10:00:00Z"),
+        persistentRecentTracksCacheEnabled = true,
+      )
 
     val songs = service.yearlyChartlist("cid", 2020, "login")
 
@@ -140,7 +168,12 @@ class LastFmServiceTest {
   fun yearlyChartlistRefreshesExpiredPersistentCache() {
     val store = InMemoryLastFmRecentTracksCacheStore()
     val rest = mockk<RestTemplate>()
-    val firstService = service(store = store, clock = fixedClock("2026-04-08T10:00:00Z"))
+    val firstService =
+      service(
+        store = store,
+        clock = fixedClock("2026-04-08T10:00:00Z"),
+        persistentRecentTracksCacheEnabled = true,
+      )
     firstService.rest = rest
     every { rest.getForObject(any<URI>(), Map::class.java) } returns
       recentTracksPage(1, Song("A", "T1"))
@@ -150,7 +183,12 @@ class LastFmServiceTest {
     val expiredRest = mockk<RestTemplate>()
     every { expiredRest.getForObject(any<URI>(), Map::class.java) } returns
       recentTracksPage(1, Song("A", "T1"))
-    val secondService = service(store = store, clock = fixedClock("2026-04-16T10:00:01Z"))
+    val secondService =
+      service(
+        store = store,
+        clock = fixedClock("2026-04-16T10:00:01Z"),
+        persistentRecentTracksCacheEnabled = true,
+      )
     secondService.rest = expiredRest
 
     secondService.yearlyChartlist("cid", 2020, "login")
@@ -200,6 +238,23 @@ class LastFmServiceTest {
     }
 
     assertEquals(2, maxActiveRequests.get())
+  }
+
+  @Test
+  fun yearlyChartlistFallsBackToNetworkWhenPersistentCacheReadFails() {
+    val store = mockk<LastFmRecentTracksCacheStore>()
+    val rest = mockk<RestTemplate>()
+    val service = service(store = store, persistentRecentTracksCacheEnabled = true)
+    service.rest = rest
+    every { store.findByKey(any()) } throws IllegalStateException("boom")
+    every { store.save(any()) } answers { firstArg() }
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      recentTracksPage(1, Song("A", "T1"))
+
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(listOf(Song("A", "T1")), songs)
+    verify(exactly = 1) { rest.getForObject(any<URI>(), Map::class.java) }
   }
 
   @Test
@@ -451,10 +506,12 @@ class LastFmServiceTest {
 
   private fun service(
     auth: LastFmAuthenticationService = mockk(relaxed = true),
-    store: InMemoryLastFmRecentTracksCacheStore = InMemoryLastFmRecentTracksCacheStore(),
+    store: LastFmRecentTracksCacheStore = InMemoryLastFmRecentTracksCacheStore(),
     clock: Clock = fixedClock(),
     recentTracksParallelism: Int = LastFmService.DEFAULT_RECENT_TRACKS_MAX_PARALLELISM,
     cacheTtl: Duration = LastFmService.DEFAULT_CACHE_TTL,
+    persistentRecentTracksCacheEnabled: Boolean =
+      LastFmService.DEFAULT_PERSISTENT_RECENT_TRACKS_CACHE_ENABLED,
   ): LastFmService {
     return LastFmService(
       lastFmAuthService = auth,
@@ -462,6 +519,7 @@ class LastFmServiceTest {
       clock = clock,
       configuredRecentTracksParallelism = recentTracksParallelism,
       configuredCacheTtl = cacheTtl,
+      configuredPersistentRecentTracksCacheEnabled = persistentRecentTracksCacheEnabled,
     )
   }
 


### PR DESCRIPTION
## What changed
- disable the Firestore-backed Last.fm recent-tracks cache by default and keep using the existing in-memory cache per instance
- make recent-tracks cache read and write failures fail open so Last.fm fetches continue instead of aborting the job
- reduce Last.fm history scan fan-out defaults from `16` to `4` for both yearly jobs and per-year recent-track paging
- add unit tests for the new default-disabled cache behavior and the persistent-cache fallback path
- document the new runtime knobs in the README

## Why it changed
- Cloud Run logs showed `POST /jobs/private-mood-taxonomy` failing with `java.lang.OutOfMemoryError: Java heap space`
- the stack trace pointed at Firestore deserialization of cached Last.fm recent-track pages during the full-history private mood scan
- the service was also configured with very aggressive default parallelism for a `512Mi` Cloud Run instance

## Validation performed
- `./gradlew ktfmtFormat`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test jacocoTestCoverageVerification`
- reran `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew test jacocoTestCoverageVerification` after rebasing onto `origin/main`

## Known limitations / follow-up work
- existing oversized or corrupted documents in `lastFmRecentTracksCache` are no longer read by default, but they are also not cleaned up by this change
- if persistent Firestore caching is re-enabled later, the same path should be load-tested before using it on Cloud Run again
