### PR TITLE
Use opaque Spotify session cookies

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -3,7 +3,9 @@ package com.lis.spotify.controller
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,10 +14,14 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("/jobs")
-class JobsController(private val jobService: JobService) {
+class JobsController(
+  private val jobService: JobService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
+) {
 
   companion object {
     private val logger = LoggerFactory.getLogger(JobsController::class.java)
@@ -28,6 +34,7 @@ class JobsController(private val jobService: JobService) {
     @CookieValue("clientId") clientId: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
+    requireAuthorizedSession(clientId)
     val lastFmLogin = request.lastFmLogin.trim()
     if (lastFmLogin.isEmpty()) {
       logger.warn("Rejecting yearly job without Last.fm login for clientId={}", clientId)
@@ -45,6 +52,7 @@ class JobsController(private val jobService: JobService) {
     @CookieValue("clientId") clientId: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
+    requireAuthorizedSession(clientId)
     val lastFmLogin = request.lastFmLogin.trim()
     if (lastFmLogin.isEmpty()) {
       logger.warn(
@@ -69,6 +77,7 @@ class JobsController(private val jobService: JobService) {
     @CookieValue("clientId") clientId: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
+    requireAuthorizedSession(clientId)
     val lastFmLogin = request.lastFmLogin.trim()
     if (lastFmLogin.isEmpty()) {
       logger.warn(
@@ -88,6 +97,13 @@ class JobsController(private val jobService: JobService) {
       jobService.startPrivateMoodTaxonomyJob(clientId, lastFmLogin, request.playlistSize ?: 50)
     logger.info("Private mood taxonomy job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
+  }
+
+  private fun requireAuthorizedSession(clientId: String) {
+    if (!spotifyAuthenticationService.isAuthorizedSession(clientId)) {
+      logger.warn("Rejecting job request for unauthorized Spotify session")
+      throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Spotify authentication required")
+    }
   }
 
   @GetMapping("/{jobId}")

--- a/src/main/kotlin/com/lis/spotify/controller/MainController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/MainController.kt
@@ -33,7 +33,7 @@ class MainController(
     )
 
     val spotifyAuthorized =
-      clientId.isNotEmpty() && spotifyAuthenticationService.getAuthToken(clientId) != null
+      clientId.isNotEmpty() && spotifyAuthenticationService.isAuthorizedSession(clientId)
     val lastFmAuthorized = lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmToken)
 
     return if (!spotifyAuthorized) {

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
@@ -75,6 +75,7 @@ class SpotifyAuthenticationController(
       path = "/"
       isHttpOnly = true
       secure = isSecureRequest(request)
+      setAttribute("SameSite", "Lax")
       maxAgeSeconds?.let { maxAge = it }
     }
   }
@@ -135,12 +136,13 @@ class SpotifyAuthenticationController(
           .build()
           .postForObject<AuthToken>(Spotify.TOKEN_URL, entity)
       logger.debug("Received AuthToken from Spotify (access token redacted).")
-      val clientId = getCurrentUserId(authToken)
-      if (clientId != null) {
-        authToken.clientId = clientId
+      val spotifyUserId = getCurrentUserId(authToken)
+      if (spotifyUserId != null) {
+        val sessionId = spotifyAuthenticationService.createSessionId()
+        authToken.clientId = sessionId
         spotifyAuthenticationService.setAuthToken(authToken)
-        response.addCookie(createCookie("clientId", clientId, request))
-        logger.info("Successfully set auth token for user: {}", clientId)
+        response.addCookie(createCookie("clientId", sessionId, request))
+        logger.info("Successfully set auth token for Spotify user: {}", spotifyUserId)
       } else {
         logger.warn("Could not retrieve client ID. Auth token not stored.")
       }

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
@@ -13,6 +13,7 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.domain.BandPlaylistRequest
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyBandPlaylistService
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -21,16 +22,19 @@ import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 class SpotifyBandPlaylistController(
-  private val spotifyBandPlaylistService: SpotifyBandPlaylistService
+  private val spotifyBandPlaylistService: SpotifyBandPlaylistService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
   @PostMapping("/bandPlaylist")
   fun createBandPlaylist(
     @CookieValue("clientId") clientId: String,
     @RequestBody request: BandPlaylistRequest,
   ): ResponseEntity<String> {
+    requireAuthorizedSession(clientId)
     val bands = request.bands.map { it.trim() }.filter { it.isNotEmpty() }
     if (bands.isEmpty()) {
       logger.warn("Band playlist request had no valid bands for clientId={}", clientId)
@@ -43,6 +47,13 @@ class SpotifyBandPlaylistController(
       ResponseEntity.status(HttpStatus.NOT_FOUND).build()
     } else {
       ResponseEntity.ok(playlistId)
+    }
+  }
+
+  private fun requireAuthorizedSession(clientId: String) {
+    if (!spotifyAuthenticationService.isAuthorizedSession(clientId)) {
+      logger.warn("Rejecting band playlist request for unauthorized Spotify session")
+      throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Spotify authentication required")
     }
   }
 

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -13,24 +13,36 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 class SpotifyTopPlaylistsController(
   val lastFmService: LastFmService,
   val spotifyTopPlaylistsService: SpotifyTopPlaylistsService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
   @PostMapping("/updateTopPlaylists")
   fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
+    requireAuthorizedSession(clientId)
     logger.info("Updating top playlists for {}", clientId)
     logger.debug("updateTopPlaylists for {}", clientId)
     val result = spotifyTopPlaylistsService.updateTopPlaylists(clientId)
     logger.info("UpdateTopPlaylists result for {} -> {}", clientId, result)
     return result
+  }
+
+  private fun requireAuthorizedSession(clientId: String) {
+    if (!spotifyAuthenticationService.isAuthorizedSession(clientId)) {
+      logger.warn("Rejecting top playlist update for unauthorized Spotify session")
+      throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Spotify authentication required")
+    }
   }
 
   companion object {

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -31,7 +31,9 @@ import com.lis.spotify.AppEnvironment.Spotify
 import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.persistence.SpotifyTokenStore
 import com.lis.spotify.persistence.StoredSpotifyAuthToken
+import java.security.SecureRandom
 import java.time.Clock
+import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -72,6 +74,20 @@ class SpotifyAuthenticationService(
       logger.warn("No token found for clientId={}, returning empty headers", clientId)
       HttpHeaders()
     }
+  }
+
+  fun createSessionId(): String {
+    val bytes = ByteArray(32)
+    sessionRandom.nextBytes(bytes)
+    return SESSION_ID_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+  }
+
+  fun isSessionId(clientId: String): Boolean {
+    return clientId.startsWith(SESSION_ID_PREFIX) && clientId.length > SESSION_ID_PREFIX.length
+  }
+
+  fun isAuthorizedSession(clientId: String): Boolean {
+    return isSessionId(clientId) && getAuthToken(clientId) != null
   }
 
   fun setAuthToken(token: AuthToken) {
@@ -179,5 +195,10 @@ class SpotifyAuthenticationService(
 
   internal fun clearCache() {
     tokenCache.clear()
+  }
+
+  companion object {
+    private const val SESSION_ID_PREFIX = "session_"
+    private val sessionRandom = SecureRandom()
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -4,15 +4,23 @@ import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 class JobsControllerTest {
   private val service = mockk<JobService>()
-  private val controller = JobsController(service)
+  private val authService = mockk<SpotifyAuthenticationService>()
+  private val controller = JobsController(service, authService)
+
+  init {
+    every { authService.isAuthorizedSession("c") } returns true
+  }
 
   @Test
   fun startReturnsId() {
@@ -56,6 +64,18 @@ class JobsControllerTest {
   fun startPrivateMoodTaxonomyRejectsBlankLogin() {
     val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
+  fun startRejectsUnauthorizedSession() {
+    every { authService.isAuthorizedSession("forged") } returns false
+
+    val ex =
+      assertThrows(ResponseStatusException::class.java) {
+        controller.start("forged", JobsController.StartRequest("login"))
+      }
+
+    assertEquals(HttpStatus.UNAUTHORIZED, ex.statusCode)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/controller/MainControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/MainControllerTest.kt
@@ -20,7 +20,7 @@ class MainControllerTest {
 
   @Test
   fun redirectsToIndexWhenAuthorized() {
-    every { spotifyService.getAuthToken("abc") } returns mockk()
+    every { spotifyService.isAuthorizedSession("abc") } returns true
     every { lastfmService.isAuthorized("login", "token") } returns true
     val result = controller.main("abc", "login", "token")
     assertEquals("forward:/index.html", result)
@@ -29,14 +29,14 @@ class MainControllerTest {
 
   @Test
   fun redirectsToSpotifyWhenMissingToken() {
-    every { spotifyService.getAuthToken("abc") } returns null
+    every { spotifyService.isAuthorizedSession("abc") } returns false
     val result = controller.main("abc", "login", "token")
     assertEquals("redirect:/auth/spotify", result)
   }
 
   @Test
   fun rendersIndexWhenLastFmMissing() {
-    every { spotifyService.getAuthToken("abc") } returns mockk()
+    every { spotifyService.isAuthorizedSession("abc") } returns true
     every { lastfmService.isAuthorized("login", "bad") } returns false
     val result = controller.main("abc", "login", "bad")
     assertEquals("forward:/index.html", result)

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -106,6 +106,7 @@ class SpotifyAuthenticationControllerTest {
     every { builder.build() } returns restTemplate
 
     val token = AuthToken("a", "b", "c", 0, "r", null)
+    every { spotifyService.createSessionId() } returns "session_cid"
     every {
       restTemplate.postForObject<AuthToken>(Spotify.TOKEN_URL, any(), AuthToken::class.java)
     } returns token
@@ -129,7 +130,7 @@ class SpotifyAuthenticationControllerTest {
             it.path == "/" &&
             it.isHttpOnly &&
             !it.secure &&
-            it.value == "cid"
+            it.value == "session_cid"
         }
       )
     }

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistControllerTest.kt
@@ -1,16 +1,24 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.domain.BandPlaylistRequest
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyBandPlaylistService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 class SpotifyBandPlaylistControllerTest {
   private val service = mockk<SpotifyBandPlaylistService>()
-  private val controller = SpotifyBandPlaylistController(service)
+  private val authService = mockk<SpotifyAuthenticationService>()
+  private val controller = SpotifyBandPlaylistController(service, authService)
+
+  init {
+    every { authService.isAuthorizedSession("cid") } returns true
+  }
 
   @Test
   fun createBandPlaylistReturnsOk() {
@@ -28,6 +36,18 @@ class SpotifyBandPlaylistControllerTest {
     val response = controller.createBandPlaylist("cid", BandPlaylistRequest(listOf(" ")))
 
     assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+  }
+
+  @Test
+  fun createBandPlaylistRejectsUnauthorizedSession() {
+    every { authService.isAuthorizedSession("forged") } returns false
+
+    val ex =
+      assertThrows(ResponseStatusException::class.java) {
+        controller.createBandPlaylist("forged", BandPlaylistRequest(listOf("Band A")))
+      }
+
+    assertEquals(HttpStatus.UNAUTHORIZED, ex.statusCode)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsControllerTest.kt
@@ -1,16 +1,35 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.service.LastFmService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 class SpotifyTopPlaylistsControllerTest {
   private val lastFmService = mockk<LastFmService>(relaxed = true)
   private val topService = mockk<SpotifyTopPlaylistsService>()
-  private val controller = SpotifyTopPlaylistsController(lastFmService, topService)
+  private val authService = mockk<SpotifyAuthenticationService>()
+  private val controller = SpotifyTopPlaylistsController(lastFmService, topService, authService)
+
+  init {
+    every { authService.isAuthorizedSession("cid") } returns true
+  }
+
+  @Test
+  fun updateTopPlaylistsRejectsUnauthorizedSession() {
+    every { authService.isAuthorizedSession("forged") } returns false
+
+    val ex =
+      assertThrows(ResponseStatusException::class.java) { controller.updateTopPlaylists("forged") }
+
+    assertEquals(HttpStatus.UNAUTHORIZED, ex.statusCode)
+  }
 
   @Test
   fun updateTopPlaylistsDelegatesToService() {

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -4,10 +4,12 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.configureFor
 import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.service.AuthenticationRequiredException
 import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
 import com.lis.spotify.service.PrivateMoodPlaylistResult
 import com.lis.spotify.service.PrivateMoodTaxonomyResult
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.clearMocks
 import io.mockk.every
@@ -40,8 +42,10 @@ class JobsControllerIT
 constructor(
   private val rest: TestRestTemplate,
   private val playlistService: SpotifyTopPlaylistsService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
   companion object {
+    private const val TEST_SESSION_ID = "session_test"
     val wm = WireMockServer(WireMockConfiguration.options().dynamicPort())
     val baseUrl: String
       get() = "http://localhost:${wm.port()}"
@@ -73,6 +77,10 @@ constructor(
   @BeforeEach
   fun reset() {
     wireMockReset()
+    spotifyAuthenticationService.clearCache()
+    spotifyAuthenticationService.setAuthToken(
+      AuthToken("access", "Bearer", "scope", 3600, "refresh", TEST_SESSION_ID)
+    )
     clearMocks(playlistService)
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
     every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
@@ -94,7 +102,7 @@ constructor(
   @Test
   fun jobLifecycle() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
     val resp = rest.postForEntity("/jobs", req, Map::class.java)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
@@ -112,7 +120,7 @@ constructor(
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } throws
       AuthenticationRequiredException("LASTFM")
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs", req, Map::class.java)
@@ -128,7 +136,7 @@ constructor(
   @Test
   fun forgottenObsessionsJobReturnsPlaylistIds() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
@@ -143,7 +151,7 @@ constructor(
   @Test
   fun forgottenObsessionsJobRejectsBlankLogin() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
 
     val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
@@ -154,7 +162,7 @@ constructor(
   @Test
   fun privateMoodTaxonomyJobReturnsPlaylistIds() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
@@ -172,7 +180,7 @@ constructor(
   @Test
   fun privateMoodTaxonomyJobRejectsBlankLogin() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
     val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)

--- a/src/test/kotlin/com/lis/spotify/integration/SpotifyAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/SpotifyAuthenticationControllerIT.kt
@@ -168,9 +168,14 @@ constructor(
     assertAll(
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
       { assertTrue(response.headers.location!!.toString().endsWith("/")) },
-      { assertTrue(cookies.any { it.contains("clientId=cid") }) },
+      {
+        val clientCookie = cookies.firstOrNull { it.contains("clientId=session_") }
+        assertNotNull(clientCookie)
+        val sessionId = clientCookie!!.substringAfter("clientId=").substringBefore(";")
+        assertTrue(spotifyAuthenticationService.isAuthorizedSession(sessionId))
+      },
+      { assertNull(spotifyAuthenticationService.getAuthToken("cid")) },
       { assertTrue(cookies.any { it.contains("spotifyAuthState=") && it.contains("Max-Age=0") }) },
-      { assertNotNull(spotifyAuthenticationService.getAuthToken("cid")) },
     )
   }
 

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -41,6 +41,18 @@ class SpotifyAuthenticationServiceTest {
   }
 
   @Test
+  fun isAuthorizedSessionRequiresOpaqueSessionId() {
+    val sessionId = service.createSessionId()
+    service.setAuthToken(AuthToken("a", "b", "c", 0, "r", sessionId))
+    service.setAuthToken(AuthToken("victim-token", "b", "c", 0, "r", "victim-public-id"))
+
+    assertTrue(service.isSessionId(sessionId))
+    assertTrue(service.isAuthorizedSession(sessionId))
+    assertFalse(service.isSessionId("victim-public-id"))
+    assertFalse(service.isAuthorizedSession("victim-public-id"))
+  }
+
+  @Test
   fun seedRefreshTokenStoresRefreshTokenInCache() {
     service.seedRefreshToken("cid", "refresh")
 


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where the public Spotify user id (clientId) was trusted as the session credential and used to persist/retrieve OAuth tokens, allowing forged `clientId` cookies to impersonate other users.
- Introduce an opaque, high-entropy server-side session id for OAuth sessions so persisted tokens are bound to an unforgeable session credential.
- Harden cookie attributes to reduce CSRF/forgery risk by adding `SameSite=Lax` and keep `HttpOnly`/`Secure` semantics.

### Description
- Generate 32-byte, URL-safe opaque session ids in `SpotifyAuthenticationService.createSessionId()` and add helpers `isSessionId()` and `isAuthorizedSession()` to distinguish opaque sessions from public Spotify ids.
- During OAuth callback, store tokens under the generated session id and return that opaque `sessionId` in the `clientId` cookie instead of the Spotify user id (controller changes in `SpotifyAuthenticationController`).
- Require opaque authorized sessions for UI main gate, and add `requireAuthorizedSession(...)` checks that reject requests with forged public ids on mutating endpoints in `SpotifyTopPlaylistsController`, `SpotifyBandPlaylistController`, and `JobsController`.
- Harden cookie creation by setting `SameSite=Lax` (in addition to `HttpOnly` and request-aware `Secure`) and update related unit and integration tests to assert session behavior and rejected forged cookies.

### Testing
- Ran formatting and tests with `./gradlew ktfmtFormat test` (executed as `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=... ./gradlew ktfmtFormat test`) and all tests passed after updates to controller and integration tests.
- Executed coverage verification with `./gradlew jacocoTestCoverageVerification` and the Jacoco check succeeded. 
- Updated unit and integration tests include assertions for opaque session id creation, `isAuthorizedSession` behavior, and unauthorized rejection for forged `clientId` cookies, and these updated tests passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0354c533fc832696a53c9b336244e6)