### PR TITLE
Require Last.fm token for private mood jobs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.controller
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.LastFmAuthenticationService
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
@@ -15,12 +16,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/jobs")
-class JobsController(private val jobService: JobService) {
-
-  companion object {
-    private val logger = LoggerFactory.getLogger(JobsController::class.java)
-  }
-
+class JobsController(
+  private val jobService: JobService,
+  private val lastFmAuthenticationService: LastFmAuthenticationService,
+) {
   data class StartRequest(val lastFmLogin: String, val playlistSize: Int? = null)
 
   @PostMapping
@@ -67,6 +66,7 @@ class JobsController(private val jobService: JobService) {
   @PostMapping("/private-mood-taxonomy")
   fun startPrivateMoodTaxonomy(
     @CookieValue("clientId") clientId: String,
+    @CookieValue("lastFmToken", defaultValue = "") lastFmToken: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
     val lastFmLogin = request.lastFmLogin.trim()
@@ -76,6 +76,15 @@ class JobsController(private val jobService: JobService) {
         clientId,
       )
       return ResponseEntity.badRequest().build()
+    }
+
+    if (!lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmToken)) {
+      logger.warn(
+        "Rejecting private mood taxonomy job for unauthorized Last.fm login={} clientId={}",
+        lastFmLogin,
+        clientId,
+      )
+      return ResponseEntity.status(403).build()
     }
 
     logger.info(
@@ -94,5 +103,9 @@ class JobsController(private val jobService: JobService) {
   fun getStatus(@PathVariable jobId: String): ResponseEntity<JobStatus> {
     val status = jobService.getJobStatus(jobId) ?: return ResponseEntity.notFound().build()
     return ResponseEntity.ok(status)
+  }
+
+  companion object {
+    private val logger = LoggerFactory.getLogger(JobsController::class.java)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -4,15 +4,18 @@ import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.LastFmAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
 class JobsControllerTest {
   private val service = mockk<JobService>()
-  private val controller = JobsController(service)
+  private val lastFmAuthenticationService = mockk<LastFmAuthenticationService>()
+  private val controller = JobsController(service, lastFmAuthenticationService)
 
   @Test
   fun startReturnsId() {
@@ -32,12 +35,29 @@ class JobsControllerTest {
 
   @Test
   fun startPrivateMoodTaxonomyReturnsId() {
+    every { lastFmAuthenticationService.isAuthorized("login", "token") } returns true
     every { service.startPrivateMoodTaxonomyJob("c", "login", 50) } returns "private-mood-id"
 
-    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("login"))
+    val resp =
+      controller.startPrivateMoodTaxonomy("c", "token", JobsController.StartRequest("login"))
 
     assertEquals(JobId("private-mood-id"), resp.body)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
+  }
+
+  @Test
+  fun startPrivateMoodTaxonomyRejectsUnauthorizedLastFmLogin() {
+    every { lastFmAuthenticationService.isAuthorized("victim", "attacker-token") } returns false
+
+    val resp =
+      controller.startPrivateMoodTaxonomy(
+        "c",
+        "attacker-token",
+        JobsController.StartRequest("victim"),
+      )
+
+    assertEquals(HttpStatus.FORBIDDEN, resp.statusCode)
+    verify(exactly = 0) { service.startPrivateMoodTaxonomyJob(any(), any(), any()) }
   }
 
   @Test
@@ -54,7 +74,7 @@ class JobsControllerTest {
 
   @Test
   fun startPrivateMoodTaxonomyRejectsBlankLogin() {
-    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("   "))
+    val resp = controller.startPrivateMoodTaxonomy("c", "token", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
   }
 

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.lis.spotify.service.AuthenticationRequiredException
 import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
+import com.lis.spotify.service.LastFmAuthenticationService
 import com.lis.spotify.service.PrivateMoodPlaylistResult
 import com.lis.spotify.service.PrivateMoodTaxonomyResult
 import com.lis.spotify.service.SpotifyTopPlaylistsService
@@ -40,6 +41,7 @@ class JobsControllerIT
 constructor(
   private val rest: TestRestTemplate,
   private val playlistService: SpotifyTopPlaylistsService,
+  private val lastFmAuthenticationService: LastFmAuthenticationService,
 ) {
   companion object {
     val wm = WireMockServer(WireMockConfiguration.options().dynamicPort())
@@ -73,7 +75,7 @@ constructor(
   @BeforeEach
   fun reset() {
     wireMockReset()
-    clearMocks(playlistService)
+    clearMocks(playlistService, lastFmAuthenticationService)
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
     every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
       ForgottenObsessionsPlaylistResult("playlist-1", 12, 12, 18)
@@ -89,6 +91,7 @@ constructor(
         )
       )
     every { playlistService.updateTopPlaylists(any()) } returns emptyList()
+    every { lastFmAuthenticationService.isAuthorized("login", "lastfm-token") } returns true
   }
 
   @Test
@@ -154,7 +157,7 @@ constructor(
   @Test
   fun privateMoodTaxonomyJobReturnsPlaylistIds() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=lastfm-token")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
@@ -178,6 +181,18 @@ constructor(
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
 
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
+  fun privateMoodTaxonomyJobRejectsUnauthorizedLastFmLogin() {
+    every { lastFmAuthenticationService.isAuthorized("victim", "attacker-token") } returns false
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=attacker-token")
+    val req = HttpEntity(mapOf("lastFmLogin" to "victim"), headers)
+
+    val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
+
+    assertEquals(HttpStatus.FORBIDDEN, resp.statusCode)
   }
 
   class Config {
@@ -208,6 +223,8 @@ constructor(
       every { svc.updateTopPlaylists(any()) } returns emptyList()
       return svc
     }
+
+    @Bean @Primary fun lastFmAuthenticationService(): LastFmAuthenticationService = mockk()
 
     @Bean
     @Primary


### PR DESCRIPTION
### Motivation
- Prevent a malicious caller from scheduling a private-mood taxonomy job for another user's Last.fm account by ensuring Last.fm authorization is bound to the active session.
- Ensure the submitted `lastFmLogin` is verified against the caller's `lastFmToken` before any work that reads private Last.fm history or writes private Spotify playlists is scheduled.

### Description
- Require the `lastFmToken` cookie on `POST /jobs/private-mood-taxonomy` and validate it with `LastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmToken)`, returning HTTP `403` when the token does not authorize the submitted login; changes in `JobsController.kt` implement this check.
- Thread the `LastFmAuthenticationService` into the controller constructor and early-reject unauthorized requests before calling `jobService.startPrivateMoodTaxonomyJob`.
- Add unit tests to `JobsControllerTest.kt` to exercise the authorized and unauthorized paths and update `JobsControllerIT.kt` to include the Last.fm token cookie and an integration test for the `403` case.
- Minor formatting/companion-object relocation performed to keep ktfmt happy and preserve existing behavior for other job endpoints.

### Testing
- Ran `./gradlew ktfmtFormat` (with `JAVA_HOME` set to Java 17) and formatting completed successfully.
- Ran `./gradlew test` (with `JAVA_HOME` set to Java 17) and all tests passed.
- Ran `./gradlew jacocoTestCoverageVerification` and coverage verification succeeded.
- Ran `./gradlew build` (with `JAVA_HOME` set to Java 17) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0353b23bc48326927056df4ebe6785)