### PR TITLE
Handle LRCLIB and OpenAI lyric scoring failures

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -74,40 +74,75 @@ class LyricsService(
       return it.lyrics
     }
 
-    val lyrics =
+    val lookupCandidates = buildLyricsLookupCandidates(song)
+    var lyrics: String? = null
+
+    for ((index, candidate) in lookupCandidates.withIndex()) {
       try {
-        executeWithRetry(
-          maxAttempts = lyricsLookupMaxAttempts,
-          shouldRetry = ::shouldRetryLyricsLookup,
-          onRetry = { attempt, maxAttempts, delayMillis, ex ->
-            logger.info(
-              "Retrying lyrics lookup for {} - {} after transient failure on attempt {}/{} ({}); waiting {} ms",
+        lyrics =
+          executeWithRetry(
+            maxAttempts = lyricsLookupMaxAttempts,
+            shouldRetry = ::shouldRetryLyricsLookup,
+            onRetry = { attempt, maxAttempts, delayMillis, ex ->
+              logger.info(
+                "Retrying lyrics lookup for {} - {} after transient failure on attempt {}/{} ({}); waiting {} ms",
+                song.artist,
+                song.title,
+                attempt,
+                maxAttempts,
+                summarizeRetryableFailure(ex),
+                delayMillis,
+              )
+            },
+          ) {
+            parseLyrics(rest.getForObject(buildLyricsUri(candidate), Map::class.java))
+          }
+      } catch (ex: HttpStatusCodeException) {
+        when (ex.statusCode) {
+          HttpStatus.NOT_FOUND -> {
+            logger.debug(
+              "Lyrics not found for {} - {} on lookup attempt {}/{}",
               song.artist,
               song.title,
-              attempt,
-              maxAttempts,
-              summarizeRetryableFailure(ex),
-              delayMillis,
+              index + 1,
+              lookupCandidates.size,
             )
-          },
-        ) {
-          parseLyrics(rest.getForObject(buildLyricsUri(song), Map::class.java))
-        }
-      } catch (ex: HttpStatusCodeException) {
-        if (ex.statusCode == HttpStatus.NOT_FOUND) {
-          logger.debug("Lyrics not found for {} - {}", song.artist, song.title)
-          null
-        } else {
-          logger.warn("Lyrics lookup failed for {} - {}", song.artist, song.title, ex)
-          null
+            continue
+          }
+          HttpStatus.BAD_REQUEST -> {
+            logger.debug(
+              "Lyrics lookup rejected for {} - {} on attempt {}/{}; trying a simplified query when available",
+              song.artist,
+              song.title,
+              index + 1,
+              lookupCandidates.size,
+            )
+            continue
+          }
+          else -> {
+            logger.warn("Lyrics lookup failed for {} - {}", song.artist, song.title, ex)
+            break
+          }
         }
       } catch (ex: ResourceAccessException) {
         logger.warn("Lyrics lookup network error for {} - {}", song.artist, song.title, ex)
-        null
+        break
       } catch (ex: Exception) {
         logger.warn("Unexpected lyrics lookup failure for {} - {}", song.artist, song.title, ex)
-        null
+        break
       }
+
+      if (lyrics != null) {
+        if (index > 0) {
+          logger.info(
+            "Lyrics lookup succeeded for {} - {} after retrying with a simplified title",
+            song.artist,
+            song.title,
+          )
+        }
+        break
+      }
+    }
 
     lyricsCache.put(key, LyricsLookupResult(lyrics))
     return lyrics
@@ -481,7 +516,7 @@ class LyricsService(
     }
     if (profiles.size != entries.size) {
       logger.warn(
-        "OpenAI lyric mood response returned {} profiles for {} requested songs; missing songs will fall back to heuristics",
+        "OpenAI lyric mood response returned {} profiles for {} requested songs; missing songs will follow the configured fallback path",
         profiles.size,
         entries.size,
       )
@@ -584,6 +619,23 @@ class LyricsService(
     return (currentDelayMillis * 2).coerceAtMost(MAX_RETRY_DELAY_MILLIS)
   }
 
+  private fun buildLyricsLookupCandidates(song: Song): List<Song> {
+    val normalizedTitles =
+      linkedSetOf(song.title.normalizedLookupTitle()).apply {
+        add(song.title.substringBefore(" / ").normalizedLookupTitle())
+        add(song.title.substringBefore('/').normalizedLookupTitle())
+        add(song.title.substringBefore(" - ").normalizedLookupTitle())
+        add(song.title.substringBefore(" – ").normalizedLookupTitle())
+        add(song.title.substringBefore(" — ").normalizedLookupTitle())
+        add(song.title.substringBefore(" (").normalizedLookupTitle())
+        add(song.title.substringBefore(" [").normalizedLookupTitle())
+      }
+
+    return normalizedTitles
+      .filter { it.isNotBlank() }
+      .map { normalizedTitle -> Song(song.artist, normalizedTitle) }
+  }
+
   private fun parseLyrics(payload: Any?): String? {
     val map = payload as? Map<*, *> ?: return null
     if ((map["instrumental"] as? Boolean) == true) {
@@ -615,6 +667,10 @@ class LyricsService(
 
   private fun String.normalizeToken(): String {
     return trim().lowercase().replace("\\s+".toRegex(), " ")
+  }
+
+  private fun String.normalizedLookupTitle(): String {
+    return trim().trim('-', '–', '—', '/', ':', ';').replace("\\s+".toRegex(), " ")
   }
 
   companion object {

--- a/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.verify
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -63,6 +64,35 @@ class LyricsServiceTest {
     val lyrics = service.fetchLyrics(Song("Artist A", "Missing Song"))
 
     assertNull(lyrics)
+  }
+
+  @Test
+  fun fetchLyricsRetriesWithSimplifiedTitleAfterBadRequest() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    val requestedUris = mutableListOf<String>()
+    service.rest = rest
+    val badRequest =
+      HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "", HttpHeaders(), ByteArray(0), null)
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        val uri = firstArg<URI>().toString()
+        requestedUris += uri
+        if (requestedUris.size == 1) {
+          throw badRequest
+        }
+        mapOf("plainLyrics" to "let it go", "instrumental" to false)
+      }
+
+    val lyrics = service.fetchLyrics(Song("Artist A", "Song A - Live / OST"))
+
+    assertEquals("let it go", lyrics)
+    assertEquals(2, requestedUris.size)
+    assertTrue(requestedUris.first().contains("Live"))
+    assertNotEquals(requestedUris.first(), requestedUris.last())
+    assertTrue(requestedUris.last().contains("Live"))
+    assertFalse(requestedUris.last().contains("OST"))
   }
 
   @Test
@@ -347,6 +377,46 @@ class LyricsServiceTest {
           coverageScore = 5.0,
           tokenCount = 4,
         )
+      }
+
+    assertTrue(profiles.isEmpty())
+    verify(exactly = 1) { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) }
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesStopsOpenAiBatchesAfterQuotaFailure() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "openai"
+    service.openAiApiKey = "test-key"
+    service.openAiBatchSize = 1
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val quotaExceeded =
+      HttpClientErrorException.create(
+        HttpStatus.TOO_MANY_REQUESTS,
+        "",
+        HttpHeaders(),
+        """
+        {"error":{"message":"quota exceeded","type":"insufficient_quota","code":"insufficient_quota"}}
+        """
+          .trimIndent()
+          .toByteArray(),
+        null,
+      )
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } throws
+      quotaExceeded
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(
+        listOf(Song("Artist A", "Song A"), Song("Artist B", "Song B"))
+      ) {
+        SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
       }
 
     assertTrue(profiles.isEmpty())


### PR DESCRIPTION
## What changed
- retry LRCLIB lookups with progressively simplified track titles after 400 bad-request responses
- keep the current transient retry behavior from main while making lyric lookups degrade more cleanly when decorated titles are rejected
- update the OpenAI missing-profile warning to reflect the configured fallback path instead of assuming heuristic fallback
- add regression coverage for LRCLIB title simplification and for stopping later OpenAI batches after an insufficient-quota failure

## Why it was changed
- Cloud Run logs showed LRCLIB rejecting some decorated track titles even though simpler queries could succeed
- main already absorbed the broader retry and openai-only provider work, so this PR now carries the remaining title-simplification and quota-abort coverage that still matter on top of that base

## Validation performed
- GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LyricsServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest
- GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew jacocoTestCoverageVerification

## Known limitations or follow-up work
- LRCLIB simplification now handles common decorated titles, but provider-side misses can still leave some songs without lyrics
- openai-only versus auto fallback behavior now comes from main; this PR only updates the warning text to match that behavior