### PR TITLE
[codex] Fix severe auth and runtime bugs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
+++ b/src/main/kotlin/com/lis/spotify/config/ExceptionLoggingAdvice.kt
@@ -6,8 +6,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.ErrorResponse
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestCookieException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ResponseStatusException
 
 @ControllerAdvice
@@ -40,9 +46,23 @@ class ExceptionLoggingAdvice {
     return ResponseEntity.status(ex.statusCode).body(ex.reason)
   }
 
+  @ExceptionHandler(
+    HttpMessageNotReadableException::class,
+    MissingRequestCookieException::class,
+    MissingServletRequestParameterException::class,
+    MethodArgumentNotValidException::class,
+    MethodArgumentTypeMismatchException::class,
+  )
+  fun handleBadRequest(ex: Exception): ResponseEntity<String> {
+    val status = (ex as? ErrorResponse)?.statusCode ?: HttpStatus.BAD_REQUEST
+    val detail = (ex as? ErrorResponse)?.body?.detail ?: "Bad request"
+    logger.warn("Request rejected with status {} {}", status, detail)
+    return ResponseEntity.status(status).body(detail)
+  }
+
   @ExceptionHandler(Exception::class)
   fun handle(ex: Exception): ResponseEntity<String> {
     logger.error("Unhandled exception", ex)
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.message)
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal server error")
   }
 }

--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -6,7 +6,10 @@ import com.lis.spotify.service.JobLimitExceededException
 import com.lis.spotify.service.JobService
 import com.lis.spotify.service.LastFmAuthenticationService
 import com.lis.spotify.service.SpotifyAuthenticationService
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.CookieValue
@@ -29,7 +32,7 @@ class JobsController(
 
   @PostMapping
   fun start(
-    @CookieValue("clientId") clientId: String,
+    @CookieValue("clientId", defaultValue = "") clientId: String,
     @CookieValue("lastFmToken", defaultValue = "") lastFmToken: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
@@ -47,7 +50,7 @@ class JobsController(
 
     if (!lastFmAuthenticationService.isAuthorized(lastFmLogin, lastFmToken)) {
       logger.warn("Rejecting yearly job for unauthorized Last.fm login={}", lastFmLogin)
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+      return lastFmAuthenticationRequired(lastFmLogin)
     }
 
     return startJob("yearly", clientId) {
@@ -57,7 +60,7 @@ class JobsController(
 
   @PostMapping("/forgotten-obsessions")
   fun startForgottenObsessions(
-    @CookieValue("clientId") clientId: String,
+    @CookieValue("clientId", defaultValue = "") clientId: String,
     @CookieValue("lastFmToken", defaultValue = "") lastFmToken: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
@@ -81,7 +84,7 @@ class JobsController(
         "Rejecting forgotten obsessions job for unauthorized Last.fm login={}",
         lastFmLogin,
       )
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+      return lastFmAuthenticationRequired(lastFmLogin)
     }
 
     return startJob("forgotten obsessions", clientId) {
@@ -91,7 +94,7 @@ class JobsController(
 
   @PostMapping("/private-mood-taxonomy")
   fun startPrivateMoodTaxonomy(
-    @CookieValue("clientId") clientId: String,
+    @CookieValue("clientId", defaultValue = "") clientId: String,
     @CookieValue("lastFmToken", defaultValue = "") lastFmToken: String,
     @RequestBody request: StartRequest,
   ): ResponseEntity<JobId> {
@@ -116,7 +119,7 @@ class JobsController(
         lastFmLogin,
         clientId,
       )
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+      return lastFmAuthenticationRequired(lastFmLogin)
     }
 
     return startJob("private mood taxonomy", clientId) {
@@ -137,9 +140,21 @@ class JobsController(
   }
 
   @GetMapping("/{jobId}")
-  fun getStatus(@PathVariable jobId: String): ResponseEntity<JobStatus> {
-    val status = jobService.getJobStatus(jobId) ?: return ResponseEntity.notFound().build()
+  fun getStatus(
+    @CookieValue("clientId", defaultValue = "") clientId: String,
+    @PathVariable jobId: String,
+  ): ResponseEntity<JobStatus> {
+    requireAuthorizedSession(clientId)
+    val status =
+      jobService.getJobStatus(jobId, clientId) ?: return ResponseEntity.notFound().build()
     return ResponseEntity.ok(status)
+  }
+
+  private fun lastFmAuthenticationRequired(lastFmLogin: String): ResponseEntity<JobId> {
+    val encodedLogin = URLEncoder.encode(lastFmLogin, StandardCharsets.UTF_8)
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+      .header(HttpHeaders.LOCATION, "/auth/lastfm?lastFmLogin=$encodedLogin")
+      .build()
   }
 
   private fun startJob(

--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -4,6 +4,8 @@ import com.lis.spotify.service.LastFmAuthenticationService
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import java.security.SecureRandom
+import java.util.Base64
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,12 +32,19 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
     value: String,
     request: HttpServletRequest,
     httpOnly: Boolean,
+    maxAgeSeconds: Int? = null,
   ): Cookie {
     return Cookie(name, value).apply {
       path = "/"
       isHttpOnly = httpOnly
       secure = isSecureRequest(request)
+      setAttribute("SameSite", "Lax")
+      maxAgeSeconds?.let { maxAge = it }
     }
+  }
+
+  private fun clearCookie(name: String, request: HttpServletRequest): Cookie {
+    return createCookie(name, "", request, httpOnly = true).apply { maxAge = 0 }
   }
 
   private fun getCookieValue(request: HttpServletRequest, name: String): String? {
@@ -44,6 +53,12 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       .firstOrNull { it.name == name }
       ?.value
       ?.takeIf { it.isNotBlank() }
+  }
+
+  private fun createState(): String {
+    val bytes = ByteArray(24)
+    stateRandom.nextBytes(bytes)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
   }
 
   @GetMapping("/auth/lastfm")
@@ -59,18 +74,44 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
       ?.let {
         response.addCookie(createCookie(LAST_FM_LOGIN_COOKIE, it, request, httpOnly = false))
       }
-    val authUrl = lastFmAuthService.getAuthorizationUrl()
-    logger.info("Redirecting user to Last.fm auth URL: $authUrl")
+    val state = createState()
+    response.addCookie(
+      createCookie(
+        LAST_FM_AUTH_STATE_COOKIE,
+        state,
+        request,
+        httpOnly = true,
+        maxAgeSeconds = AUTH_STATE_COOKIE_MAX_AGE_SECONDS,
+      )
+    )
+    val authUrl = lastFmAuthService.getAuthorizationUrl(state)
+    logger.info("Redirecting user to Last.fm auth URL")
     return RedirectView(authUrl)
   }
 
   @GetMapping("/auth/lastfm/callback")
   fun handleCallback(
     @RequestParam token: String?,
+    @RequestParam(required = false) state: String?,
     request: HttpServletRequest,
     response: HttpServletResponse,
   ): String {
-    logger.debug("handleCallback token={}", token)
+    logger.debug(
+      "handleCallback tokenPresent={} statePresent={}",
+      !token.isNullOrBlank(),
+      !state.isNullOrBlank(),
+    )
+    val expectedState = getCookieValue(request, LAST_FM_AUTH_STATE_COOKIE)
+    if (expectedState.isNullOrBlank() || state.isNullOrBlank() || state != expectedState) {
+      logger.warn(
+        "Rejecting Last.fm callback because OAuth state validation failed. expectedPresent={} actualPresent={}",
+        !expectedState.isNullOrBlank(),
+        !state.isNullOrBlank(),
+      )
+      response.addCookie(clearCookie(LAST_FM_AUTH_STATE_COOKIE, request))
+      return "redirect:/error"
+    }
+    response.addCookie(clearCookie(LAST_FM_AUTH_STATE_COOKIE, request))
     if (token.isNullOrEmpty()) {
       logger.warn("Token is missing in Last.fm callback")
       return "redirect:/error"
@@ -96,6 +137,9 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
   companion object {
     private const val LAST_FM_LOGIN_COOKIE = "lastFmLogin"
     private const val LAST_FM_TOKEN_COOKIE = "lastFmToken"
+    private const val LAST_FM_AUTH_STATE_COOKIE = "lastFmAuthState"
+    private const val AUTH_STATE_COOKIE_MAX_AGE_SECONDS = 300
+    private val stateRandom = SecureRandom()
     private val logger = LoggerFactory.getLogger(LastFmAuthenticationController::class.java)
   }
 }

--- a/src/main/kotlin/com/lis/spotify/controller/MainController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/MainController.kt
@@ -26,10 +26,10 @@ class MainController(
     @CookieValue("lastFmToken", defaultValue = "") lastFmToken: String,
   ): String {
     logger.debug(
-      "Entering main() with clientId='{}', lastFmLogin='{}' and lastFmToken='{}'",
+      "Entering main() with clientId='{}', lastFmLogin='{}' and lastFmTokenPresent={}",
       clientId,
       lastFmLogin,
-      lastFmToken,
+      lastFmToken.isNotBlank(),
     )
 
     val spotifyAuthorized =

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
@@ -4,6 +4,7 @@ import com.lis.spotify.AppEnvironment.Spotify
 import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.domain.User
 import com.lis.spotify.service.SpotifyAuthenticationService
+import com.lis.spotify.service.withDefaultTimeouts
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -31,21 +32,14 @@ class SpotifyAuthenticationController(
   private val restTemplateBuilder: RestTemplateBuilder,
 ) {
 
-  private fun callbackUrl(request: HttpServletRequest): String {
-    val proto = request.getHeader("X-Forwarded-Proto") ?: request.scheme
-    val host = request.getHeader("X-Forwarded-Host") ?: request.serverName
-    val portHeader = request.getHeader("X-Forwarded-Port")
-    val port = portHeader ?: request.serverPort.toString()
-    val defaultPort = if (proto == "https") "443" else "80"
-    val portPart = if (port == defaultPort || port.isEmpty()) "" else ":$port"
-    return "$proto://$host$portPart" + Spotify.CALLBACK_PATH
-  }
+  private fun callbackUrl(): String = Spotify.CALLBACK_URL
 
   fun getCurrentUserId(token: AuthToken): String? {
     logger.debug("Attempting to retrieve current user ID using provided AuthToken.")
     return try {
       val response =
         restTemplateBuilder
+          .withDefaultTimeouts()
           .build()
           .exchange<User>(
             Spotify.USER_INFO_URL,
@@ -105,8 +99,8 @@ class SpotifyAuthenticationController(
     @RequestParam(required = false) state: String?,
     response: HttpServletResponse,
   ): String {
-    logger.debug("callback with code {}", code)
-    logger.info("Received callback from Spotify with code: {}", code)
+    logger.debug("callback with codePresent={}", code.isNotBlank())
+    logger.info("Received callback from Spotify")
 
     val expectedState = getCookieValue(request, SPOTIFY_AUTH_STATE_COOKIE)
     if (expectedState.isNullOrBlank() || state.isNullOrBlank() || state != expectedState) {
@@ -125,13 +119,14 @@ class SpotifyAuthenticationController(
       LinkedMultiValueMap<String, String>().apply {
         add("grant_type", "authorization_code")
         add("code", code)
-        add("redirect_uri", callbackUrl(request))
+        add("redirect_uri", callbackUrl())
       }
     val entity = HttpEntity(body, headers)
 
     return try {
       val authToken =
         restTemplateBuilder
+          .withDefaultTimeouts()
           .basicAuthentication(Spotify.CLIENT_ID, Spotify.CLIENT_SECRET)
           .build()
           .postForObject<AuthToken>(Spotify.TOKEN_URL, entity)
@@ -171,7 +166,7 @@ class SpotifyAuthenticationController(
         .queryParam("response_type", "code")
         .queryParam("client_id", Spotify.CLIENT_ID)
         .queryParam("scope", Spotify.SCOPES)
-        .queryParam("redirect_uri", callbackUrl(request))
+        .queryParam("redirect_uri", callbackUrl())
         .queryParam("state", state)
     logger.debug("Redirecting user to Spotify authorization URL.")
     return "redirect:" + builder.toUriString()

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
@@ -31,7 +31,7 @@ class SpotifyBandPlaylistController(
 ) {
   @PostMapping("/bandPlaylist")
   fun createBandPlaylist(
-    @CookieValue("clientId") clientId: String,
+    @CookieValue("clientId", defaultValue = "") clientId: String,
     @RequestBody request: BandPlaylistRequest,
   ): ResponseEntity<String> {
     requireAuthorizedSession(clientId)

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -29,7 +29,9 @@ class SpotifyTopPlaylistsController(
   private val spotifyAuthenticationService: SpotifyAuthenticationService,
 ) {
   @PostMapping("/updateTopPlaylists")
-  fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
+  fun updateTopPlaylists(
+    @CookieValue("clientId", defaultValue = "") clientId: String
+  ): List<String> {
     requireAuthorizedSession(clientId)
     logger.info("Updating top playlists for {}", clientId)
     logger.debug("updateTopPlaylists for {}", clientId)

--- a/src/main/kotlin/com/lis/spotify/service/HttpClientTimeouts.kt
+++ b/src/main/kotlin/com/lis/spotify/service/HttpClientTimeouts.kt
@@ -1,0 +1,11 @@
+package com.lis.spotify.service
+
+import java.time.Duration
+import org.springframework.boot.web.client.RestTemplateBuilder
+
+internal val DEFAULT_HTTP_CONNECT_TIMEOUT: Duration = Duration.ofSeconds(5)
+internal val DEFAULT_HTTP_READ_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+internal fun RestTemplateBuilder.withDefaultTimeouts(): RestTemplateBuilder {
+  return connectTimeout(DEFAULT_HTTP_CONNECT_TIMEOUT).readTimeout(DEFAULT_HTTP_READ_TIMEOUT)
+}

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -29,10 +29,20 @@ class JobService(
   private val activeClients = ConcurrentHashMap.newKeySet<String>()
   private val clientStartTimes = ConcurrentHashMap<String, ArrayDeque<Instant>>()
 
-  fun getJobStatus(jobId: String): JobStatus? {
+  fun getJobStatus(jobId: String, clientId: String? = null): JobStatus? {
     val now = Instant.now(clock)
     jobStatusStore.deleteExpired(now)
-    return jobStatusStore.findById(jobId)?.takeIf { it.expiresAt.isAfter(now) }?.toJobStatus()
+    val storedStatus =
+      jobStatusStore.findById(jobId)?.takeIf { it.expiresAt.isAfter(now) } ?: return null
+    if (clientId != null && storedStatus.clientId != clientId) {
+      logger.warn(
+        "Rejecting job status read for jobId={} by non-owner clientId={}",
+        jobId,
+        clientId,
+      )
+      return null
+    }
+    return storedStatus.toJobStatus()
   }
 
   fun startYearlyJob(

--- a/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmAuthenticationService.kt
@@ -9,13 +9,13 @@ import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.LoggerFactory
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
-import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 
 /**
@@ -26,9 +26,12 @@ import org.springframework.web.util.UriComponentsBuilder
  * secret, and then generating an MD5 hash.
  */
 @Service
-class LastFmAuthenticationService(private val lastFmSessionStore: LastFmSessionStore) {
+class LastFmAuthenticationService(
+  private val lastFmSessionStore: LastFmSessionStore,
+  restTemplateBuilder: RestTemplateBuilder = RestTemplateBuilder(),
+) {
 
-  private val restTemplate = RestTemplate()
+  private val restTemplate = restTemplateBuilder.withDefaultTimeouts().build()
   private val logger = LoggerFactory.getLogger(LastFmAuthenticationService::class.java)
   private val clock: Clock = Clock.systemUTC()
   private val sessionCache = ConcurrentHashMap<String, String>()
@@ -79,13 +82,18 @@ class LastFmAuthenticationService(private val lastFmSessionStore: LastFmSessionS
    *
    * Format: https://www.last.fm/api/auth/?api_key=xxx&cb=<redirectUri>
    */
-  fun getAuthorizationUrl(): String {
+  fun getAuthorizationUrl(state: String? = null): String {
     logger.debug("getAuthorizationUrl() called")
+    val callbackUrl =
+      UriComponentsBuilder.fromHttpUrl(LastFm.CALLBACK_URL)
+        .apply { state?.takeIf { it.isNotBlank() }?.let { queryParam("state", it) } }
+        .build()
+        .toUriString()
     return UriComponentsBuilder.fromHttpUrl(LastFm.AUTHORIZE_URL)
       .queryParam("api_key", LastFm.API_KEY)
       .queryParam("cb", "{cb}")
       .encode()
-      .buildAndExpand(LastFm.CALLBACK_URL)
+      .buildAndExpand(callbackUrl)
       .toUriString()
   }
 
@@ -103,7 +111,7 @@ class LastFmAuthenticationService(private val lastFmSessionStore: LastFmSessionS
    * @return A map containing session data if successful; otherwise, null.
    */
   fun getSession(token: String): Map<String, Any>? {
-    logger.debug("getSession called with token {}", token)
+    logger.debug("getSession called with tokenPresent={}", token.isNotBlank())
     val method = "auth.getSession"
     // Create signature string:
     // "api_keyYOUR_API_KEYmethodauth.getSessiontokenYOUR_TOKENYOUR_API_SECRET"
@@ -137,7 +145,7 @@ class LastFmAuthenticationService(private val lastFmSessionStore: LastFmSessionS
       }
       body
     } catch (ex: Exception) {
-      logger.error("Error getting session for token $token", ex)
+      logger.error("Error getting Last.fm session", ex)
       null
     }
   }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -25,10 +25,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.ResourceAccessException
-import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 
 @Service
@@ -43,9 +43,10 @@ class LastFmService(
   @Value("\${lastfm.recent-tracks.persistent-cache.enabled:false}")
   configuredPersistentRecentTracksCacheEnabled: Boolean =
     DEFAULT_PERSISTENT_RECENT_TRACKS_CACHE_ENABLED,
+  restTemplateBuilder: RestTemplateBuilder = RestTemplateBuilder(),
 ) {
 
-  internal var rest = RestTemplate()
+  internal var rest = restTemplateBuilder.withDefaultTimeouts().build()
   internal var sleeper: LastFmSleeper = LastFmSleeper { millis -> Thread.sleep(millis) }
   internal var recentTracksParallelism = configuredRecentTracksParallelism.coerceAtLeast(1)
   internal var cacheTtl = configuredCacheTtl

--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -21,7 +22,6 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.ResourceAccessException
-import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 
 @Service
@@ -38,8 +38,9 @@ class LyricsService(
   configuredOpenAiModel: String = DEFAULT_OPENAI_MODEL,
   @Value("\${lyrics.mood.openai.batch-size:8}")
   configuredOpenAiBatchSize: Int = DEFAULT_OPENAI_BATCH_SIZE,
+  restTemplateBuilder: RestTemplateBuilder = RestTemplateBuilder(),
 ) {
-  internal var rest = RestTemplate()
+  internal var rest = restTemplateBuilder.withDefaultTimeouts().build()
   internal var mapper = jacksonObjectMapper()
   internal var baseUrl = configuredBaseUrl.trimEnd('/')
   internal var fetchParallelism = configuredFetchParallelism.coerceAtLeast(1)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -160,6 +160,7 @@ class SpotifyAuthenticationService(
     return try {
       val authToken =
         restTemplateBuilder
+          .withDefaultTimeouts()
           .basicAuthentication(Spotify.CLIENT_ID, Spotify.CLIENT_SECRET)
           .build()
           .postForObject<AuthToken>(tokenUrl, entity)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
@@ -33,7 +33,10 @@ class SpotifyRestService(
 ) {
 
   val restTemplate: RestTemplate =
-    restTemplateBuilder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java).build()
+    restTemplateBuilder
+      .withDefaultTimeouts()
+      .requestFactory(HttpComponentsClientHttpRequestFactory::class.java)
+      .build()
   private val retryTemplate: RetryTemplate =
     RetryTemplate.builder()
       .maxAttempts(3)

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
@@ -121,7 +121,7 @@ class SpotifyTopPlaylistsRefreshService(
         lastPlaylistIds = previousState?.lastPlaylistIds.orEmpty(),
         updatedAt = Instant.now(clock),
       )
-      throw ex
+      null
     }
   }
 

--- a/src/main/resources/static/index.js
+++ b/src/main/resources/static/index.js
@@ -48,7 +48,7 @@ function appendPlayButton(div, playlistId, label) {
 }
 
 function renderPlaylistEmbeds(div, playlistIds, labels) {
-    $('#' + div).empty();
+    $('#' + div + ' .playlist-embed').remove();
     for (var i = 0; i < playlistIds.length; i += 1) {
         appendPlayButton(div, playlistIds[i], labels && labels[i] ? labels[i] : null);
     }
@@ -294,7 +294,16 @@ function startLastfmJob(jobPath, startMessage, failureMessage, playlistConfig) {
             }
             pollLastfmJob(data.jobId);
         },
-        error: function () {
+        error: function (xhr) {
+            var redirectUrl = xhr.getResponseHeader('Location');
+            if (redirectUrl) {
+                lastFmJobRunning = false;
+                lastFmPlaylistConfig = null;
+                updateLastfmButtonState();
+                setLastfmStatus('Last.fm authentication required. Redirecting...');
+                redirectToLastfmAuth(redirectUrl);
+                return;
+            }
             lastFmJobRunning = false;
             lastFmPlaylistConfig = null;
             updateLastfmButtonState();

--- a/src/test/kotlin/com/lis/spotify/config/ExceptionLoggingAdviceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/config/ExceptionLoggingAdviceTest.kt
@@ -4,6 +4,7 @@ import com.lis.spotify.service.LastFmException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 class ExceptionLoggingAdviceTest {
   @Test
@@ -12,5 +13,23 @@ class ExceptionLoggingAdviceTest {
     val result = advice.handleLastFm(LastFmException(17, "Login"))
     assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
     assertEquals("/auth/lastfm", result.headers.location.toString())
+  }
+
+  @Test
+  fun responseStatusExceptionPreservesStatus() {
+    val advice = ExceptionLoggingAdvice()
+    val result = advice.handleResponseStatus(ResponseStatusException(HttpStatus.BAD_REQUEST, "bad"))
+
+    assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
+    assertEquals("bad", result.body)
+  }
+
+  @Test
+  fun genericExceptionDoesNotLeakMessage() {
+    val advice = ExceptionLoggingAdvice()
+    val result = advice.handle(IllegalStateException("secret"))
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.statusCode)
+    assertEquals("Internal server error", result.body)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/JobsControllerTest.kt
@@ -90,7 +90,8 @@ class JobsControllerTest {
         JobsController.StartRequest("victim"),
       )
 
-    assertEquals(HttpStatus.FORBIDDEN, resp.statusCode)
+    assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
+    assertEquals("/auth/lastfm?lastFmLogin=victim", resp.headers.location.toString())
     verify(exactly = 0) { service.startPrivateMoodTaxonomyJob(any(), any(), any(), any()) }
   }
 
@@ -119,6 +120,7 @@ class JobsControllerTest {
     val resp = controller.start("c", "attacker-token", JobsController.StartRequest("victim"))
 
     assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
+    assertEquals("/auth/lastfm?lastFmLogin=victim", resp.headers.location.toString())
     verify(exactly = 0) { service.startYearlyJob(any(), any(), any()) }
   }
 
@@ -137,11 +139,21 @@ class JobsControllerTest {
   @Test
   fun getStatusReturnsJobStatus() {
     val status = JobStatus("id", JobState.RUNNING, 25, "Processing 2025 (1/21)")
-    every { service.getJobStatus("id") } returns status
+    every { service.getJobStatus("id", "c") } returns status
 
-    val response = controller.getStatus("id")
+    val response = controller.getStatus("c", "id")
 
     assertEquals(HttpStatus.OK, response.statusCode)
     assertEquals(status, response.body)
+  }
+
+  @Test
+  fun getStatusReturnsNotFoundForDifferentClient() {
+    every { authService.isAuthorizedSession("other") } returns true
+    every { service.getJobStatus("id", "other") } returns null
+
+    val response = controller.getStatus("other", "id")
+
+    assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -23,33 +23,48 @@ class LastFmAuthenticationControllerTest {
     every { request.scheme } returns "https"
     every { request.isSecure } returns true
 
-    every { service.getAuthorizationUrl() } returns "http://x"
+    every { service.getAuthorizationUrl(any()) } returns "http://x"
+    val response = mockk<HttpServletResponse>(relaxed = true)
+    val cookies = mutableListOf<Cookie>()
+    every { response.addCookie(capture(cookies)) } answers {}
 
-    val view = controller.authenticateUser(request, mockk(relaxed = true), "login")
+    val view = controller.authenticateUser(request, response, "login")
 
     assertEquals("http://x", view.url)
-    verify { service.getAuthorizationUrl() }
+    assertTrue(cookies.any { it.name == "lastFmAuthState" && it.isHttpOnly && it.maxAge == 300 })
+    verify { service.getAuthorizationUrl(any()) }
   }
 
   @Test
   fun handleCallbackWithToken() {
     every { service.getSession("tok") } returns
       mapOf("session" to mapOf("key" to "v", "name" to "login"))
-    val result = controller.handleCallback("tok", mockk(relaxed = true), mockk(relaxed = true))
+    val result =
+      controller.handleCallback("tok", "state", requestWithState(), mockk(relaxed = true))
     assertTrue(result.startsWith("redirect:/"))
   }
 
   @Test
   fun handleCallbackMissingToken() {
-    val result = controller.handleCallback(null, mockk(relaxed = true), mockk(relaxed = true))
+    val result = controller.handleCallback(null, "state", requestWithState(), mockk(relaxed = true))
     assertEquals("redirect:/error", result)
   }
 
   @Test
   fun handleCallbackNoSession() {
     every { service.getSession("tok") } returns null
-    val result = controller.handleCallback("tok", mockk(relaxed = true), mockk(relaxed = true))
+    val result =
+      controller.handleCallback("tok", "state", requestWithState(), mockk(relaxed = true))
     assertEquals("redirect:/error", result)
+  }
+
+  @Test
+  fun handleCallbackRejectsInvalidState() {
+    val response = mockk<HttpServletResponse>(relaxed = true)
+    val result = controller.handleCallback("tok", "wrong", requestWithState(), response)
+
+    assertEquals("redirect:/error", result)
+    verify(exactly = 0) { service.getSession(any()) }
   }
 
   @Test
@@ -60,21 +75,21 @@ class LastFmAuthenticationControllerTest {
     every { request.getHeader(any()) } returns null
     every { request.scheme } returns "http"
     every { request.isSecure } returns false
-    every { request.cookies } returns emptyArray()
+    every { request.cookies } returns arrayOf(Cookie("lastFmAuthState", "state"))
 
     val response = mockk<HttpServletResponse>(relaxed = true)
     val cookies = mutableListOf<Cookie>()
     every { response.addCookie(capture(cookies)) } answers {}
 
-    controller.handleCallback("tok", request, response)
+    controller.handleCallback("tok", "state", request, response)
 
-    verify(exactly = 2) { response.addCookie(any()) }
-    assertEquals("/", cookies[0].path)
-    assertTrue(cookies[0].isHttpOnly)
-    assertEquals(false, cookies[0].secure)
-    assertEquals("lastFmToken", cookies[0].name)
-    assertEquals("lastFmLogin", cookies[1].name)
-    assertFalse(cookies[1].isHttpOnly)
+    verify(exactly = 3) { response.addCookie(any()) }
+    val tokenCookie = cookies.first { it.name == "lastFmToken" }
+    val loginCookie = cookies.first { it.name == "lastFmLogin" }
+    assertEquals("/", tokenCookie.path)
+    assertTrue(tokenCookie.isHttpOnly)
+    assertEquals(false, tokenCookie.secure)
+    assertFalse(loginCookie.isHttpOnly)
     verify { service.setSession("login", "v") }
   }
 
@@ -85,12 +100,22 @@ class LastFmAuthenticationControllerTest {
     every { request.getHeader(any()) } returns null
     every { request.scheme } returns "http"
     every { request.isSecure } returns false
-    every { request.cookies } returns arrayOf(Cookie("lastFmLogin", "saved-login"))
+    every { request.cookies } returns
+      arrayOf(Cookie("lastFmLogin", "saved-login"), Cookie("lastFmAuthState", "state"))
 
     val response = mockk<HttpServletResponse>(relaxed = true)
 
-    controller.handleCallback("tok", request, response)
+    controller.handleCallback("tok", "state", request, response)
 
     verify { service.setSession("saved-login", "v") }
+  }
+
+  private fun requestWithState(): HttpServletRequest {
+    val request = mockk<HttpServletRequest>()
+    every { request.getHeader(any()) } returns null
+    every { request.scheme } returns "http"
+    every { request.isSecure } returns false
+    every { request.cookies } returns arrayOf(Cookie("lastFmAuthState", "state"))
+    return request
   }
 }

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -25,7 +25,7 @@ import org.springframework.web.client.RestTemplate
 class SpotifyAuthenticationControllerTest {
   private val spotifyService = mockk<SpotifyAuthenticationService>(relaxed = true)
   private val restTemplate = mockk<RestTemplate>()
-  private val builder = mockk<RestTemplateBuilder>()
+  private val builder = timeoutBuilder()
   private val controller = SpotifyAuthenticationController(spotifyService, builder)
 
   @Test
@@ -158,5 +158,12 @@ class SpotifyAuthenticationControllerTest {
         match { it.name == "spotifyAuthState" && it.maxAge == 0 && it.path == "/" && !it.secure }
       )
     }
+  }
+
+  private fun timeoutBuilder(): RestTemplateBuilder {
+    val builder = mockk<RestTemplateBuilder>()
+    every { builder.connectTimeout(any()) } returns builder
+    every { builder.readTimeout(any()) } returns builder
+    return builder
   }
 }

--- a/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/JobsControllerIT.kt
@@ -124,7 +124,7 @@ constructor(
     assertEquals(HttpStatus.ACCEPTED, resp.statusCode)
     val jobId = resp.body?.get("jobId") as String
 
-    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+    val status = getJobStatus(jobId)
 
     assertEquals(HttpStatus.OK, status.statusCode)
     assertEquals("COMPLETED", status.body?.get("state"))
@@ -142,7 +142,7 @@ constructor(
     val resp = rest.postForEntity("/jobs", req, Map::class.java)
     val jobId = resp.body?.get("jobId") as String
 
-    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+    val status = getJobStatus(jobId)
 
     assertEquals(HttpStatus.OK, status.statusCode)
     assertEquals("FAILED", status.body?.get("state"))
@@ -157,7 +157,7 @@ constructor(
 
     val resp = rest.postForEntity("/jobs/forgotten-obsessions", req, Map::class.java)
     val jobId = resp.body?.get("jobId") as String
-    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+    val status = getJobStatus(jobId)
 
     assertEquals(HttpStatus.OK, status.statusCode)
     assertEquals("COMPLETED", status.body?.get("state"))
@@ -183,7 +183,7 @@ constructor(
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
     val jobId = resp.body?.get("jobId") as String
-    val status = rest.getForEntity("/jobs/$jobId", Map::class.java)
+    val status = getJobStatus(jobId)
 
     assertEquals(HttpStatus.OK, status.statusCode)
     assertEquals("COMPLETED", status.body?.get("state"))
@@ -213,7 +213,20 @@ constructor(
 
     val resp = rest.postForEntity("/jobs/private-mood-taxonomy", req, Map::class.java)
 
-    assertEquals(HttpStatus.FORBIDDEN, resp.statusCode)
+    assertEquals(HttpStatus.UNAUTHORIZED, resp.statusCode)
+    assertEquals("/auth/lastfm?lastFmLogin=victim", resp.headers.location.toString())
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun getJobStatus(jobId: String): ResponseEntity<Map<String, Any>> {
+    val headers = HttpHeaders()
+    headers.add(HttpHeaders.COOKIE, "clientId=$TEST_SESSION_ID")
+    return rest.exchange(
+      "/jobs/$jobId",
+      HttpMethod.GET,
+      HttpEntity<String>(headers),
+      Map::class.java,
+    ) as ResponseEntity<Map<String, Any>>
   }
 
   class Config {

--- a/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
+++ b/src/test/kotlin/com/lis/spotify/integration/LastFmAuthenticationControllerIT.kt
@@ -86,6 +86,7 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
       { assertTrue(response.headers.location!!.toString().startsWith(baseUrl)) },
       { assertTrue(cookies.any { it.contains("lastFmLogin=saved-login") }) },
+      { assertTrue(cookies.any { it.contains("lastFmAuthState=") }) },
     )
   }
 
@@ -114,6 +115,7 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
       { assertFalse(decodedLocation.contains("attacker.example")) },
       { assertTrue(decodedLocation.contains("cb=http://localhost/auth/lastfm/callback")) },
+      { assertTrue(decodedLocation.contains("state=")) },
     )
   }
 
@@ -127,7 +129,15 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
       rest.withRequestFactorySettings {
         it.withRedirects(ClientHttpRequestFactorySettings.Redirects.DONT_FOLLOW)
       }
-    val response = noRedirect.getForEntity("/auth/lastfm/callback?token=t", String::class.java)
+    val headers = org.springframework.http.HttpHeaders()
+    headers.add(org.springframework.http.HttpHeaders.COOKIE, "lastFmAuthState=state")
+    val response =
+      noRedirect.exchange(
+        "/auth/lastfm/callback?token=t&state=state",
+        org.springframework.http.HttpMethod.GET,
+        org.springframework.http.HttpEntity<String>(headers),
+        String::class.java,
+      )
     val cookies = response.headers["Set-Cookie"].orEmpty()
     assertAll(
       { assertEquals(HttpStatus.FOUND, response.statusCode) },
@@ -145,11 +155,14 @@ class LastFmAuthenticationControllerIT @Autowired constructor(private val rest: 
         it.withRedirects(ClientHttpRequestFactorySettings.Redirects.DONT_FOLLOW)
       }
     val headers = org.springframework.http.HttpHeaders()
-    headers.add(org.springframework.http.HttpHeaders.COOKIE, "lastFmLogin=remembered")
+    headers.add(
+      org.springframework.http.HttpHeaders.COOKIE,
+      "lastFmLogin=remembered; lastFmAuthState=state",
+    )
 
     val response =
       noRedirect.exchange(
-        "/auth/lastfm/callback?token=t",
+        "/auth/lastfm/callback?token=t&state=state",
         org.springframework.http.HttpMethod.GET,
         org.springframework.http.HttpEntity<String>(headers),
         String::class.java,

--- a/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmAuthenticationServiceTest.kt
@@ -28,6 +28,15 @@ class LastFmAuthenticationServiceTest {
   }
 
   @Test
+  fun getAuthorizationUrlIncludesStateInCallback() {
+    val service = LastFmAuthenticationService(InMemoryLastFmSessionStore())
+    val url = service.getAuthorizationUrl("state-value")
+    val encoded =
+      URLEncoder.encode("${AppEnvironment.LastFm.CALLBACK_URL}?state=state-value", "UTF-8")
+    assert(url.contains("cb=$encoded"))
+  }
+
+  @Test
   fun getSessionHandlesResponse() {
     val rest = mockk<RestTemplate>()
     val service = LastFmAuthenticationService(InMemoryLastFmSessionStore())

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -23,6 +23,8 @@ class SpotifyAuthenticationServiceTest {
   private val service = SpotifyAuthenticationService(builder, store)
 
   init {
+    every { builder.connectTimeout(any()) } returns builder
+    every { builder.readTimeout(any()) } returns builder
     every { builder.build() } returns restTemplate
   }
 

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyRestServiceTest.kt
@@ -28,7 +28,7 @@ class SpotifyRestServiceTest {
   @Test
   fun doGetRetriesAndReturns() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -52,7 +52,7 @@ class SpotifyRestServiceTest {
   @Test
   fun postAndDeleteReturnValues() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -87,7 +87,7 @@ class SpotifyRestServiceTest {
   @Test
   fun postReturnsUnitWhenBodyIsNull() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -111,7 +111,7 @@ class SpotifyRestServiceTest {
   @Test
   fun retriesOnTooManyRequests() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -143,7 +143,7 @@ class SpotifyRestServiceTest {
   @Test
   fun usesRetryAfterHeaderAsBackoff() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     val sleeper = mockk<Sleeper>(relaxUnitFun = true)
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
@@ -177,7 +177,7 @@ class SpotifyRestServiceTest {
   @Test
   fun unauthorizedThrowsAuthExceptionWhenRefreshFails() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -212,7 +212,7 @@ class SpotifyRestServiceTest {
   @Test
   fun unauthorizedRetriesOnceAfterRefreshingToken() {
     val restTemplate = mockk<RestTemplate>()
-    val builder = mockk<RestTemplateBuilder>()
+    val builder = timeoutBuilder()
     val auth = mockk<SpotifyAuthenticationService>()
     every { builder.requestFactory(HttpComponentsClientHttpRequestFactory::class.java) } returns
       builder
@@ -242,5 +242,12 @@ class SpotifyRestServiceTest {
 
     assertEquals("ok", result)
     verify(exactly = 1) { auth.refreshToken("cid") }
+  }
+
+  private fun timeoutBuilder(): RestTemplateBuilder {
+    val builder = mockk<RestTemplateBuilder>()
+    every { builder.connectTimeout(any()) } returns builder
+    every { builder.readTimeout(any()) } returns builder
+    return builder
   }
 }

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class SpotifyTopPlaylistsRefreshServiceTest {
   @Test
@@ -161,7 +160,9 @@ class SpotifyTopPlaylistsRefreshServiceTest {
         refreshTriggerToken = "secret",
       )
 
-    assertThrows<IllegalStateException> { service.refreshConfiguredPlaylists("test") }
+    val result = service.refreshConfiguredPlaylists("test")
+
+    assertNull(result)
     assertEquals("FAILED", refreshStateStore.getTopPlaylists()?.lastStatus)
   }
 }


### PR DESCRIPTION
## Summary

- Protect job status reads by requiring the owning authenticated client session.
- Add Last.fm OAuth state validation and restore the first-time Last.fm auth redirect flow.
- Redact exchangeable auth secrets from logs and use configured OAuth callback URLs.
- Add finite HTTP client timeouts and preserve expected 4xx request errors.
- Keep configured refresh failures as 503/null and avoid removing the Spotify button when rendering embeds.

## Validation

- `./gradlew.bat --no-daemon --max-workers=1 --project-cache-dir .gradle-codex -g .gradle-user "-Dorg.gradle.jvmargs=-Xmx512m" -PjavaVersion=21 -PbuildDir=build-codex ktfmtFormat test`

Note: verification used Java 21 because this machine does not have a Java 17 toolchain installed.