### PR TITLE
Reduce Last.fm yearly chart memory spikes

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -23,8 +23,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -242,26 +240,54 @@ class LastFmService(
       }
 
       val pagesToFetch = pagesToFetch(firstPage.totalPages, startPage, limit)
-      val pageResults = mutableListOf(startPage to firstPage)
-      if (pagesToFetch.isNotEmpty()) {
-        val semaphore = Semaphore(recentTracksParallelism.coerceAtLeast(1))
-        pageResults += coroutineScope {
-          pagesToFetch
-            .map { page ->
-              async(Dispatchers.IO) {
-                semaphore.withPermit {
+      val songs = mutableListOf<Song>()
+      appendSongsWithinLimit(songs, firstPage.songs, limit)
+      var fetchedPages = 1
+      val pageBatches = pagesToFetch.chunked(recentTracksParallelism.coerceAtLeast(1))
+
+      if (songs.size < limit && pageBatches.isNotEmpty()) {
+        var limitReached = false
+        for ((index, pageBatch) in pageBatches.withIndex()) {
+          val batchResults = coroutineScope {
+            pageBatch
+              .map { page ->
+                async(Dispatchers.IO) {
                   page to fetchRecent(lastFmLogin, from, to, page, sessionKey)
                 }
               }
+              .awaitAll()
+              .sortedBy { it.first }
+          }
+          fetchedPages += batchResults.size
+          for ((_, pageResult) in batchResults) {
+            if (appendSongsWithinLimit(songs, pageResult.songs, limit)) {
+              limitReached = true
+              break
             }
-            .awaitAll()
+          }
+          logger.debug(
+            "yearlyChartlist {} {} completed batch {}/{} ({} pages fetched, {} songs accumulated)",
+            lastFmLogin,
+            year,
+            index + 1,
+            pageBatches.size,
+            fetchedPages,
+            songs.size,
+          )
+          if (limitReached) {
+            break
+          }
         }
       }
 
-      val songs = pageResults.sortedBy { it.first }.flatMap { it.second.songs }
-      val result = if (limit == Int.MAX_VALUE) songs else songs.take(limit)
-      logger.debug("yearlyChartlist {} {} fetched {} pages", lastFmLogin, year, pageResults.size)
-      result
+      logger.debug(
+        "yearlyChartlist {} {} fetched {} pages and returned {} songs",
+        lastFmLogin,
+        year,
+        fetchedPages,
+        songs.size,
+      )
+      songs
     }
   }
 
@@ -578,6 +604,28 @@ class LastFmService(
       return emptyList()
     }
     return (startPage + 1..lastPage).toList()
+  }
+
+  private fun appendSongsWithinLimit(
+    accumulatedSongs: MutableList<Song>,
+    songs: List<Song>,
+    limit: Int,
+  ): Boolean {
+    if (songs.isEmpty()) {
+      return limit != Int.MAX_VALUE && accumulatedSongs.size >= limit
+    }
+    if (limit == Int.MAX_VALUE) {
+      accumulatedSongs += songs
+      return false
+    }
+
+    val remaining = (limit - accumulatedSongs.size).coerceAtLeast(0)
+    if (remaining == 0) {
+      return true
+    }
+
+    accumulatedSongs += songs.take(remaining)
+    return accumulatedSongs.size >= limit
   }
 
   private fun saveRecentTracksPage(

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -242,6 +242,38 @@ class LastFmServiceTest {
   }
 
   @Test
+  fun yearlyChartlistPreservesPageOrderAcrossMultipleParallelBatches() {
+    val rest = mockk<RestTemplate>()
+    val service = service(recentTracksParallelism = 2)
+    service.rest = rest
+
+    every { rest.getForObject(any<URI>(), String::class.java) } answers
+      {
+        when (page(firstArg())) {
+          1 -> recentTracksPayload(5, Song("Artist 1", "Track 1"))
+          2 -> recentTracksPayload(5, Song("Artist 2", "Track 2"))
+          3 -> recentTracksPayload(5, Song("Artist 3", "Track 3"))
+          4 -> recentTracksPayload(5, Song("Artist 4", "Track 4"))
+          else -> recentTracksPayload(5, Song("Artist 5", "Track 5"))
+        }
+      }
+
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(
+      listOf(
+        Song("Artist 1", "Track 1"),
+        Song("Artist 2", "Track 2"),
+        Song("Artist 3", "Track 3"),
+        Song("Artist 4", "Track 4"),
+        Song("Artist 5", "Track 5"),
+      ),
+      songs,
+    )
+    verify(exactly = 5) { rest.getForObject(any<URI>(), String::class.java) }
+  }
+
+  @Test
   fun yearlyChartlistFallsBackToNetworkWhenPersistentCacheReadFails() {
     val store = mockk<LastFmRecentTracksCacheStore>()
     val rest = mockk<RestTemplate>()


### PR DESCRIPTION
## What changed
- changed `LastFmService.yearlyChartlist` to append page results incrementally instead of collecting every fetched page and flattening them afterward
- kept the existing parallel fetch behavior, but now process page batches in bounded groups based on `recentTracksParallelism`
- added a regression test that verifies page order stays stable across more than one parallel fetch batch

## Why it was changed
- Cloud Run error logs showed a historical `OutOfMemoryError` in the Last.fm yearly chart fetch path
- the favicon 404 noise was already fixed on current `main`, so the remaining actionable error was reducing peak memory pressure in yearly Last.fm aggregation
- this refactor lowers peak heap usage by avoiding the extra `pageResults` accumulation on top of the final song list

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LastFmServiceTest --tests com.lis.spotify.controller.MainControllerTest`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew jacocoTestCoverageVerification`
- inspected Cloud Run logs and confirmed the current revision had no active warning/error logs; the serious OOM was historical on older revision `spotify-web-api-demo-00127-jvc`

## Known limitations / follow-up work
- the method still returns the full yearly song list, so memory use remains proportional to the returned result size
- if Last.fm returns unexpectedly large single-page payloads, further work may be needed around request sizing or downstream aggregation