### PR TITLE
Prevent host/header poisoning of Last.fm OAuth callback

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -1,6 +1,5 @@
 package com.lis.spotify.controller
 
-import com.lis.spotify.AppEnvironment.LastFm
 import com.lis.spotify.service.LastFmAuthenticationService
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
@@ -20,16 +19,6 @@ import org.springframework.web.servlet.view.RedirectView
  */
 @Controller
 class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthenticationService) {
-
-  private fun callbackUrl(request: HttpServletRequest): String {
-    val proto = request.getHeader("X-Forwarded-Proto") ?: request.scheme
-    val host = request.getHeader("X-Forwarded-Host") ?: request.serverName
-    val portHeader = request.getHeader("X-Forwarded-Port")
-    val port = portHeader ?: request.serverPort.toString()
-    val defaultPort = if (proto == "https") "443" else "80"
-    val portPart = if (port == defaultPort || port.isEmpty()) "" else ":$port"
-    return "$proto://$host$portPart" + LastFm.CALLBACK_PATH
-  }
 
   private fun isSecureRequest(request: HttpServletRequest): Boolean {
     val proto = request.getHeader("X-Forwarded-Proto") ?: request.scheme
@@ -70,7 +59,7 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       ?.let {
         response.addCookie(createCookie(LAST_FM_LOGIN_COOKIE, it, request, httpOnly = false))
       }
-    val authUrl = lastFmAuthService.getAuthorizationUrl(callbackUrl(request))
+    val authUrl = lastFmAuthService.getAuthorizationUrl()
     logger.info("Redirecting user to Last.fm auth URL: $authUrl")
     return RedirectView(authUrl)
   }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -79,13 +79,13 @@ class LastFmAuthenticationService(private val lastFmSessionStore: LastFmSessionS
    *
    * Format: https://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
    */
-  fun getAuthorizationUrl(callbackUrl: String = LastFm.CALLBACK_URL): String {
+  fun getAuthorizationUrl(): String {
     logger.debug("getAuthorizationUrl() called")
     return UriComponentsBuilder.fromHttpUrl(LastFm.AUTHORIZE_URL)
       .queryParam("api_key", LastFm.API_KEY)
       .queryParam("cb", "{cb}")
       .encode()
-      .buildAndExpand(callbackUrl)
+      .buildAndExpand(LastFm.CALLBACK_URL)
       .toUriString()
   }
 

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -19,19 +19,16 @@ class LastFmAuthenticationControllerTest {
   @Test
   fun authenticateUserRedirects() {
     val request = mockk<HttpServletRequest>()
-    every { request.getHeader("X-Forwarded-Proto") } returns null
-    every { request.getHeader("X-Forwarded-Host") } returns null
-    every { request.getHeader("X-Forwarded-Port") } returns null
+    every { request.getHeader(any()) } returns null
     every { request.scheme } returns "https"
-    every { request.serverName } returns "example.com"
-    every { request.serverPort } returns 443
+    every { request.isSecure } returns true
 
-    every { service.getAuthorizationUrl("https://example.com/auth/lastfm/callback") } returns
-      "http://x"
+    every { service.getAuthorizationUrl() } returns "http://x"
 
     val view = controller.authenticateUser(request, mockk(relaxed = true), "login")
 
     assertEquals("http://x", view.url)
+    verify { service.getAuthorizationUrl() }
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
@@ -8,9 +8,12 @@ import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -83,6 +86,34 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
       { assertTrue(response.headers.location!!.toString().startsWith(baseUrl)) },
       { assertTrue(cookies.any { it.contains("lastFmLogin=saved-login") }) },
+    )
+  }
+
+  @Test
+  fun authenticateUserIgnoresForwardedHostForCallback() {
+    val noRedirect =
+      rest.withRequestFactorySettings {
+        it.withRedirects(ClientHttpRequestFactorySettings.Redirects.DONT_FOLLOW)
+      }
+    val headers = org.springframework.http.HttpHeaders()
+    headers.add("X-Forwarded-Proto", "https")
+    headers.add("X-Forwarded-Host", "attacker.example")
+    headers.add("X-Forwarded-Port", "443")
+
+    val response =
+      noRedirect.exchange(
+        "/auth/lastfm",
+        org.springframework.http.HttpMethod.GET,
+        org.springframework.http.HttpEntity<String>(headers),
+        String::class.java,
+      )
+    val location = response.headers.location!!.toString()
+    val decodedLocation = URLDecoder.decode(location, StandardCharsets.UTF_8)
+
+    assertAll(
+      { assertEquals(HttpStatus.FOUND, response.statusCode) },
+      { assertFalse(decodedLocation.contains("attacker.example")) },
+      { assertTrue(decodedLocation.contains("cb=http://localhost/auth/lastfm/callback")) },
     )
   }
 


### PR DESCRIPTION
### Motivation

- The Last.fm authorization flow previously constructed the OAuth callback URL from request-derived `X-Forwarded-*`/host headers, which allows an attacker to poison the `cb` parameter and exfiltrate Last.fm tokens/session keys. 
- The intent of the change is to ensure the OAuth `cb` parameter is always the configured application callback and not influenced by attacker-controlled headers.

### Description

- Remove the request-derived `callbackUrl(...)` logic from `LastFmAuthenticationController` and stop passing a request-built callback into the authorization URL builder. 
- Change `LastFmAuthenticationService.getAuthorizationUrl` to a no-argument method that always expands `LastFm.CALLBACK_URL` from configuration instead of accepting an arbitrary callback string. 
- Update the controller to call the no-argument `getAuthorizationUrl()` and adjust imports accordingly. 
- Add/modify unit and integration tests to assert that forwarded host headers are ignored (`LastFmAuthenticationControllerTest` and `LastFmAuthenticationControllerIT`).

### Testing

- Ran code formatting with `./gradlew ktfmtFormat` (executed under Java 17 when running CI locally) and `ktfmtCheck`, and both completed successfully. 
- Executed targeted tests `com.lis.spotify.controller.LastFmAuthenticationControllerTest` and `com.lis.spotify.integration.LastFmAuthenticationControllerIT` via `./gradlew test` and they passed. 
- Ran the full test suite with `./gradlew test` (with Java 17 in the environment) and the build/tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0356446c9c832685b199903e08aad7)