### PR TITLE
Remove unsupported OpenAI temperature override

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -348,7 +348,6 @@ class LyricsService(
               "schema" to OPENAI_RESPONSE_SCHEMA,
             ),
         ),
-      "temperature" to 0,
       "reasoning_effort" to "low",
     )
   }

--- a/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -133,6 +134,7 @@ class LyricsServiceTest {
     val responseFormat = body["response_format"] as Map<*, *>
     val jsonSchema = responseFormat["json_schema"] as Map<*, *>
     assertEquals("gpt-5.4-mini", body["model"])
+    assertFalse(body.containsKey("temperature"))
     assertEquals("json_schema", responseFormat["type"])
     assertEquals("private_mood_lyrics_batch", jsonSchema["name"])
     assertTrue(


### PR DESCRIPTION
## What changed
- removed the explicit `temperature=0` override from the OpenAI chat completions request used for lyric mood scoring
- added a regression assertion to keep the request body free of that field

## Why it was changed
- Cloud Run logs showed OpenAI rejecting the request with `unsupported_value` because the configured model only supports the default temperature value
- omitting the field lets the request use the model default and avoids the 400 error

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LyricsServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew jacocoTestCoverageVerification`

## Known limitations or follow-up work
- this only fixes the unsupported request parameter; separate provider-fallback handling is still tracked elsewhere