### PR TITLE
Add free Gemini lyric mood scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ credentials are available at runtime:
 - `SPOTIFY_CLIENT_SECRET` – Spotify application client secret
 - `LASTFM_API_KEY` – Last.fm API key
 - `LASTFM_API_SECRET` – Last.fm API secret
+- `LYRICS_MOOD_PROVIDER` – Optional lyric mood classifier (`auto`, `heuristic`, or `gemini`)
+- `LYRICS_MOOD_GEMINI_API_KEY` – Optional Gemini API key for free-tier lyric mood scoring
 - Last.fm endpoints default to HTTPS. Override `LASTFM_API_URL` and
   `LASTFM_AUTHORIZE_URL` only if custom values are required.
 
@@ -218,12 +220,15 @@ song lyrics fetched from LRCLIB:
 - `Private Mood - Frontier`
 
 The app uses listening history, Spotify top tracks, Last.fm similar
-tracks/artists, and lyric keyword scoring from LRCLIB. It does not use Last.fm
-tags, Spotify recommendations, audio features, audio analysis, or any trained
-model. The lyric lookup is best-effort: if lyrics are unavailable for a song,
-the existing listening heuristics remain as the fallback. The UI reuses the
-background job polling flow and shows the resulting playlists as embedded
-Spotify iframes.
+tracks/artists, and lyric scoring from LRCLIB. By default it uses the built-in
+keyword heuristic. If `LYRICS_MOOD_PROVIDER=gemini` or
+`LYRICS_MOOD_PROVIDER=auto` with `LYRICS_MOOD_GEMINI_API_KEY` set, it batches
+lyric classifications through Gemini `gemini-2.5-flash-lite`, which has a free
+API tier suitable for prototyping. The lyric lookup and Gemini call are both
+best-effort: if lyrics are unavailable or Gemini does not return a usable
+classification, the existing heuristic scorer remains the fallback. The UI
+reuses the background job polling flow and shows the resulting playlists as
+embedded Spotify iframes.
 
 The underlying API accepts an optional playlist size when starting the job:
 

--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -1,5 +1,6 @@
 package com.lis.spotify.service
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import com.lis.spotify.domain.Song
@@ -13,7 +14,10 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.ResourceAccessException
@@ -26,14 +30,31 @@ class LyricsService(
   configuredBaseUrl: String = DEFAULT_BASE_URL,
   @Value("\${lyrics.fetch.max-parallelism:8}")
   configuredFetchParallelism: Int = DEFAULT_FETCH_PARALLELISM,
+  @Value("\${lyrics.mood.provider:auto}") configuredMoodProvider: String = DEFAULT_MOOD_PROVIDER,
+  @Value("\${lyrics.mood.gemini.api-key:}") configuredGeminiApiKey: String = "",
+  @Value("\${lyrics.mood.gemini.base-url:https://generativelanguage.googleapis.com}")
+  configuredGeminiBaseUrl: String = DEFAULT_GEMINI_BASE_URL,
+  @Value("\${lyrics.mood.gemini.model:gemini-2.5-flash-lite}")
+  configuredGeminiModel: String = DEFAULT_GEMINI_MODEL,
+  @Value("\${lyrics.mood.gemini.batch-size:8}")
+  configuredGeminiBatchSize: Int = DEFAULT_GEMINI_BATCH_SIZE,
 ) {
   internal var rest = RestTemplate()
+  internal var mapper = jacksonObjectMapper()
   internal var baseUrl = configuredBaseUrl.trimEnd('/')
   internal var fetchParallelism = configuredFetchParallelism.coerceAtLeast(1)
+  internal var moodProvider = configuredMoodProvider.trim().lowercase()
+  internal var geminiApiKey = configuredGeminiApiKey.trim()
+  internal var geminiBaseUrl = configuredGeminiBaseUrl.trimEnd('/')
+  internal var geminiModel = configuredGeminiModel.trim().ifBlank { DEFAULT_GEMINI_MODEL }
+  internal var geminiBatchSize = configuredGeminiBatchSize.coerceIn(1, MAX_GEMINI_BATCH_SIZE)
 
   private val logger = LoggerFactory.getLogger(LyricsService::class.java)
   private val lyricsCache: Cache<Pair<String, String>, LyricsLookupResult> =
     CacheBuilder.newBuilder().expireAfterWrite(12, TimeUnit.HOURS).build()
+  private val moodProfileCache:
+    Cache<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> =
+    CacheBuilder.newBuilder().expireAfterWrite(7, TimeUnit.DAYS).build()
 
   fun fetchLyrics(song: Song): String? {
     val key = song.normalizedKey()
@@ -88,6 +109,54 @@ class LyricsService(
     }
   }
 
+  internal fun buildPrivateMoodLyricsProfiles(
+    songs: Collection<Song>,
+    heuristicAnalyzer: (String) -> SpotifyTopPlaylistsService.PrivateMoodLyricsProfile,
+  ): Map<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> {
+    val uniqueSongs = songs.distinctBy { it.normalizedKey() }
+    if (uniqueSongs.isEmpty()) {
+      return emptyMap()
+    }
+
+    val profiles =
+      LinkedHashMap<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile>()
+    val songsNeedingAnalysis = mutableListOf<Song>()
+
+    uniqueSongs.forEach { song ->
+      val key = song.normalizedKey()
+      val cachedProfile = moodProfileCache.getIfPresent(key)
+      if (cachedProfile != null) {
+        profiles[key] = cachedProfile
+      } else {
+        songsNeedingAnalysis += song
+      }
+    }
+
+    if (songsNeedingAnalysis.isEmpty()) {
+      return profiles.filterValues { it.coverageScore > 0.0 }
+    }
+
+    val lyricsByKey = fetchLyrics(songsNeedingAnalysis)
+    val geminiProfiles =
+      if (shouldUseGeminiMoodScoring() && lyricsByKey.isNotEmpty()) {
+        classifyPrivateMoodLyricsWithGemini(lyricsByKey)
+      } else {
+        emptyMap()
+      }
+
+    songsNeedingAnalysis.forEach { song ->
+      val key = song.normalizedKey()
+      val profile =
+        geminiProfiles[key]
+          ?: lyricsByKey[key]?.let(heuristicAnalyzer)
+          ?: SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
+      moodProfileCache.put(key, profile)
+      profiles[key] = profile
+    }
+
+    return profiles.filterValues { it.coverageScore > 0.0 }
+  }
+
   private fun buildLyricsUri(song: Song): URI {
     return UriComponentsBuilder.fromUriString(baseUrl)
       .path("/get")
@@ -95,6 +164,161 @@ class LyricsService(
       .queryParam("track_name", song.title.trim())
       .build()
       .toUri()
+  }
+
+  private fun shouldUseGeminiMoodScoring(): Boolean {
+    return when (moodProvider) {
+      "",
+      DEFAULT_MOOD_PROVIDER -> geminiApiKey.isNotBlank()
+      GEMINI_MOOD_PROVIDER -> {
+        if (geminiApiKey.isBlank()) {
+          logger.warn("lyrics.mood.provider is gemini but lyrics.mood.gemini.api-key is missing")
+          false
+        } else {
+          true
+        }
+      }
+      HEURISTIC_MOOD_PROVIDER -> false
+      else -> {
+        logger.warn(
+          "Unknown lyrics mood provider '{}'; falling back to automatic provider selection",
+          moodProvider,
+        )
+        geminiApiKey.isNotBlank()
+      }
+    }
+  }
+
+  private fun classifyPrivateMoodLyricsWithGemini(
+    lyricsByKey: Map<Pair<String, String>, String>
+  ): Map<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> {
+    val entries =
+      lyricsByKey.entries.mapIndexed { index, (key, lyrics) ->
+        GeminiMoodRequestSong(id = "song-$index", key = key, lyrics = lyrics)
+      }
+
+    return entries
+      .chunked(geminiBatchSize)
+      .flatMap { batch ->
+        try {
+          classifyGeminiBatch(batch).entries
+        } catch (ex: HttpStatusCodeException) {
+          logger.warn("Gemini lyric mood classification failed with status {}", ex.statusCode, ex)
+          emptyList()
+        } catch (ex: ResourceAccessException) {
+          logger.warn("Gemini lyric mood classification network failure", ex)
+          emptyList()
+        } catch (ex: Exception) {
+          logger.warn("Unexpected Gemini lyric mood classification failure", ex)
+          emptyList()
+        }
+      }
+      .associate { it.toPair() }
+  }
+
+  private fun classifyGeminiBatch(
+    entries: List<GeminiMoodRequestSong>
+  ): Map<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> {
+    if (entries.isEmpty()) {
+      return emptyMap()
+    }
+
+    val headers =
+      HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_JSON
+        set("x-goog-api-key", geminiApiKey)
+      }
+    val request = HttpEntity(buildGeminiRequest(entries), headers)
+    val response =
+      rest.postForObject(buildGeminiUri(), request, Map::class.java) ?: return emptyMap()
+    val responseText = extractGeminiResponseText(response) ?: return emptyMap()
+    return parseGeminiMoodProfiles(entries, responseText)
+  }
+
+  private fun buildGeminiUri(): URI {
+    return UriComponentsBuilder.fromUriString(geminiBaseUrl)
+      .path("/v1beta/models/$geminiModel:generateContent")
+      .build()
+      .toUri()
+  }
+
+  private fun buildGeminiRequest(entries: List<GeminiMoodRequestSong>): Map<String, Any> {
+    val songsJson =
+      mapper.writeValueAsString(
+        entries.map {
+          mapOf(
+            "id" to it.id,
+            "artist" to it.key.first,
+            "title" to it.key.second,
+            "lyrics" to it.lyrics,
+          )
+        }
+      )
+
+    return mapOf(
+      "systemInstruction" to mapOf("parts" to listOf(mapOf("text" to GEMINI_SYSTEM_PROMPT))),
+      "contents" to
+        listOf(
+          mapOf(
+            "parts" to
+              listOf(
+                mapOf(
+                  "text" to "Assess the following song lyrics and return JSON only.\n$songsJson"
+                )
+              )
+          )
+        ),
+      "generationConfig" to
+        mapOf(
+          "temperature" to 0,
+          "responseMimeType" to "application/json",
+          "responseSchema" to GEMINI_RESPONSE_SCHEMA,
+        ),
+    )
+  }
+
+  private fun extractGeminiResponseText(response: Map<*, *>): String? {
+    val candidates = response["candidates"] as? List<*> ?: return null
+    val firstCandidate = candidates.firstOrNull() as? Map<*, *> ?: return null
+    val content = firstCandidate["content"] as? Map<*, *> ?: return null
+    val parts = content["parts"] as? List<*> ?: return null
+    val firstPart = parts.firstOrNull() as? Map<*, *> ?: return null
+    return (firstPart["text"] as? String)?.trim()?.ifBlank { null }
+  }
+
+  private fun parseGeminiMoodProfiles(
+    entries: List<GeminiMoodRequestSong>,
+    responseText: String,
+  ): Map<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> {
+    val parsed = mapper.readValue(responseText, Map::class.java)
+    val assessments = parsed["assessments"] as? List<*> ?: return emptyMap()
+    val keysById = entries.associate { it.id to it.key }
+    return assessments
+      .mapNotNull { rawAssessment ->
+        val assessment = rawAssessment as? Map<*, *> ?: return@mapNotNull null
+        val id = (assessment["id"] as? String)?.trim().orEmpty()
+        val key = keysById[id] ?: return@mapNotNull null
+        key to
+          SpotifyTopPlaylistsService.PrivateMoodLyricsProfile(
+            happyScore = assessment.numberValue("happyScore"),
+            sadScore = assessment.numberValue("sadScore"),
+            surgeScore = assessment.numberValue("surgeScore"),
+            nightDriftScore = assessment.numberValue("nightDriftScore"),
+            anchorScore = assessment.numberValue("anchorScore"),
+            frontierScore = assessment.numberValue("frontierScore"),
+            coverageScore = assessment.numberValue("coverageScore"),
+            tokenCount = assessment.intValue("tokenCount"),
+          )
+      }
+      .toMap(LinkedHashMap())
+  }
+
+  private fun Map<*, *>.numberValue(key: String): Double {
+    return ((this[key] as? Number)?.toDouble() ?: 0.0).coerceAtLeast(0.0)
+  }
+
+  private fun Map<*, *>.intValue(key: String): Int {
+    return ((this[key] as? Number)?.toInt() ?: 0).coerceAtLeast(0)
   }
 
   private fun parseLyrics(payload: Any?): String? {
@@ -132,9 +356,74 @@ class LyricsService(
 
   companion object {
     internal const val DEFAULT_FETCH_PARALLELISM = 8
+    internal const val DEFAULT_MOOD_PROVIDER = "auto"
+    internal const val DEFAULT_GEMINI_BATCH_SIZE = 8
     private const val DEFAULT_BASE_URL = "https://lrclib.net/api"
+    private const val DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
+    private const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"
+    private const val GEMINI_MOOD_PROVIDER = "gemini"
+    private const val HEURISTIC_MOOD_PROVIDER = "heuristic"
+    private const val MAX_GEMINI_BATCH_SIZE = 16
     private val SYNCED_LYRIC_TIMESTAMP_REGEX = Regex("^\\[[^\\]]+]\\s*")
+    private val GEMINI_RESPONSE_SCHEMA =
+      mapOf(
+        "type" to "object",
+        "properties" to
+          mapOf(
+            "assessments" to
+              mapOf(
+                "type" to "array",
+                "items" to
+                  mapOf(
+                    "type" to "object",
+                    "properties" to
+                      mapOf(
+                        "id" to mapOf("type" to "string"),
+                        "anchorScore" to mapOf("type" to "number"),
+                        "happyScore" to mapOf("type" to "number"),
+                        "sadScore" to mapOf("type" to "number"),
+                        "surgeScore" to mapOf("type" to "number"),
+                        "nightDriftScore" to mapOf("type" to "number"),
+                        "frontierScore" to mapOf("type" to "number"),
+                        "coverageScore" to mapOf("type" to "number"),
+                        "tokenCount" to mapOf("type" to "integer"),
+                      ),
+                    "required" to
+                      listOf(
+                        "id",
+                        "anchorScore",
+                        "happyScore",
+                        "sadScore",
+                        "surgeScore",
+                        "nightDriftScore",
+                        "frontierScore",
+                        "coverageScore",
+                        "tokenCount",
+                      ),
+                  ),
+              )
+          ),
+        "required" to listOf("assessments"),
+      )
+    private const val GEMINI_SYSTEM_PROMPT =
+      "You classify song lyrics into six internal playlist moods. " +
+        "Use only the provided lyrics. Return JSON only that matches the schema. " +
+        "Scores must be non-negative numbers from 0 to 10, where higher means a stronger fit. " +
+        "coverageScore measures how much lyrical evidence exists and should be 0 when the lyrics are too sparse or repetitive to judge. " +
+        "tokenCount is the approximate number of lyric tokens used. " +
+        "Anchor means comfort, grounding, home, reassurance, devotion, healing, and stability. " +
+        "Happy means joy, lightness, celebration, playfulness, sunshine, and dancing. " +
+        "Sad means heartbreak, grief, longing, loneliness, regret, tears, and darkness. " +
+        "Surge means adrenaline, momentum, confidence, movement, defiance, and intensity. " +
+        "Night Drift means nocturnal, hazy, intimate, dreamy, after-hours, insomnia, and reflective darkness. " +
+        "Frontier means escape, horizons, wandering, reinvention, exploration, and the unknown."
   }
 
   private data class LyricsLookupResult(val lyrics: String?)
+
+  private data class GeminiMoodRequestSong(
+    val id: String,
+    val key: Pair<String, String>,
+    val lyrics: String,
+  )
 }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -879,10 +879,9 @@ class SpotifyTopPlaylistsService(
   private fun buildPrivateMoodLyricsProfiles(
     candidates: Collection<PrivateMoodCandidateSong>
   ): Map<Pair<String, String>, PrivateMoodLyricsProfile> {
-    return lyricsService
-      .fetchLyrics(candidates.map { it.song })
-      .mapValues { (_, lyrics) -> analyzePrivateMoodLyrics(lyrics) }
-      .filterValues { it.coverageScore > 0.0 }
+    return lyricsService.buildPrivateMoodLyricsProfiles(candidates.map { it.song }) { lyrics ->
+      analyzePrivateMoodLyrics(lyrics)
+    }
   }
 
   internal fun analyzePrivateMoodLyrics(lyrics: String): PrivateMoodLyricsProfile {

--- a/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
@@ -7,10 +7,13 @@ import io.mockk.verify
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 
 class LyricsServiceTest {
@@ -59,5 +62,112 @@ class LyricsServiceTest {
     val lyrics = service.fetchLyrics(Song("Artist A", "Missing Song"))
 
     assertNull(lyrics)
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesUsesGeminiAndFallsBackForMissingAssessments() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    var request: HttpEntity<*>? = null
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "gemini"
+    service.geminiApiKey = "test-key"
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        val uri = firstArg<URI>().toString()
+        when {
+          uri.contains("artist_name=Artist+A") || uri.contains("artist_name=Artist%20A") ->
+            mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+          uri.contains("artist_name=Artist+B") || uri.contains("artist_name=Artist%20B") ->
+            mapOf("plainLyrics" to "lonely tears in the dark", "instrumental" to false)
+          else -> error("Unexpected lyrics URI $uri")
+        }
+      }
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } answers
+      {
+        request = secondArg<HttpEntity<*>>()
+        mapOf(
+          "candidates" to
+            listOf(
+              mapOf(
+                "content" to
+                  mapOf(
+                    "parts" to
+                      listOf(
+                        mapOf(
+                          "text" to
+                            """
+                            {"assessments":[{"id":"song-0","anchorScore":1,"happyScore":9,"sadScore":0.5,"surgeScore":4,"nightDriftScore":0.5,"frontierScore":1.5,"coverageScore":8,"tokenCount":4}]}
+                            """
+                              .trimIndent()
+                        )
+                      )
+                  )
+              )
+            )
+        )
+      }
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(
+        listOf(Song("Artist A", "Song A"), Song("Artist B", "Song B"))
+      ) { lyrics ->
+        if (lyrics.contains("lonely", ignoreCase = true)) {
+          SpotifyTopPlaylistsService.PrivateMoodLyricsProfile(
+            happyScore = 0.5,
+            sadScore = 8.0,
+            surgeScore = 0.0,
+            nightDriftScore = 3.0,
+            anchorScore = 0.0,
+            frontierScore = 0.0,
+            coverageScore = 6.0,
+            tokenCount = 5,
+          )
+        } else {
+          SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
+        }
+      }
+
+    assertEquals(2, profiles.size)
+    assertEquals(9.0, profiles.getValue("artist a" to "song a").happyScore)
+    assertEquals(8.0, profiles.getValue("artist b" to "song b").sadScore)
+    assertEquals("test-key", request?.headers?.getFirst("x-goog-api-key"))
+    assertTrue(
+      request?.body.toString().contains("responseMimeType=application/json"),
+      "Expected Gemini request to ask for JSON output",
+    )
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesFallsBackWhenGeminiFails() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "gemini"
+    service.geminiApiKey = "test-key"
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } throws
+      ResourceAccessException("offline")
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(listOf(Song("Artist A", "Song A"))) {
+        SpotifyTopPlaylistsService.PrivateMoodLyricsProfile(
+          happyScore = 7.0,
+          sadScore = 0.0,
+          surgeScore = 2.0,
+          nightDriftScore = 0.0,
+          anchorScore = 1.0,
+          frontierScore = 0.0,
+          coverageScore = 5.0,
+          tokenCount = 4,
+        )
+      }
+
+    assertEquals(7.0, profiles.getValue("artist a" to "song a").happyScore)
   }
 }


### PR DESCRIPTION
## What changed
- added an optional Gemini free-tier lyric mood scorer inside `LyricsService`
- batched lyric classification requests with structured JSON output and cached the resulting mood profiles
- kept the existing keyword heuristic as the fallback when Gemini is disabled, unavailable, or returns incomplete results
- documented the new `LYRICS_MOOD_PROVIDER` and `LYRICS_MOOD_GEMINI_API_KEY` settings

## Why it was changed
- mood classification based on lyrics can benefit from a stronger semantic model than keyword matching alone
- Gemini `gemini-2.5-flash-lite` provides a free API tier that can improve lyric mood assessment without adding paid infrastructure by default
- the heuristic path remains in place so the feature still works without an API key and degrades gracefully on API failures

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LyricsServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew jacocoTestCoverageVerification`

## Known limitations / follow-up work
- Gemini scoring is optional and only used when configured through environment or Spring properties
- the app currently sends batched lyrics through the Gemini Developer API, so free-tier requests may still be subject to Google rate limits and free-tier data handling
- the structured output prompt is tuned for the existing playlist buckets rather than a generic music-emotion taxonomy