### PR TITLE
Harden polling job creation and limit background work

### DIFF
--- a/src/main/kotlin/com/lis/spotify/Application.kt
+++ b/src/main/kotlin/com/lis/spotify/Application.kt
@@ -27,7 +27,11 @@ class Application {
 
   @Bean
   fun taskScheduler(): TaskScheduler {
-    return ThreadPoolTaskScheduler()
+    return ThreadPoolTaskScheduler().apply {
+      poolSize = 4
+      setThreadNamePrefix("playlist-job-")
+      setRemoveOnCancelPolicy(true)
+    }
   }
 }
 

--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -2,8 +2,11 @@ package com.lis.spotify.controller
 
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobStatus
+import com.lis.spotify.service.JobLimitExceededException
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,7 +18,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/jobs")
-class JobsController(private val jobService: JobService) {
+class JobsController(
+  private val jobService: JobService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
+) {
 
   companion object {
     private val logger = LoggerFactory.getLogger(JobsController::class.java)
@@ -34,10 +40,12 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
-    logger.info("Starting yearly job for clientId={} lastFmLogin={}", clientId, lastFmLogin)
-    val id = jobService.startYearlyJob(clientId, lastFmLogin)
-    logger.info("Yearly job {} scheduled", id)
-    return ResponseEntity.accepted().body(JobId(id))
+    if (!spotifyAuthenticationService.isAuthorized(clientId)) {
+      logger.warn("Rejecting yearly job for unauthorized clientId={}", clientId)
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+    }
+
+    return startJob("yearly", clientId) { jobService.startYearlyJob(clientId, lastFmLogin) }
   }
 
   @PostMapping("/forgotten-obsessions")
@@ -54,14 +62,14 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
-    logger.info(
-      "Starting forgotten obsessions job for clientId={} lastFmLogin={}",
-      clientId,
-      lastFmLogin,
-    )
-    val id = jobService.startForgottenObsessionsJob(clientId, lastFmLogin)
-    logger.info("Forgotten obsessions job {} scheduled", id)
-    return ResponseEntity.accepted().body(JobId(id))
+    if (!spotifyAuthenticationService.isAuthorized(clientId)) {
+      logger.warn("Rejecting forgotten obsessions job for unauthorized clientId={}", clientId)
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+    }
+
+    return startJob("forgotten obsessions", clientId) {
+      jobService.startForgottenObsessionsJob(clientId, lastFmLogin)
+    }
   }
 
   @PostMapping("/private-mood-taxonomy")
@@ -78,21 +86,35 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
-    logger.info(
-      "Starting private mood taxonomy job for clientId={} lastFmLogin={} playlistSize={}",
-      clientId,
-      lastFmLogin,
-      request.playlistSize,
-    )
-    val id =
+    if (!spotifyAuthenticationService.isAuthorized(clientId)) {
+      logger.warn("Rejecting private mood taxonomy job for unauthorized clientId={}", clientId)
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+    }
+
+    return startJob("private mood taxonomy", clientId) {
       jobService.startPrivateMoodTaxonomyJob(clientId, lastFmLogin, request.playlistSize ?: 50)
-    logger.info("Private mood taxonomy job {} scheduled", id)
-    return ResponseEntity.accepted().body(JobId(id))
+    }
   }
 
   @GetMapping("/{jobId}")
   fun getStatus(@PathVariable jobId: String): ResponseEntity<JobStatus> {
     val status = jobService.getJobStatus(jobId) ?: return ResponseEntity.notFound().build()
     return ResponseEntity.ok(status)
+  }
+
+  private fun startJob(
+    jobName: String,
+    clientId: String,
+    starter: () -> String,
+  ): ResponseEntity<JobId> {
+    logger.info("Starting {} job for clientId={}", jobName, clientId)
+    return try {
+      val id = starter()
+      logger.info("{} job {} scheduled", jobName, id)
+      ResponseEntity.accepted().body(JobId(id))
+    } catch (e: JobLimitExceededException) {
+      logger.warn("Rejecting {} job for clientId={}: {}", jobName, clientId, e.message)
+      ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build()
+    }
   }
 }

--- a/src/main/kotlin/com/lis/spotify/persistence/AppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/AppStateStores.kt
@@ -1,9 +1,13 @@
 package com.lis.spotify.persistence
 
+import java.time.Instant
+
 interface JobStatusStore {
   fun save(job: StoredJobStatus): StoredJobStatus
 
   fun findById(jobId: String): StoredJobStatus?
+
+  fun deleteExpired(now: Instant): Int
 }
 
 interface SpotifyTokenStore {

--- a/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.persistence
 
 import com.google.cloud.firestore.DocumentSnapshot
 import com.google.cloud.firestore.Firestore
+import java.time.Instant
 import org.slf4j.LoggerFactory
 
 private const val JOBS_COLLECTION = "jobs"
@@ -25,6 +26,22 @@ abstract class FirestoreStoreSupport(protected val firestore: Firestore) {
     val snapshot = firestore.collection(collection).whereEqualTo(field, value).limit(1).get().get()
     return snapshot.documents.firstOrNull { it.exists() }
   }
+
+  protected fun deleteExpiredDocuments(collection: String, now: Instant): Int {
+    val snapshot =
+      firestore
+        .collection(collection)
+        .whereLessThanOrEqualTo("expiresAt", now.toFirestoreTimestamp())
+        .limit(EXPIRED_DOCUMENT_DELETE_LIMIT)
+        .get()
+        .get()
+    snapshot.documents.forEach { it.reference.delete().get() }
+    return snapshot.size()
+  }
+
+  companion object {
+    private const val EXPIRED_DOCUMENT_DELETE_LIMIT = 100
+  }
 }
 
 class FirestoreJobStatusStore(firestore: Firestore) :
@@ -40,6 +57,10 @@ class FirestoreJobStatusStore(firestore: Firestore) :
   override fun findById(jobId: String): StoredJobStatus? {
     val document = loadDocument(JOBS_COLLECTION, jobId) ?: return null
     return StoredJobStatus.fromDocument(document)
+  }
+
+  override fun deleteExpired(now: Instant): Int {
+    return deleteExpiredDocuments(JOBS_COLLECTION, now)
   }
 }
 

--- a/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
@@ -1,5 +1,6 @@
 package com.lis.spotify.persistence
 
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.LoggerFactory
@@ -16,6 +17,12 @@ class InMemoryJobStatusStore : JobStatusStore {
 
   override fun findById(jobId: String): StoredJobStatus? {
     return jobs[jobId]
+  }
+
+  override fun deleteExpired(now: Instant): Int {
+    val expiredIds = jobs.filterValues { !it.expiresAt.isAfter(now) }.keys
+    expiredIds.forEach { jobs.remove(it) }
+    return expiredIds.size
   }
 
   fun clear() {

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -11,6 +11,8 @@ import java.time.Duration
 import java.time.Instant
 import java.util.Date
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
@@ -23,9 +25,14 @@ class JobService(
 ) {
   private val logger = LoggerFactory.getLogger(JobService::class.java)
   private val clock: Clock = Clock.systemUTC()
+  private val activeJobCount = AtomicInteger(0)
+  private val activeClients = ConcurrentHashMap.newKeySet<String>()
+  private val clientStartTimes = ConcurrentHashMap<String, ArrayDeque<Instant>>()
 
   fun getJobStatus(jobId: String): JobStatus? {
-    return jobStatusStore.findById(jobId)?.toJobStatus()
+    val now = Instant.now(clock)
+    jobStatusStore.deleteExpired(now)
+    return jobStatusStore.findById(jobId)?.takeIf { it.expiresAt.isAfter(now) }?.toJobStatus()
   }
 
   fun startYearlyJob(clientId: String, lastFmLogin: String): String {
@@ -139,99 +146,149 @@ class JobService(
     failureMessage: String,
     work: (((Int, String) -> Unit) -> JobCompletion),
   ): String {
-    val id = UUID.randomUUID().toString()
     val createdAt = Instant.now(clock)
+    reserveJobSlot(clientId, createdAt)
+    val id = UUID.randomUUID().toString()
     val expiresAt = createdAt.plus(JOB_TTL)
-    updateJob(
-      jobId = id,
-      state = JobState.QUEUED,
-      progressPercent = 0,
-      message = queuedMessage,
-      clientId = clientId,
-      lastFmLogin = lastFmLogin,
-      createdAt = createdAt,
-      expiresAt = expiresAt,
-    )
-    scheduler.schedule(
-      {
-        updateJob(
-          jobId = id,
-          state = JobState.RUNNING,
-          progressPercent = 0,
-          message = startMessage,
-          clientId = clientId,
-          lastFmLogin = lastFmLogin,
-          createdAt = createdAt,
-          expiresAt = expiresAt,
-        )
-        try {
-          val completion = work { progressPercent, message ->
+    try {
+      jobStatusStore.deleteExpired(createdAt)
+      updateJob(
+        jobId = id,
+        state = JobState.QUEUED,
+        progressPercent = 0,
+        message = queuedMessage,
+        clientId = clientId,
+        lastFmLogin = lastFmLogin,
+        createdAt = createdAt,
+        expiresAt = expiresAt,
+      )
+      scheduler.schedule(
+        {
+          try {
             updateJob(
               jobId = id,
               state = JobState.RUNNING,
-              progressPercent = progressPercent,
-              message = message,
+              progressPercent = 0,
+              message = startMessage,
               clientId = clientId,
               lastFmLogin = lastFmLogin,
               createdAt = createdAt,
               expiresAt = expiresAt,
             )
+            val completion = work { progressPercent, message ->
+              updateJob(
+                jobId = id,
+                state = JobState.RUNNING,
+                progressPercent = progressPercent,
+                message = message,
+                clientId = clientId,
+                lastFmLogin = lastFmLogin,
+                createdAt = createdAt,
+                expiresAt = expiresAt,
+              )
+            }
+            updateJob(
+              jobId = id,
+              state = JobState.COMPLETED,
+              progressPercent = 100,
+              message = completion.message,
+              playlistIds = completion.playlistIds,
+              clientId = clientId,
+              lastFmLogin = lastFmLogin,
+              createdAt = createdAt,
+              expiresAt = expiresAt,
+            )
+          } catch (e: AuthenticationRequiredException) {
+            logger.error("Authentication required during job {}", id, e)
+            updateJob(
+              jobId = id,
+              state = JobState.FAILED,
+              progressPercent = currentProgress(id),
+              message = authenticationMessage(e.provider),
+              redirectUrl = authenticationRedirectUrl(e.provider, lastFmLogin),
+              clientId = clientId,
+              lastFmLogin = lastFmLogin,
+              createdAt = createdAt,
+              expiresAt = expiresAt,
+            )
+          } catch (e: PlaylistUpdateException) {
+            logger.error("Playlist update failed during job {}", id, e)
+            updateJob(
+              jobId = id,
+              state = JobState.FAILED,
+              progressPercent = currentProgress(id),
+              message = failureMessage,
+              playlistIds = e.playlistIds,
+              clientId = clientId,
+              lastFmLogin = lastFmLogin,
+              createdAt = createdAt,
+              expiresAt = expiresAt,
+            )
+          } catch (e: Exception) {
+            logger.error("Job {} failed", id, e)
+            updateJob(
+              jobId = id,
+              state = JobState.FAILED,
+              progressPercent = currentProgress(id),
+              message = failureMessage,
+              clientId = clientId,
+              lastFmLogin = lastFmLogin,
+              createdAt = createdAt,
+              expiresAt = expiresAt,
+            )
+          } finally {
+            releaseJobSlot(clientId)
           }
-          updateJob(
-            jobId = id,
-            state = JobState.COMPLETED,
-            progressPercent = 100,
-            message = completion.message,
-            playlistIds = completion.playlistIds,
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        } catch (e: AuthenticationRequiredException) {
-          logger.error("Authentication required during job {}", id, e)
-          updateJob(
-            jobId = id,
-            state = JobState.FAILED,
-            progressPercent = currentProgress(id),
-            message = authenticationMessage(e.provider),
-            redirectUrl = authenticationRedirectUrl(e.provider, lastFmLogin),
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        } catch (e: PlaylistUpdateException) {
-          logger.error("Playlist update failed during job {}", id, e)
-          updateJob(
-            jobId = id,
-            state = JobState.FAILED,
-            progressPercent = currentProgress(id),
-            message = failureMessage,
-            playlistIds = e.playlistIds,
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        } catch (e: Exception) {
-          logger.error("Job {} failed", id, e)
-          updateJob(
-            jobId = id,
-            state = JobState.FAILED,
-            progressPercent = currentProgress(id),
-            message = failureMessage,
-            clientId = clientId,
-            lastFmLogin = lastFmLogin,
-            createdAt = createdAt,
-            expiresAt = expiresAt,
-          )
-        }
-      },
-      Date.from(createdAt),
-    )
+        },
+        Date.from(createdAt),
+      )
+    } catch (e: Exception) {
+      releaseJobSlot(clientId)
+      throw e
+    }
     logger.info("Job {} scheduled", id)
     return id
+  }
+
+  private fun reserveJobSlot(clientId: String, now: Instant) {
+    pruneClientStarts(clientId, now)
+    if (!activeClients.add(clientId)) {
+      throw JobLimitExceededException("A playlist job is already running for this client")
+    }
+
+    val total = activeJobCount.incrementAndGet()
+    if (total > MAX_ACTIVE_JOBS) {
+      activeJobCount.decrementAndGet()
+      activeClients.remove(clientId)
+      throw JobLimitExceededException("Too many playlist jobs are running")
+    }
+
+    val starts = clientStartTimes.computeIfAbsent(clientId) { ArrayDeque() }
+    synchronized(starts) {
+      if (starts.size >= MAX_CLIENT_JOB_STARTS_PER_HOUR) {
+        activeJobCount.decrementAndGet()
+        activeClients.remove(clientId)
+        throw JobLimitExceededException("Too many playlist jobs were started recently")
+      }
+      starts.addLast(now)
+    }
+  }
+
+  private fun releaseJobSlot(clientId: String) {
+    activeClients.remove(clientId)
+    activeJobCount.updateAndGet { count -> (count - 1).coerceAtLeast(0) }
+  }
+
+  private fun pruneClientStarts(clientId: String, now: Instant) {
+    val starts = clientStartTimes[clientId] ?: return
+    synchronized(starts) {
+      while (starts.isNotEmpty() && starts.first().plus(CLIENT_RATE_LIMIT_WINDOW).isBefore(now)) {
+        starts.removeFirst()
+      }
+      if (starts.isEmpty()) {
+        clientStartTimes.remove(clientId, starts)
+      }
+    }
   }
 
   private fun updateJob(
@@ -292,6 +349,9 @@ class JobService(
 
   companion object {
     private val JOB_TTL: Duration = Duration.ofDays(7)
+    private val CLIENT_RATE_LIMIT_WINDOW: Duration = Duration.ofHours(1)
+    private const val MAX_ACTIVE_JOBS = 25
+    private const val MAX_CLIENT_JOB_STARTS_PER_HOUR = 10
   }
 
   private data class JobCompletion(
@@ -299,3 +359,5 @@ class JobService(
     val playlistIds: List<String> = emptyList(),
   )
 }
+
+class JobLimitExceededException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -3,7 +3,9 @@ package com.lis.spotify.controller
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
+import com.lis.spotify.service.JobLimitExceededException
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.SpotifyAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,10 +14,12 @@ import org.springframework.http.HttpStatus
 
 class JobsControllerTest {
   private val service = mockk<JobService>()
-  private val controller = JobsController(service)
+  private val authService = mockk<SpotifyAuthenticationService>()
+  private val controller = JobsController(service, authService)
 
   @Test
   fun startReturnsId() {
+    every { authService.isAuthorized("c") } returns true
     every { service.startYearlyJob("c", "login") } returns "id"
     val resp = controller.start("c", JobsController.StartRequest("login"))
     assertEquals(JobId("id"), resp.body)
@@ -24,6 +28,7 @@ class JobsControllerTest {
 
   @Test
   fun startForgottenObsessionsReturnsId() {
+    every { authService.isAuthorized("c") } returns true
     every { service.startForgottenObsessionsJob("c", "login") } returns "forgotten-id"
     val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("login"))
     assertEquals(JobId("forgotten-id"), resp.body)
@@ -32,12 +37,32 @@ class JobsControllerTest {
 
   @Test
   fun startPrivateMoodTaxonomyReturnsId() {
+    every { authService.isAuthorized("c") } returns true
     every { service.startPrivateMoodTaxonomyJob("c", "login", 50) } returns "private-mood-id"
 
     val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("login"))
 
     assertEquals(JobId("private-mood-id"), resp.body)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
+  }
+
+  @Test
+  fun startRejectsUnauthorizedClient() {
+    every { authService.isAuthorized("c") } returns false
+
+    val resp = controller.start("c", JobsController.StartRequest("login"))
+
+    assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
+  }
+
+  @Test
+  fun startReturnsTooManyRequestsWhenJobLimitIsExceeded() {
+    every { authService.isAuthorized("c") } returns true
+    every { service.startYearlyJob("c", "login") } throws JobLimitExceededException("too many")
+
+    val resp = controller.start("c", JobsController.StartRequest("login"))
+
+    assertEquals(HttpStatus.TOO_MANY_REQUESTS, resp.statusCode)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -4,10 +4,12 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.configureFor
 import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.service.AuthenticationRequiredException
 import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
 import com.lis.spotify.service.PrivateMoodPlaylistResult
 import com.lis.spotify.service.PrivateMoodTaxonomyResult
+import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
 import io.mockk.clearMocks
 import io.mockk.every
@@ -40,6 +42,7 @@ class JobsControllerIT
 constructor(
   private val rest: TestRestTemplate,
   private val playlistService: SpotifyTopPlaylistsService,
+  private val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
   companion object {
     val wm = WireMockServer(WireMockConfiguration.options().dynamicPort())
@@ -73,6 +76,9 @@ constructor(
   @BeforeEach
   fun reset() {
     wireMockReset()
+    spotifyAuthenticationService.setAuthToken(
+      AuthToken("access", "Bearer", "scope", 3600, "refresh", "cid")
+    )
     clearMocks(playlistService)
     every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
     every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
@@ -89,6 +95,17 @@ constructor(
         )
       )
     every { playlistService.updateTopPlaylists(any()) } returns emptyList()
+  }
+
+  @Test
+  fun jobStartRejectsUnauthorizedClient() {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=unknown")
+    val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
+
+    val resp = rest.postForEntity("/jobs", req, Map::class.java)
+
+    assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.scheduling.TaskScheduler
@@ -33,6 +34,22 @@ class JobServiceTest {
     assertNotNull(status)
     assertEquals(JobState.COMPLETED, status?.state)
     assertEquals(100, status?.progressPercent)
+  }
+
+  @Test
+  fun startJobRejectsSecondActiveJobForClient() {
+    val playlistService = mockk<SpotifyTopPlaylistsService>(relaxed = true)
+    val jobStatusStore = InMemoryJobStatusStore()
+    val scheduler = mockk<TaskScheduler>()
+    every { scheduler.schedule(any<Runnable>(), any<java.util.Date>()) } returns
+      mockk(relaxed = true)
+    val service = JobService(playlistService, jobStatusStore, scheduler)
+
+    service.startYearlyJob("c", "login")
+
+    assertThrows(JobLimitExceededException::class.java) {
+      service.startForgottenObsessionsJob("c", "login")
+    }
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated and unbounded background work being scheduled via the public `POST /jobs` endpoints, which allowed attacker-controlled `clientId` cookies to create unbounded scheduler tasks and grow job state indefinitely.
- Add server-side admission controls and cleanup so the service remains available when exposed to public traffic. 

### Description
- Require server-side authorization before accepting job requests by calling `SpotifyAuthenticationService.isAuthorized(clientId)` and return `401 Unauthorized` for unauthorized clientIds in the `/jobs` endpoints; introduce centralized `startJob` handling that maps limit rejections to `429 Too Many Requests` in `JobsController`. 
- Add in-process admission controls in `JobService`: one active job per client, a global active-job cap, and a per-client hourly start limit, with `JobLimitExceededException` thrown when limits are hit and slots released on job completion/failure. 
- Add expiration/cleanup of stale job status entries to the job store contract and implement `deleteExpired` for both in-memory and Firestore-backed stores so progress entries do not accumulate indefinitely. 
- Configure the `TaskScheduler` with limited pool size and cancel-on-remove policy and add unit and integration tests covering unauthorized requests and job-limit behavior. 

### Testing
- Ran formatting with `./gradlew ktfmtFormat` which succeeded. 
- Ran the test suite with `./gradlew test` which completed successfully. 
- Verified coverage gate with `./gradlew jacocoTestCoverageVerification` which succeeded. 
- Built the project with `./gradlew build` which succeeded; modified and added unit/integration tests were executed during these runs and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035ae46448832694bc53eadbd51b0c)