### PR TITLE
Bind Last.fm job requests to requester session

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.controller
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.LastFmAuthenticationService
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
@@ -15,7 +16,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/jobs")
-class JobsController(private val jobService: JobService) {
+class JobsController(
+  private val jobService: JobService,
+  private val lastFmAuthenticationService: LastFmAuthenticationService,
+) {
 
   companion object {
     private val logger = LoggerFactory.getLogger(JobsController::class.java)
@@ -26,6 +30,7 @@ class JobsController(private val jobService: JobService) {
   @PostMapping
   fun start(
     @CookieValue("clientId") clientId: String,
+    @CookieValue("lastFmToken", defaultValue = "") lastFmSessionKey: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
     val lastFmLogin = request.lastFmLogin.trim()
@@ -34,8 +39,13 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
+    if (!lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmSessionKey)) {
+      logger.warn("Rejecting yearly job for unauthorized Last.fm login {}", lastFmLogin)
+      return ResponseEntity.status(401).build()
+    }
+
     logger.info("Starting yearly job for clientId={} lastFmLogin={}", clientId, lastFmLogin)
-    val id = jobService.startYearlyJob(clientId, lastFmLogin)
+    val id = jobService.startYearlyJob(clientId, lastFmLogin, lastFmSessionKey)
     logger.info("Yearly job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
   }
@@ -43,6 +53,7 @@ class JobsController(private val jobService: JobService) {
   @PostMapping("/forgotten-obsessions")
   fun startForgottenObsessions(
     @CookieValue("clientId") clientId: String,
+    @CookieValue("lastFmToken", defaultValue = "") lastFmSessionKey: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
     val lastFmLogin = request.lastFmLogin.trim()
@@ -54,12 +65,20 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
+    if (!lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmSessionKey)) {
+      logger.warn(
+        "Rejecting forgotten obsessions job for unauthorized Last.fm login {}",
+        lastFmLogin,
+      )
+      return ResponseEntity.status(401).build()
+    }
+
     logger.info(
       "Starting forgotten obsessions job for clientId={} lastFmLogin={}",
       clientId,
       lastFmLogin,
     )
-    val id = jobService.startForgottenObsessionsJob(clientId, lastFmLogin)
+    val id = jobService.startForgottenObsessionsJob(clientId, lastFmLogin, lastFmSessionKey)
     logger.info("Forgotten obsessions job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
   }
@@ -67,6 +86,7 @@ class JobsController(private val jobService: JobService) {
   @PostMapping("/private-mood-taxonomy")
   fun startPrivateMoodTaxonomy(
     @CookieValue("clientId") clientId: String,
+    @CookieValue("lastFmToken", defaultValue = "") lastFmSessionKey: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
     val lastFmLogin = request.lastFmLogin.trim()
@@ -78,6 +98,14 @@ class JobsController(private val jobService: JobService) {
       return ResponseEntity.badRequest().build()
     }
 
+    if (!lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmSessionKey)) {
+      logger.warn(
+        "Rejecting private mood taxonomy job for unauthorized Last.fm login {}",
+        lastFmLogin,
+      )
+      return ResponseEntity.status(401).build()
+    }
+
     logger.info(
       "Starting private mood taxonomy job for clientId={} lastFmLogin={} playlistSize={}",
       clientId,
@@ -85,7 +113,12 @@ class JobsController(private val jobService: JobService) {
       request.playlistSize,
     )
     val id =
-      jobService.startPrivateMoodTaxonomyJob(clientId, lastFmLogin, request.playlistSize ?: 50)
+      jobService.startPrivateMoodTaxonomyJob(
+        clientId,
+        lastFmLogin,
+        request.playlistSize ?: 50,
+        lastFmSessionKey,
+      )
     logger.info("Private mood taxonomy job {} scheduled", id)
     return ResponseEntity.accepted().body(JobId(id))
   }

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -28,7 +28,11 @@ class JobService(
     return jobStatusStore.findById(jobId)?.toJobStatus()
   }
 
-  fun startYearlyJob(clientId: String, lastFmLogin: String): String {
+  fun startYearlyJob(
+    clientId: String,
+    lastFmLogin: String,
+    lastFmSessionKey: String? = null,
+  ): String {
     logger.info(
       "Scheduling yearly playlist update for clientId={} lastFmLogin={}",
       clientId,
@@ -41,13 +45,17 @@ class JobService(
       startMessage = "Starting yearly playlist refresh",
       failureMessage = "Yearly playlist refresh failed",
       work = { progress ->
-        playlistService.updateYearlyPlaylists(clientId, lastFmLogin, progress)
+        playlistService.updateYearlyPlaylists(clientId, lastFmLogin, lastFmSessionKey, progress)
         JobCompletion("Yearly playlists refreshed")
       },
     )
   }
 
-  fun startForgottenObsessionsJob(clientId: String, lastFmLogin: String): String {
+  fun startForgottenObsessionsJob(
+    clientId: String,
+    lastFmLogin: String,
+    lastFmSessionKey: String? = null,
+  ): String {
     logger.info(
       "Scheduling forgotten obsessions playlist update for clientId={} lastFmLogin={}",
       clientId,
@@ -61,7 +69,12 @@ class JobService(
       failureMessage = "Forgotten obsessions playlist refresh failed",
       work = { progress ->
         val result =
-          playlistService.updateForgottenObsessionsPlaylist(clientId, lastFmLogin, progress)
+          playlistService.updateForgottenObsessionsPlaylist(
+            clientId,
+            lastFmLogin,
+            lastFmSessionKey,
+            progress,
+          )
         when {
           result.playlistId != null ->
             JobCompletion(
@@ -79,6 +92,7 @@ class JobService(
     clientId: String,
     lastFmLogin: String,
     playlistSize: Int = 50,
+    lastFmSessionKey: String? = null,
   ): String {
     logger.info(
       "Scheduling private mood taxonomy playlist update for clientId={} lastFmLogin={} playlistSize={}",
@@ -98,6 +112,7 @@ class JobService(
             clientId = clientId,
             lastFmLogin = lastFmLogin,
             playlistSize = playlistSize,
+            lastFmSessionKey = lastFmSessionKey,
             progress = progress,
           )
         JobCompletion(

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -225,14 +225,13 @@ class LastFmService(
     lastFmLogin: String,
     limit: Int = Int.MAX_VALUE,
     startPage: Int = 1,
+    sessionKey: String? = null,
   ): List<Song> {
     logger.info("Fetching yearly chartlist for user {} year {}", lastFmLogin, year)
     logger.debug("yearlyChartlist {} {} {}", spotifyClientId, year, lastFmLogin)
     if (lastFmLogin.isBlank()) throw LastFmException(400, "user is required")
     val from = LocalDate.of(year, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC)
     val to = LocalDate.of(year, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC)
-    val sessionKey = lastFmAuthService.getSessionKey(lastFmLogin)
-
     return runBlocking(Dispatchers.IO) {
       val firstPage = fetchRecent(lastFmLogin, from, to, startPage, sessionKey)
       if (firstPage.songs.isEmpty()) {

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -139,6 +139,7 @@ class SpotifyTopPlaylistsService(
   fun updateYearlyPlaylists(
     clientId: String,
     lastFmLogin: String,
+    lastFmSessionKey: String? = null,
     progress: (Int, String) -> Unit = { _, _ -> },
   ) {
     logger.debug("updateYearlyPlaylists {} {}", clientId, lastFmLogin)
@@ -165,7 +166,13 @@ class SpotifyTopPlaylistsService(
               val trackList =
                 spotifySearchService.searchTrackIds(
                   lastFmService
-                    .yearlyChartlist(clientId, year, lastFmLogin, yearlyLimit)
+                    .yearlyChartlist(
+                      clientId,
+                      year,
+                      lastFmLogin,
+                      yearlyLimit,
+                      sessionKey = lastFmSessionKey,
+                    )
                     .take(yearlyLimit),
                   clientId,
                 )
@@ -195,6 +202,7 @@ class SpotifyTopPlaylistsService(
   fun updateForgottenObsessionsPlaylist(
     clientId: String,
     lastFmLogin: String,
+    lastFmSessionKey: String? = null,
     progress: (Int, String) -> Unit = { _, _ -> },
   ): ForgottenObsessionsPlaylistResult {
     val normalizedLastFmLogin = lastFmLogin.trim()
@@ -225,7 +233,13 @@ class SpotifyTopPlaylistsService(
             yearSemaphore.withPermit {
               logger.info("Scanning forgotten obsessions candidates for year {}", year)
               val yearScrobbles =
-                lastFmService.yearlyChartlist(clientId, year, normalizedLastFmLogin, Int.MAX_VALUE)
+                lastFmService.yearlyChartlist(
+                  clientId,
+                  year,
+                  normalizedLastFmLogin,
+                  Int.MAX_VALUE,
+                  sessionKey = lastFmSessionKey,
+                )
               accumulateForgottenObsessionStats(yearScrobbles, forgottenObsessionStats)
               val completedPercent: Int
               synchronized(progressLock) {
@@ -342,6 +356,7 @@ class SpotifyTopPlaylistsService(
     clientId: String,
     lastFmLogin: String,
     playlistSize: Int = PRIVATE_MOOD_DEFAULT_PLAYLIST_SIZE,
+    lastFmSessionKey: String? = null,
     progress: (Int, String) -> Unit = { _, _ -> },
   ): PrivateMoodTaxonomyResult {
     val normalizedLastFmLogin = lastFmLogin.trim()
@@ -379,7 +394,13 @@ class SpotifyTopPlaylistsService(
             yearSemaphore.withPermit {
               logger.info("Scanning private mood history for year {}", year)
               val yearScrobbles =
-                lastFmService.yearlyChartlist(clientId, year, normalizedLastFmLogin, Int.MAX_VALUE)
+                lastFmService.yearlyChartlist(
+                  clientId,
+                  year,
+                  normalizedLastFmLogin,
+                  Int.MAX_VALUE,
+                  sessionKey = lastFmSessionKey,
+                )
               synchronized(scrobbleLock) { scrobbles += yearScrobbles }
               val completedPercent: Int
               synchronized(progressLock) {

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -4,6 +4,7 @@ import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
 import com.lis.spotify.service.JobService
+import com.lis.spotify.service.LastFmAuthenticationService
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -12,29 +13,36 @@ import org.springframework.http.HttpStatus
 
 class JobsControllerTest {
   private val service = mockk<JobService>()
-  private val controller = JobsController(service)
+  private val lastFmAuthenticationService = mockk<LastFmAuthenticationService>()
+  private val controller = JobsController(service, lastFmAuthenticationService)
 
   @Test
   fun startReturnsId() {
-    every { service.startYearlyJob("c", "login") } returns "id"
-    val resp = controller.start("c", JobsController.StartRequest("login"))
+    every { lastFmAuthenticationService.isAuthorized("login", "token") } returns true
+    every { service.startYearlyJob("c", "login", "token") } returns "id"
+    val resp = controller.start("c", "token", JobsController.StartRequest("login"))
     assertEquals(JobId("id"), resp.body)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
   }
 
   @Test
   fun startForgottenObsessionsReturnsId() {
-    every { service.startForgottenObsessionsJob("c", "login") } returns "forgotten-id"
-    val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("login"))
+    every { lastFmAuthenticationService.isAuthorized("login", "token") } returns true
+    every { service.startForgottenObsessionsJob("c", "login", "token") } returns "forgotten-id"
+    val resp =
+      controller.startForgottenObsessions("c", "token", JobsController.StartRequest("login"))
     assertEquals(JobId("forgotten-id"), resp.body)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
   }
 
   @Test
   fun startPrivateMoodTaxonomyReturnsId() {
-    every { service.startPrivateMoodTaxonomyJob("c", "login", 50) } returns "private-mood-id"
+    every { lastFmAuthenticationService.isAuthorized("login", "token") } returns true
+    every { service.startPrivateMoodTaxonomyJob("c", "login", 50, "token") } returns
+      "private-mood-id"
 
-    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("login"))
+    val resp =
+      controller.startPrivateMoodTaxonomy("c", "token", JobsController.StartRequest("login"))
 
     assertEquals(JobId("private-mood-id"), resp.body)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
@@ -42,20 +50,29 @@ class JobsControllerTest {
 
   @Test
   fun startRejectsBlankLogin() {
-    val resp = controller.start("c", JobsController.StartRequest("   "))
+    val resp = controller.start("c", "token", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
   }
 
   @Test
   fun startForgottenObsessionsRejectsBlankLogin() {
-    val resp = controller.startForgottenObsessions("c", JobsController.StartRequest("   "))
+    val resp = controller.startForgottenObsessions("c", "token", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
   }
 
   @Test
   fun startPrivateMoodTaxonomyRejectsBlankLogin() {
-    val resp = controller.startPrivateMoodTaxonomy("c", JobsController.StartRequest("   "))
+    val resp = controller.startPrivateMoodTaxonomy("c", "token", JobsController.StartRequest("   "))
     assertEquals(HttpStatus.BAD_REQUEST, resp.statusCode)
+  }
+
+  @Test
+  fun startRejectsUnauthorizedLastFmLogin() {
+    every { lastFmAuthenticationService.isAuthorized("victim", "attacker-token") } returns false
+
+    val resp = controller.start("c", "attacker-token", JobsController.StartRequest("victim"))
+
+    assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.reset as wireMockReset
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.lis.spotify.service.AuthenticationRequiredException
 import com.lis.spotify.service.ForgottenObsessionsPlaylistResult
+import com.lis.spotify.service.LastFmAuthenticationService
 import com.lis.spotify.service.PrivateMoodPlaylistResult
 import com.lis.spotify.service.PrivateMoodTaxonomyResult
 import com.lis.spotify.service.SpotifyTopPlaylistsService
@@ -40,6 +41,7 @@ class JobsControllerIT
 constructor(
   private val rest: TestRestTemplate,
   private val playlistService: SpotifyTopPlaylistsService,
+  private val lastFmAuthenticationService: LastFmAuthenticationService,
 ) {
   companion object {
     val wm = WireMockServer(WireMockConfiguration.options().dynamicPort())
@@ -73,11 +75,14 @@ constructor(
   @BeforeEach
   fun reset() {
     wireMockReset()
-    clearMocks(playlistService)
-    every { playlistService.updateYearlyPlaylists(any(), any(), any()) } returns Unit
-    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
+    clearMocks(playlistService, lastFmAuthenticationService)
+    every { lastFmAuthenticationService.isAuthorized(any(), any()) } returns true
+    every { playlistService.updateYearlyPlaylists(any(), any(), any(), any()) } returns Unit
+    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any(), any()) } returns
       ForgottenObsessionsPlaylistResult("playlist-1", 12, 12, 18)
-    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } returns
+    every {
+      playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any(), any())
+    } returns
       PrivateMoodTaxonomyResult(
         listOf(
           PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
@@ -94,7 +99,7 @@ constructor(
   @Test
   fun jobLifecycle() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
     val resp = rest.postForEntity("/jobs", req, Map::class.java)
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
@@ -109,10 +114,10 @@ constructor(
 
   @Test
   fun jobAuthFailurePreservesLastFmRedirect() {
-    every { playlistService.updateYearlyPlaylists(any(), any(), any()) } throws
+    every { playlistService.updateYearlyPlaylists(any(), any(), any(), any()) } throws
       AuthenticationRequiredException("LASTFM")
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs", req, Map::class.java)
@@ -128,7 +133,7 @@ constructor(
   @Test
   fun forgottenObsessionsJobReturnsPlaylistIds() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
@@ -143,7 +148,7 @@ constructor(
   @Test
   fun forgottenObsessionsJobRejectsBlankLogin() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
 
     val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
@@ -154,7 +159,7 @@ constructor(
   @Test
   fun privateMoodTaxonomyJobReturnsPlaylistIds() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "login"), headers)
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
@@ -172,7 +177,7 @@ constructor(
   @Test
   fun privateMoodTaxonomyJobRejectsBlankLogin() {
     val headers = HttpHeaders()
-    headers.add(HttpHeaders.COOKIE, "clientId=cid")
+    headers.add(HttpHeaders.COOKIE, "clientId=cid; lastFmToken=token")
     val req = HttpEntity(mapOf("lastFmLogin" to "   "), headers)
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
@@ -207,6 +212,12 @@ constructor(
         )
       every { svc.updateTopPlaylists(any()) } returns emptyList()
       return svc
+    }
+
+    @Bean
+    @Primary
+    fun lastFmAuthenticationService(): LastFmAuthenticationService {
+      return mockk(relaxed = true)
     }
 
     @Bean

--- a/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/JobServiceTest.kt
@@ -28,7 +28,7 @@ class JobServiceTest {
 
     val jobId = service.startYearlyJob("c", "l")
 
-    verify { playlistService.updateYearlyPlaylists("c", "l", any()) }
+    verify { playlistService.updateYearlyPlaylists("c", "l", null, any()) }
     val status = service.getJobStatus(jobId)
     assertNotNull(status)
     assertEquals(JobState.COMPLETED, status?.state)
@@ -46,13 +46,13 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updateYearlyPlaylists(any(), any(), any()) } throws
+    every { playlistService.updateYearlyPlaylists(any(), any(), null, any()) } throws
       AuthenticationRequiredException("LASTFM")
     val service = JobService(playlistService, jobStatusStore, scheduler)
 
     val jobId = service.startYearlyJob("c", "last fm")
 
-    verify { playlistService.updateYearlyPlaylists("c", "last fm", any()) }
+    verify { playlistService.updateYearlyPlaylists("c", "last fm", null, any()) }
     val status = service.getJobStatus(jobId)
     assertEquals(JobState.FAILED, status?.state)
     assertEquals("Last.fm authentication required", status?.message)
@@ -70,7 +70,7 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updateYearlyPlaylists(any(), any(), any()) } throws
+    every { playlistService.updateYearlyPlaylists(any(), any(), null, any()) } throws
       AuthenticationRequiredException("SPOTIFY")
     val service = JobService(playlistService, jobStatusStore, scheduler)
 
@@ -115,7 +115,7 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } returns
+    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), null, any()) } returns
       ForgottenObsessionsPlaylistResult("playlist-1", 12, 12, 18)
     val service = JobService(playlistService, jobStatusStore, scheduler)
 
@@ -138,7 +138,7 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), any()) } throws
+    every { playlistService.updateForgottenObsessionsPlaylist(any(), any(), null, any()) } throws
       PlaylistUpdateException(listOf("playlist-1"), IllegalStateException("boom"))
     val service = JobService(playlistService, jobStatusStore, scheduler)
 
@@ -160,7 +160,9 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } returns
+    every {
+      playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), null, any())
+    } returns
       PrivateMoodTaxonomyResult(
         listOf(
           PrivateMoodPlaylistResult("Anchor", "Private Mood - Anchor", "anchor-id", 12, 20),
@@ -198,8 +200,9 @@ class JobServiceTest {
         runnable.captured.run()
         mockk(relaxed = true)
       }
-    every { playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), any()) } throws
-      PlaylistUpdateException(listOf("anchor-id", "surge-id"), IllegalStateException("boom"))
+    every {
+      playlistService.updatePrivateMoodTaxonomyPlaylists(any(), any(), any(), null, any())
+    } throws PlaylistUpdateException(listOf("anchor-id", "surge-id"), IllegalStateException("boom"))
     val service = JobService(playlistService, jobStatusStore, scheduler)
 
     val jobId = service.startPrivateMoodTaxonomyJob("c", "login")

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -397,18 +397,32 @@ class LastFmServiceTest {
   }
 
   @Test
-  fun sessionKeyAddedToRequest() {
+  fun sessionKeyAddedToRequestOnlyWhenProvidedByCaller() {
+    val rest = mockk<RestTemplate>()
+    val service = service()
+    service.rest = rest
+    val uriSlot = io.mockk.slot<URI>()
+    every { rest.getForObject(capture(uriSlot), String::class.java) } returns recentTracksPayload(1)
+
+    service.yearlyChartlist("c", 2020, "login", sessionKey = "sess")
+
+    assertTrue(uriSlot.captured.query!!.contains("sk=sess"))
+  }
+
+  @Test
+  fun yearlyChartlistDoesNotReuseStoredSessionByLogin() {
     val rest = mockk<RestTemplate>()
     val auth = mockk<LastFmAuthenticationService>()
-    every { auth.getSessionKey("login") } returns "sess"
+    every { auth.getSessionKey(any()) } returns "victim-session"
     val service = service(auth = auth)
     service.rest = rest
     val uriSlot = io.mockk.slot<URI>()
     every { rest.getForObject(capture(uriSlot), String::class.java) } returns recentTracksPayload(1)
 
-    service.yearlyChartlist("c", 2020, "login")
+    service.yearlyChartlist("attacker-client", 2020, "victim-login")
 
-    assertTrue(uriSlot.captured.query!!.contains("sk=sess"))
+    assertTrue(!uriSlot.captured.query!!.contains("sk="))
+    io.mockk.verify(exactly = 0) { auth.getSessionKey(any()) }
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Fix a cross-tenant Last.fm session reuse vulnerability that allowed an attacker to request playlist creation for another user's Last.fm login and cause the service to attach a stored `sk` for that login to outbound Last.fm requests.
- Ensure playlist-generation work only uses a Last.fm session key when the requester proves ownership of the Last.fm account (cookie/session binding), preserving legitimate user flows without global session reuse.

### Description
- Require the `lastFmToken` cookie to be provided and validated for `/jobs` endpoints and return `401` if the provided token is not authorized for the requested Last.fm login by calling `LastFmAuthenticationService.isAuthorized(login, token)` in `JobsController`.
- Stop automatic lookup of a session key by username in `LastFmService.yearlyChartlist`; add an explicit `sessionKey: String?` parameter and only attach `sk` to Last.fm URIs when the caller supplies it.
- Thread the authorized Last.fm session key through job/playlist flows by adding optional `lastFmSessionKey` parameters to `JobService` and `SpotifyTopPlaylistsService`, and passing the validated token from the controller into scheduled jobs.
- Update and add tests to assert: job requests without a matching Last.fm token are rejected, `LastFmService` only uses an `sk` when explicitly passed, and existing job/playlists functionality remains intact.

### Testing
- Ran formatting and unit/integration tests: `./gradlew ktfmtFormat` and `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew test --no-daemon` and they completed successfully.
- Ran static/coverage checks: `./gradlew ktfmtCheck jacocoTestCoverageVerification` and `./gradlew build`, which completed successfully and preserved existing coverage checks. 
- All automated tests included with the repository passed after the changes and the build is green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035fc8032c83269defdc652bab38d5)