### PR TITLE
Retry transient lyric provider failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,13 @@ keyword heuristic. If `LYRICS_MOOD_PROVIDER=openai` or
 `LYRICS_MOOD_PROVIDER=auto` with `LYRICS_MOOD_OPENAI_API_KEY` or
 `OPENAI_API_KEY` set, it batches lyric classifications through OpenAI
 `gpt-5.4-mini` using strict JSON schema output. The lyric lookup and OpenAI
-call are both best-effort: if lyrics are unavailable or the model does not
-return a usable classification, the existing heuristic scorer remains the
-fallback. The UI reuses the background job polling flow and shows the resulting
-playlists as embedded Spotify iframes.
+call both use bounded retries for transient network, rate-limit, and `5xx`
+failures. In `LYRICS_MOOD_PROVIDER=auto`, the existing heuristic scorer remains
+the fallback if lyrics are unavailable or the model does not return a usable
+classification. In `LYRICS_MOOD_PROVIDER=openai`, lyric validation is OpenAI
+only: songs without a successful OpenAI classification remain unscored instead
+of falling back to the heuristic scorer. The UI reuses the background job
+polling flow and shows the resulting playlists as embedded Spotify iframes.
 
 The underlying API accepts an optional playlist size when starting the job:
 

--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -48,6 +48,14 @@ class LyricsService(
   internal var openAiBaseUrl = configuredOpenAiBaseUrl.trimEnd('/')
   internal var openAiModel = configuredOpenAiModel.trim().ifBlank { DEFAULT_OPENAI_MODEL }
   internal var openAiBatchSize = configuredOpenAiBatchSize.coerceIn(1, MAX_OPENAI_BATCH_SIZE)
+  internal var lyricsLookupMaxAttempts = DEFAULT_LYRICS_LOOKUP_MAX_ATTEMPTS
+  internal var openAiRequestMaxAttempts = DEFAULT_OPENAI_REQUEST_MAX_ATTEMPTS
+  internal var retryBaseDelayMillis = DEFAULT_RETRY_BASE_DELAY_MILLIS
+  internal var retrySleeper: (Long) -> Unit = { millis ->
+    if (millis > 0) {
+      Thread.sleep(millis)
+    }
+  }
 
   private val logger = LoggerFactory.getLogger(LyricsService::class.java)
   private val lyricsCache: Cache<Pair<String, String>, LyricsLookupResult> =
@@ -68,7 +76,23 @@ class LyricsService(
 
     val lyrics =
       try {
-        parseLyrics(rest.getForObject(buildLyricsUri(song), Map::class.java))
+        executeWithRetry(
+          maxAttempts = lyricsLookupMaxAttempts,
+          shouldRetry = ::shouldRetryLyricsLookup,
+          onRetry = { attempt, maxAttempts, delayMillis, ex ->
+            logger.info(
+              "Retrying lyrics lookup for {} - {} after transient failure on attempt {}/{} ({}); waiting {} ms",
+              song.artist,
+              song.title,
+              attempt,
+              maxAttempts,
+              summarizeRetryableFailure(ex),
+              delayMillis,
+            )
+          },
+        ) {
+          parseLyrics(rest.getForObject(buildLyricsUri(song), Map::class.java))
+        }
       } catch (ex: HttpStatusCodeException) {
         if (ex.statusCode == HttpStatus.NOT_FOUND) {
           logger.debug("Lyrics not found for {} - {}", song.artist, song.title)
@@ -166,15 +190,21 @@ class LyricsService(
         emptyMap()
       }
 
+    val openAiOnlyMode = moodProvider == OPENAI_MOOD_PROVIDER
     var heuristicFallbackCount = 0
+    var openAiOnlySkippedCount = 0
     songsNeedingAnalysis.forEach { song ->
       val key = song.normalizedKey()
       val profile =
         when {
           openAiProfiles[key] != null -> openAiProfiles.getValue(key)
-          lyricsByKey[key] != null -> {
+          lyricsByKey[key] != null && !openAiOnlyMode -> {
             heuristicFallbackCount += 1
             heuristicAnalyzer(lyricsByKey.getValue(key))
+          }
+          lyricsByKey[key] != null -> {
+            openAiOnlySkippedCount += 1
+            SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
           }
           else -> SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
         }
@@ -183,9 +213,10 @@ class LyricsService(
     }
 
     logger.debug(
-      "Private mood lyric profile build complete: {} OpenAI profiles, {} heuristic fallbacks, {} no-lyrics fallbacks",
+      "Private mood lyric profile build complete: {} OpenAI profiles, {} heuristic fallbacks, {} OpenAI-only skips, {} no-lyrics fallbacks",
       openAiProfiles.size,
       heuristicFallbackCount,
+      openAiOnlySkippedCount,
       missingLyricsCount,
     )
 
@@ -232,6 +263,8 @@ class LyricsService(
         OpenAiMoodRequestSong(id = "song-$index", key = key, lyrics = lyrics)
       }
     val batches = entries.chunked(openAiBatchSize)
+    val profiles =
+      LinkedHashMap<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile>()
 
     logger.info(
       "Submitting OpenAI lyric mood scoring for {} songs across {} batches using model {}",
@@ -240,47 +273,77 @@ class LyricsService(
       openAiModel,
     )
 
-    return batches
-      .flatMapIndexed { index, batch ->
-        try {
-          logger.debug(
-            "Submitting OpenAI lyric mood batch {}/{} with {} songs",
-            index + 1,
-            batches.size,
-            batch.size,
-          )
-          classifyOpenAiBatch(batch).entries
-        } catch (ex: HttpStatusCodeException) {
+    for ((index, batch) in batches.withIndex()) {
+      try {
+        logger.debug(
+          "Submitting OpenAI lyric mood batch {}/{} with {} songs",
+          index + 1,
+          batches.size,
+          batch.size,
+        )
+        profiles.putAll(classifyOpenAiBatchWithRetry(batch, index + 1, batches.size))
+      } catch (ex: HttpStatusCodeException) {
+        if (shouldAbortOpenAiMoodScoring(ex)) {
           logger.warn(
-            "OpenAI lyric mood batch {}/{} failed with status {} for {} songs",
+            "Aborting OpenAI lyric mood scoring after batch {}/{} due to {}. Songs without OpenAI classifications will remain unscored in openai-only mode",
             index + 1,
             batches.size,
-            ex.statusCode,
-            batch.size,
-            ex,
+            summarizeOpenAiError(ex),
           )
-          emptyList()
-        } catch (ex: ResourceAccessException) {
-          logger.warn(
-            "OpenAI lyric mood batch {}/{} network failure for {} songs",
-            index + 1,
-            batches.size,
-            batch.size,
-            ex,
-          )
-          emptyList()
-        } catch (ex: Exception) {
-          logger.warn(
-            "Unexpected OpenAI lyric mood batch {}/{} failure for {} songs",
-            index + 1,
-            batches.size,
-            batch.size,
-            ex,
-          )
-          emptyList()
+          break
         }
+        logger.warn(
+          "OpenAI lyric mood batch {}/{} failed with status {} for {} songs",
+          index + 1,
+          batches.size,
+          ex.statusCode,
+          batch.size,
+          ex,
+        )
+      } catch (ex: ResourceAccessException) {
+        logger.warn(
+          "OpenAI lyric mood batch {}/{} network failure for {} songs",
+          index + 1,
+          batches.size,
+          batch.size,
+          ex,
+        )
+      } catch (ex: Exception) {
+        logger.warn(
+          "Unexpected OpenAI lyric mood batch {}/{} failure for {} songs",
+          index + 1,
+          batches.size,
+          batch.size,
+          ex,
+        )
       }
-      .associate { it.toPair() }
+    }
+
+    return profiles
+  }
+
+  private fun classifyOpenAiBatchWithRetry(
+    entries: List<OpenAiMoodRequestSong>,
+    batchIndex: Int,
+    batchCount: Int,
+  ): Map<Pair<String, String>, SpotifyTopPlaylistsService.PrivateMoodLyricsProfile> {
+    return executeWithRetry(
+      maxAttempts = openAiRequestMaxAttempts,
+      shouldRetry = ::shouldRetryOpenAiRequest,
+      onRetry = { attempt, maxAttempts, delayMillis, ex ->
+        logger.info(
+          "Retrying OpenAI lyric mood batch {}/{} after transient failure on attempt {}/{} ({}); waiting {} ms",
+          batchIndex,
+          batchCount,
+          attempt,
+          maxAttempts,
+          summarizeRetryableFailure(ex),
+          delayMillis,
+        )
+      },
+    ) {
+      classifyOpenAiBatch(entries)
+    }
   }
 
   private fun classifyOpenAiBatch(
@@ -435,6 +498,92 @@ class LyricsService(
     return ((this[key] as? Number)?.toInt() ?: 0).coerceAtLeast(0)
   }
 
+  private fun <T> executeWithRetry(
+    maxAttempts: Int,
+    shouldRetry: (Exception) -> Boolean,
+    onRetry: (attempt: Int, maxAttempts: Int, delayMillis: Long, ex: Exception) -> Unit,
+    block: () -> T,
+  ): T {
+    var attempt = 1
+    var delayMillis = retryBaseDelayMillis.coerceAtLeast(0)
+
+    while (true) {
+      try {
+        return block()
+      } catch (ex: Exception) {
+        if (attempt >= maxAttempts || !shouldRetry(ex)) {
+          throw ex
+        }
+        onRetry(attempt, maxAttempts, delayMillis, ex)
+        retrySleeper(delayMillis)
+        attempt += 1
+        delayMillis = nextRetryDelayMillis(delayMillis)
+      }
+    }
+  }
+
+  private fun shouldRetryLyricsLookup(ex: Exception): Boolean {
+    return ex is ResourceAccessException ||
+      (ex is HttpStatusCodeException &&
+        (ex.statusCode.is5xxServerError ||
+          ex.statusCode == HttpStatus.REQUEST_TIMEOUT ||
+          ex.statusCode == HttpStatus.TOO_MANY_REQUESTS))
+  }
+
+  private fun shouldRetryOpenAiRequest(ex: Exception): Boolean {
+    return ex is ResourceAccessException ||
+      (ex is HttpStatusCodeException &&
+        ((ex.statusCode.is5xxServerError || ex.statusCode == HttpStatus.REQUEST_TIMEOUT) ||
+          (ex.statusCode == HttpStatus.TOO_MANY_REQUESTS && !isInsufficientQuota(ex))))
+  }
+
+  private fun shouldAbortOpenAiMoodScoring(ex: HttpStatusCodeException): Boolean {
+    return ex.statusCode == HttpStatus.UNAUTHORIZED ||
+      ex.statusCode == HttpStatus.FORBIDDEN ||
+      (ex.statusCode == HttpStatus.TOO_MANY_REQUESTS && isInsufficientQuota(ex))
+  }
+
+  private fun isInsufficientQuota(ex: HttpStatusCodeException): Boolean {
+    val error = parseOpenAiError(ex)
+    return error["code"] == "insufficient_quota" || error["type"] == "insufficient_quota"
+  }
+
+  private fun summarizeOpenAiError(ex: HttpStatusCodeException): String {
+    val error = parseOpenAiError(ex)
+    val details =
+      listOfNotNull(error["code"], error["type"], error["message"]).joinToString(" / ").ifBlank {
+        ex.statusCode.toString()
+      }
+    return details
+  }
+
+  private fun parseOpenAiError(ex: HttpStatusCodeException): Map<String, String> {
+    return runCatching {
+        val payload = mapper.readValue(ex.responseBodyAsString, Map::class.java) as? Map<*, *>
+        val error = payload?.get("error") as? Map<*, *>
+        buildMap {
+          (error?.get("code") as? String)?.let { put("code", it) }
+          (error?.get("type") as? String)?.let { put("type", it) }
+          (error?.get("message") as? String)?.let { put("message", it) }
+        }
+      }
+      .getOrDefault(emptyMap())
+  }
+
+  private fun summarizeRetryableFailure(ex: Exception): String {
+    return when (ex) {
+      is HttpStatusCodeException -> ex.statusCode.toString()
+      else -> ex.javaClass.simpleName
+    }
+  }
+
+  private fun nextRetryDelayMillis(currentDelayMillis: Long): Long {
+    if (currentDelayMillis <= 0) {
+      return 0
+    }
+    return (currentDelayMillis * 2).coerceAtMost(MAX_RETRY_DELAY_MILLIS)
+  }
+
   private fun parseLyrics(payload: Any?): String? {
     val map = payload as? Map<*, *> ?: return null
     if ((map["instrumental"] as? Boolean) == true) {
@@ -472,12 +621,16 @@ class LyricsService(
     internal const val DEFAULT_FETCH_PARALLELISM = 8
     internal const val DEFAULT_MOOD_PROVIDER = "auto"
     internal const val DEFAULT_OPENAI_BATCH_SIZE = 8
+    internal const val DEFAULT_LYRICS_LOOKUP_MAX_ATTEMPTS = 3
+    internal const val DEFAULT_OPENAI_REQUEST_MAX_ATTEMPTS = 3
+    internal const val DEFAULT_RETRY_BASE_DELAY_MILLIS = 250L
     private const val DEFAULT_BASE_URL = "https://lrclib.net/api"
     private const val DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
     private const val DEFAULT_OPENAI_MODEL = "gpt-5.4-mini"
     private const val OPENAI_MOOD_PROVIDER = "openai"
     private const val HEURISTIC_MOOD_PROVIDER = "heuristic"
     private const val MAX_OPENAI_BATCH_SIZE = 16
+    private const val MAX_RETRY_DELAY_MILLIS = 2_000L
     private val SYNCED_LYRIC_TIMESTAMP_REGEX = Regex("^\\[[^\\]]+]\\s*")
     private val OPENAI_RESPONSE_SCHEMA =
       mapOf(

--- a/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
@@ -66,13 +66,45 @@ class LyricsServiceTest {
   }
 
   @Test
+  fun fetchLyricsRetriesTransientServerFailure() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val unavailable =
+      HttpClientErrorException.create(
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "",
+        HttpHeaders(),
+        ByteArray(0),
+        null,
+      )
+    var lyricsLookupCalls = 0
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        lyricsLookupCalls += 1
+        if (lyricsLookupCalls == 1) {
+          throw unavailable
+        }
+        mapOf("plainLyrics" to "retry success", "instrumental" to false)
+      }
+
+    val lyrics = service.fetchLyrics(Song("Artist A", "Song A"))
+
+    assertEquals("retry success", lyrics)
+    verify(exactly = 2) { rest.getForObject(any<URI>(), Map::class.java) }
+  }
+
+  @Test
   fun buildPrivateMoodLyricsProfilesUsesOpenAiAndFallsBackForMissingAssessments() {
     val rest = mockk<RestTemplate>()
     val service = LyricsService()
     var request: HttpEntity<*>? = null
     service.rest = rest
     service.fetchParallelism = 1
-    service.moodProvider = "openai"
+    service.moodProvider = "auto"
     service.openAiApiKey = "test-key"
 
     every { rest.getForObject(any<URI>(), Map::class.java) } answers
@@ -149,8 +181,10 @@ class LyricsServiceTest {
     val service = LyricsService()
     service.rest = rest
     service.fetchParallelism = 1
-    service.moodProvider = "openai"
+    service.moodProvider = "auto"
     service.openAiApiKey = "test-key"
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
 
     every { rest.getForObject(any<URI>(), Map::class.java) } returns
       mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
@@ -172,5 +206,150 @@ class LyricsServiceTest {
       }
 
     assertEquals(7.0, profiles.getValue("artist a" to "song a").happyScore)
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesRetriesOpenAiBatchAfterTransientFailure() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "openai"
+    service.openAiApiKey = "test-key"
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val unavailable =
+      HttpClientErrorException.create(
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "",
+        HttpHeaders(),
+        ByteArray(0),
+        null,
+      )
+    var openAiCalls = 0
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } answers
+      {
+        openAiCalls += 1
+        if (openAiCalls == 1) {
+          throw unavailable
+        }
+        mapOf(
+          "choices" to
+            listOf(
+              mapOf(
+                "message" to
+                  mapOf(
+                    "content" to
+                      """
+                      {"assessments":[{"id":"song-0","anchorScore":1,"happyScore":9,"sadScore":0.5,"surgeScore":4,"nightDriftScore":0.5,"frontierScore":1.5,"coverageScore":8,"tokenCount":4}]}
+                      """
+                        .trimIndent()
+                  )
+              )
+            )
+        )
+      }
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(listOf(Song("Artist A", "Song A"))) {
+        SpotifyTopPlaylistsService.PrivateMoodLyricsProfile.empty()
+      }
+
+    assertEquals(1, profiles.size)
+    assertEquals(9.0, profiles.getValue("artist a" to "song a").happyScore)
+    verify(exactly = 2) { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) }
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesDoesNotFallbackWhenProviderIsOpenAiAndOpenAiFails() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "openai"
+    service.openAiApiKey = "test-key"
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val unavailable =
+      HttpClientErrorException.create(
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "",
+        HttpHeaders(),
+        ByteArray(0),
+        null,
+      )
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } throws
+      unavailable
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(listOf(Song("Artist A", "Song A"))) {
+        SpotifyTopPlaylistsService.PrivateMoodLyricsProfile(
+          happyScore = 7.0,
+          sadScore = 0.0,
+          surgeScore = 2.0,
+          nightDriftScore = 0.0,
+          anchorScore = 1.0,
+          frontierScore = 0.0,
+          coverageScore = 5.0,
+          tokenCount = 4,
+        )
+      }
+
+    assertTrue(profiles.isEmpty())
+    verify(exactly = service.openAiRequestMaxAttempts) {
+      rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java)
+    }
+  }
+
+  @Test
+  fun buildPrivateMoodLyricsProfilesDoesNotRetryOpenAiQuotaFailure() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.fetchParallelism = 1
+    service.moodProvider = "openai"
+    service.openAiApiKey = "test-key"
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val quotaExceeded =
+      HttpClientErrorException.create(
+        HttpStatus.TOO_MANY_REQUESTS,
+        "",
+        HttpHeaders(),
+        """
+        {"error":{"message":"quota exceeded","type":"insufficient_quota","code":"insufficient_quota"}}
+        """
+          .trimIndent()
+          .toByteArray(),
+        null,
+      )
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } returns
+      mapOf("plainLyrics" to "sunshine dancing all day", "instrumental" to false)
+    every { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) } throws
+      quotaExceeded
+
+    val profiles =
+      service.buildPrivateMoodLyricsProfiles(listOf(Song("Artist A", "Song A"))) {
+        SpotifyTopPlaylistsService.PrivateMoodLyricsProfile(
+          happyScore = 7.0,
+          sadScore = 0.0,
+          surgeScore = 2.0,
+          nightDriftScore = 0.0,
+          anchorScore = 1.0,
+          frontierScore = 0.0,
+          coverageScore = 5.0,
+          tokenCount = 4,
+        )
+      }
+
+    assertTrue(profiles.isEmpty())
+    verify(exactly = 1) { rest.postForObject(any<URI>(), any<HttpEntity<*>>(), Map::class.java) }
   }
 }


### PR DESCRIPTION
## What changed
- added bounded retries with backoff for transient LRCLIB lyric lookups and transient OpenAI lyric-scoring requests
- kept OpenAI retries limited to retryable failures such as network errors, timeouts, server errors, and non-quota 429s
- stopped heuristic lyric fallback when `LYRICS_MOOD_PROVIDER=openai`, so OpenAI mode now leaves songs unscored instead of silently switching classifiers
- updated README to document the retry behavior and the `openai` vs `auto` fallback difference
- added regression coverage for LRCLIB retries, OpenAI retries, OpenAI-only mode, and non-retryable quota failures

## Why it was changed
- Cloud Run logs showed transient LRCLIB 503 responses during lyric fetches
- the OpenAI flow needed the same kind of resilience for transient upstream failures without retrying permanent quota/auth problems
- you asked to use only OpenAI lyric validation once the flow is fixed, which required removing heuristic fallback in `openai` mode

## Validation performed
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew ktfmtFormat test --tests com.lis.spotify.service.LyricsServiceTest --tests com.lis.spotify.service.SpotifyTopPlaylistsServiceTest`
- `GRADLE_USER_HOME=/home/andrz/git/spotify-web-api-demo/.gradle-home ./gradlew jacocoTestCoverageVerification`

## Known limitations or follow-up work
- `LYRICS_MOOD_PROVIDER=openai` now skips songs when OpenAI does not return a usable classification after retries; if broader fallback is desired, use `auto`
- LRCLIB retries help with transient outages but do not address provider-side misses for specific songs