### PR TITLE
Isolate configured Spotify refresh token

### DIFF
--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
@@ -4,6 +4,7 @@ import com.lis.spotify.persistence.RefreshStateStore
 import com.lis.spotify.persistence.StoredRefreshState
 import java.time.Clock
 import java.time.Instant
+import java.util.UUID
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -24,6 +25,7 @@ class SpotifyTopPlaylistsRefreshService(
   @Value("\${spotify.top-playlists.refresh-trigger-token:}") private val refreshTriggerToken: String,
 ) {
   private val clock: Clock = Clock.systemUTC()
+  private val refreshTokenCacheClientId = "configured-top-playlists-refresh-${UUID.randomUUID()}"
 
   @EventListener(ApplicationReadyEvent::class)
   fun triggerRefreshOnStartup() {
@@ -69,8 +71,8 @@ class SpotifyTopPlaylistsRefreshService(
       return null
     }
 
-    spotifyAuthenticationService.seedRefreshToken(refreshClientId, refreshToken)
-    if (!spotifyAuthenticationService.refreshToken(refreshClientId)) {
+    spotifyAuthenticationService.seedRefreshToken(refreshTokenCacheClientId, refreshToken)
+    if (!spotifyAuthenticationService.refreshToken(refreshTokenCacheClientId)) {
       logger.warn(
         "Skipping configured top playlist refresh for trigger={} because Spotify token refresh failed",
         trigger,
@@ -87,7 +89,7 @@ class SpotifyTopPlaylistsRefreshService(
     }
 
     return try {
-      val playlistIds = spotifyTopPlaylistsService.updateTopPlaylists(refreshClientId)
+      val playlistIds = spotifyTopPlaylistsService.updateTopPlaylists(refreshTokenCacheClientId)
       val completedAt = Instant.now(clock)
       saveRefreshState(
         clientId = refreshClientId,

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.service
 import com.lis.spotify.persistence.InMemoryRefreshStateStore
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -18,8 +19,9 @@ class SpotifyTopPlaylistsRefreshServiceTest {
     val authService = mockk<SpotifyAuthenticationService>(relaxed = true)
     val topPlaylistsService = mockk<SpotifyTopPlaylistsService>()
     val refreshStateStore = InMemoryRefreshStateStore()
-    every { authService.refreshToken("cid") } returns true
-    every { topPlaylistsService.updateTopPlaylists("cid") } returns listOf("playlist-1")
+    val cacheClientId = slot<String>()
+    every { authService.refreshToken(capture(cacheClientId)) } returns true
+    every { topPlaylistsService.updateTopPlaylists(any()) } returns listOf("playlist-1")
 
     val service =
       SpotifyTopPlaylistsRefreshService(
@@ -35,9 +37,12 @@ class SpotifyTopPlaylistsRefreshServiceTest {
 
     service.refreshConfiguredPlaylists("test")
 
-    verify { authService.seedRefreshToken("cid", "refresh-token") }
-    verify { authService.refreshToken("cid") }
-    verify { topPlaylistsService.updateTopPlaylists("cid") }
+    assertTrue(cacheClientId.captured.startsWith("configured-top-playlists-refresh-"))
+    assertFalse(cacheClientId.captured == "cid")
+    verify { authService.seedRefreshToken(cacheClientId.captured, "refresh-token") }
+    verify(exactly = 0) { authService.seedRefreshToken("cid", any()) }
+    verify { authService.refreshToken(cacheClientId.captured) }
+    verify { topPlaylistsService.updateTopPlaylists(cacheClientId.captured) }
     val savedState = refreshStateStore.getTopPlaylists()
     assertNotNull(savedState)
     assertEquals("COMPLETED", savedState?.lastStatus)
@@ -52,7 +57,8 @@ class SpotifyTopPlaylistsRefreshServiceTest {
     val authService = mockk<SpotifyAuthenticationService>(relaxed = true)
     val topPlaylistsService = mockk<SpotifyTopPlaylistsService>(relaxed = true)
     val refreshStateStore = InMemoryRefreshStateStore()
-    every { authService.refreshToken("cid") } returns false
+    val cacheClientId = slot<String>()
+    every { authService.refreshToken(capture(cacheClientId)) } returns false
 
     val service =
       SpotifyTopPlaylistsRefreshService(
@@ -68,8 +74,11 @@ class SpotifyTopPlaylistsRefreshServiceTest {
 
     service.refreshConfiguredPlaylists("test")
 
-    verify { authService.seedRefreshToken("cid", "refresh-token") }
-    verify { authService.refreshToken("cid") }
+    assertTrue(cacheClientId.captured.startsWith("configured-top-playlists-refresh-"))
+    assertFalse(cacheClientId.captured == "cid")
+    verify { authService.seedRefreshToken(cacheClientId.captured, "refresh-token") }
+    verify(exactly = 0) { authService.seedRefreshToken("cid", any()) }
+    verify { authService.refreshToken(cacheClientId.captured) }
     verify(exactly = 0) { topPlaylistsService.updateTopPlaylists(any()) }
     assertEquals("FAILED_SPOTIFY_REFRESH", refreshStateStore.getTopPlaylists()?.lastStatus)
   }
@@ -138,8 +147,8 @@ class SpotifyTopPlaylistsRefreshServiceTest {
     val authService = mockk<SpotifyAuthenticationService>(relaxed = true)
     val topPlaylistsService = mockk<SpotifyTopPlaylistsService>()
     val refreshStateStore = InMemoryRefreshStateStore()
-    every { authService.refreshToken("cid") } returns true
-    every { topPlaylistsService.updateTopPlaylists("cid") } throws IllegalStateException("boom")
+    every { authService.refreshToken(any()) } returns true
+    every { topPlaylistsService.updateTopPlaylists(any()) } throws IllegalStateException("boom")
     val service =
       SpotifyTopPlaylistsRefreshService(
         spotifyAuthenticationService = authService,


### PR DESCRIPTION
### Motivation
- Prevent the configured top-playlists refresh token from being stored in the shared per-user token cache under a public Spotify user id, which would let an attacker impersonate the configured account by forging the `clientId` cookie.

### Description
- Add a per-service random cache key (`refreshTokenCacheClientId`) in `SpotifyTopPlaylistsRefreshService` and use it to `seedRefreshToken`, call `refreshToken`, and run `updateTopPlaylists`, while still recording the configured `refreshClientId` in refresh state and logs.
- Keep refresh state reporting and logs tied to the configured client id so operational telemetry is unchanged.
- Update `SpotifyTopPlaylistsRefreshServiceTest` to capture the runtime cache key with a `mockk` `slot` and assert that token seeding/refresh/update use the isolated cache key and do not seed the configured `clientId`.

### Testing
- Ran `./gradlew ktfmtFormat test --tests com.lis.spotify.service.SpotifyTopPlaylistsRefreshServiceTest` under the environment default Java (25) which failed during Gradle configuration due to Java/Kotlin tooling compatibility.
- Re-ran tests with Java 17 via `JAVA_HOME=$(mise where java@17.0.2) PATH="$(mise where java@17.0.2)/bin:$PATH" ./gradlew ktfmtFormat test --tests com.lis.spotify.service.SpotifyTopPlaylistsRefreshServiceTest` and the focused test suite passed.
- Ran a full build with Java 17 via `JAVA_HOME=$(mise where java@17.0.2) PATH="$(mise where java@17.0.2)/bin:$PATH" ./gradlew build` and the build, tests, and `jacocoTestCoverageVerification` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0355ca5bc88326adda02bedff7afd1)