### PR TITLE
Redact Spotify session IDs in logs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/JobsController.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.controller
 
 import com.lis.spotify.domain.JobId
 import com.lis.spotify.domain.JobStatus
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.service.JobLimitExceededException
 import com.lis.spotify.service.JobService
 import com.lis.spotify.service.LastFmAuthenticationService
@@ -36,12 +37,18 @@ class JobsController(
     requireAuthorizedSession(clientId)
     val lastFmLogin = request.lastFmLogin.trim()
     if (lastFmLogin.isEmpty()) {
-      logger.warn("Rejecting yearly job without Last.fm login for clientId={}", clientId)
+      logger.warn(
+        "Rejecting yearly job without Last.fm login for clientId={}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ResponseEntity.badRequest().build()
     }
 
     if (!spotifyAuthenticationService.isAuthorized(clientId)) {
-      logger.warn("Rejecting yearly job for unauthorized clientId={}", clientId)
+      logger.warn(
+        "Rejecting yearly job for unauthorized clientId={}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
     }
 
@@ -66,13 +73,16 @@ class JobsController(
     if (lastFmLogin.isEmpty()) {
       logger.warn(
         "Rejecting forgotten obsessions job without Last.fm login for clientId={}",
-        clientId,
+        clientId.asSafeClientIdForLogs(),
       )
       return ResponseEntity.badRequest().build()
     }
 
     if (!spotifyAuthenticationService.isAuthorized(clientId)) {
-      logger.warn("Rejecting forgotten obsessions job for unauthorized clientId={}", clientId)
+      logger.warn(
+        "Rejecting forgotten obsessions job for unauthorized clientId={}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
     }
 
@@ -100,13 +110,16 @@ class JobsController(
     if (lastFmLogin.isEmpty()) {
       logger.warn(
         "Rejecting private mood taxonomy job without Last.fm login for clientId={}",
-        clientId,
+        clientId.asSafeClientIdForLogs(),
       )
       return ResponseEntity.badRequest().build()
     }
 
     if (!spotifyAuthenticationService.isAuthorized(clientId)) {
-      logger.warn("Rejecting private mood taxonomy job for unauthorized clientId={}", clientId)
+      logger.warn(
+        "Rejecting private mood taxonomy job for unauthorized clientId={}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
     }
 
@@ -114,7 +127,7 @@ class JobsController(
       logger.warn(
         "Rejecting private mood taxonomy job for unauthorized Last.fm login={} clientId={}",
         lastFmLogin,
-        clientId,
+        clientId.asSafeClientIdForLogs(),
       )
       return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
     }
@@ -147,13 +160,18 @@ class JobsController(
     clientId: String,
     starter: () -> String,
   ): ResponseEntity<JobId> {
-    logger.info("Starting {} job for clientId={}", jobName, clientId)
+    logger.info("Starting {} job for clientId={}", jobName, clientId.asSafeClientIdForLogs())
     return try {
       val id = starter()
       logger.info("{} job {} scheduled", jobName, id)
       ResponseEntity.accepted().body(JobId(id))
     } catch (e: JobLimitExceededException) {
-      logger.warn("Rejecting {} job for clientId={}: {}", jobName, clientId, e.message)
+      logger.warn(
+        "Rejecting {} job for clientId={}: {}",
+        jobName,
+        clientId.asSafeClientIdForLogs(),
+        e.message,
+      )
       ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build()
     }
   }

--- a/src/main/kotlin/com/lis/spotify/controller/MainController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/MainController.kt
@@ -1,5 +1,6 @@
 package com.lis.spotify.controller
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.service.LastFmAuthenticationService
 import com.lis.spotify.service.SpotifyAuthenticationService
 import org.slf4j.Logger
@@ -27,7 +28,7 @@ class MainController(
   ): String {
     logger.debug(
       "Entering main() with clientId='{}', lastFmLogin='{}' and lastFmToken='{}'",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       lastFmLogin,
       lastFmToken,
     )
@@ -43,7 +44,7 @@ class MainController(
       if (lastFmAuthorized) {
         logger.info(
           "Both Spotify and Last.fm are authenticated; refreshing token for clientId='{}'.",
-          clientId,
+          clientId.asSafeClientIdForLogs(),
         )
       } else {
         logger.info(

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
@@ -3,6 +3,7 @@ package com.lis.spotify.controller
 import com.lis.spotify.AppEnvironment.Spotify
 import com.lis.spotify.domain.AuthToken
 import com.lis.spotify.domain.User
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.service.SpotifyAuthenticationService
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
@@ -160,8 +161,11 @@ class SpotifyAuthenticationController(
     response: HttpServletResponse,
     @CookieValue("clientId", defaultValue = "") clientId: String,
   ): String {
-    logger.debug("authorize with clientId {}", clientId)
-    logger.info("Authorize endpoint called. Current clientId from cookie: {}", clientId)
+    logger.debug("authorize with clientId {}", clientId.asSafeClientIdForLogs())
+    logger.info(
+      "Authorize endpoint called. Current clientId from cookie: {}",
+      clientId.asSafeClientIdForLogs(),
+    )
     val state = createState()
     response.addCookie(
       createCookie(SPOTIFY_AUTH_STATE_COOKIE, state, request, AUTH_STATE_COOKIE_MAX_AGE_SECONDS)

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
@@ -13,6 +13,7 @@
 package com.lis.spotify.controller
 
 import com.lis.spotify.domain.BandPlaylistRequest
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyBandPlaylistService
 import org.slf4j.LoggerFactory
@@ -37,7 +38,10 @@ class SpotifyBandPlaylistController(
     requireAuthorizedSession(clientId)
     val bands = request.bands.map { it.trim() }.filter { it.isNotEmpty() }
     if (bands.isEmpty()) {
-      logger.warn("Band playlist request had no valid bands for clientId={}", clientId)
+      logger.warn(
+        "Band playlist request had no valid bands for clientId={}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ResponseEntity.badRequest().build()
     }
 
@@ -51,7 +55,11 @@ class SpotifyBandPlaylistController(
       return ResponseEntity.badRequest().build()
     }
 
-    logger.info("Band playlist request for {} bands (clientId={})", bands.size, clientId)
+    logger.info(
+      "Band playlist request for {} bands (clientId={})",
+      bands.size,
+      clientId.asSafeClientIdForLogs(),
+    )
     val playlistId = spotifyBandPlaylistService.createBandPlaylist(clientId, bands)
     return if (playlistId == null) {
       ResponseEntity.status(HttpStatus.NOT_FOUND).build()

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyTopPlaylistsController.kt
@@ -12,6 +12,7 @@
 
 package com.lis.spotify.controller
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.service.LastFmService
 import com.lis.spotify.service.SpotifyAuthenticationService
 import com.lis.spotify.service.SpotifyTopPlaylistsService
@@ -31,10 +32,10 @@ class SpotifyTopPlaylistsController(
   @PostMapping("/updateTopPlaylists")
   fun updateTopPlaylists(@CookieValue("clientId") clientId: String): List<String> {
     requireAuthorizedSession(clientId)
-    logger.info("Updating top playlists for {}", clientId)
-    logger.debug("updateTopPlaylists for {}", clientId)
+    logger.info("Updating top playlists for {}", clientId.asSafeClientIdForLogs())
+    logger.debug("updateTopPlaylists for {}", clientId.asSafeClientIdForLogs())
     val result = spotifyTopPlaylistsService.updateTopPlaylists(clientId)
-    logger.info("UpdateTopPlaylists result for {} -> {}", clientId, result)
+    logger.info("UpdateTopPlaylists result for {} -> {}", clientId.asSafeClientIdForLogs(), result)
     return result
   }
 

--- a/src/main/kotlin/com/lis/spotify/logging/LogSanitizer.kt
+++ b/src/main/kotlin/com/lis/spotify/logging/LogSanitizer.kt
@@ -1,0 +1,22 @@
+package com.lis.spotify.logging
+
+import java.security.MessageDigest
+
+private const val SESSION_ID_PREFIX = "session_"
+
+fun String?.asSafeClientIdForLogs(): String {
+  if (this.isNullOrBlank()) {
+    return "[blank]"
+  }
+
+  return if (startsWith(SESSION_ID_PREFIX)) {
+    "${SESSION_ID_PREFIX}[redacted:${sha256Prefix()}]"
+  } else {
+    this
+  }
+}
+
+private fun String.sha256Prefix(): String {
+  val digest = MessageDigest.getInstance("SHA-256").digest(toByteArray(Charsets.UTF_8))
+  return digest.take(6).joinToString("") { "%02x".format(it) }
+}

--- a/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/FirestoreAppStateStores.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.persistence
 
 import com.google.cloud.firestore.DocumentSnapshot
 import com.google.cloud.firestore.Firestore
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import java.time.Instant
 import org.slf4j.LoggerFactory
 
@@ -70,7 +71,7 @@ class FirestoreSpotifyTokenStore(firestore: Firestore) :
 
   override fun save(token: StoredSpotifyAuthToken): StoredSpotifyAuthToken {
     saveDocument(SPOTIFY_AUTH_TOKENS_COLLECTION, token.clientId, token.toFirestoreMap())
-    logger.debug("Saved Firestore Spotify token {}", token.clientId)
+    logger.debug("Saved Firestore Spotify token {}", token.clientId.asSafeClientIdForLogs())
     return token
   }
 

--- a/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
@@ -1,5 +1,6 @@
 package com.lis.spotify.persistence
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
@@ -36,7 +37,7 @@ class InMemorySpotifyTokenStore : SpotifyTokenStore {
 
   override fun save(token: StoredSpotifyAuthToken): StoredSpotifyAuthToken {
     tokens[token.clientId] = token
-    logger.debug("Saved in-memory Spotify token {}", token.clientId)
+    logger.debug("Saved in-memory Spotify token {}", token.clientId.asSafeClientIdForLogs())
     return token
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/JobService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/JobService.kt
@@ -2,6 +2,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.JobState
 import com.lis.spotify.domain.JobStatus
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.persistence.JobStatusStore
 import com.lis.spotify.persistence.StoredJobStatus
 import java.net.URLEncoder
@@ -42,7 +43,7 @@ class JobService(
   ): String {
     logger.info(
       "Scheduling yearly playlist update for clientId={} lastFmLogin={}",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       lastFmLogin,
     )
     return scheduleJob(
@@ -65,7 +66,7 @@ class JobService(
   ): String {
     logger.info(
       "Scheduling forgotten obsessions playlist update for clientId={} lastFmLogin={}",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       lastFmLogin,
     )
     return scheduleJob(
@@ -103,7 +104,7 @@ class JobService(
   ): String {
     logger.info(
       "Scheduling private mood taxonomy playlist update for clientId={} lastFmLogin={} playlistSize={}",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       lastFmLogin,
       playlistSize,
     )

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyArtistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyArtistService.kt
@@ -16,6 +16,7 @@ import com.lis.spotify.domain.Artist
 import com.lis.spotify.domain.ArtistSearchResult
 import com.lis.spotify.domain.ArtistTopTracks
 import com.lis.spotify.domain.Track
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -24,7 +25,7 @@ class SpotifyArtistService(private val spotifyRestService: SpotifyRestService) {
   private val logger = LoggerFactory.getLogger(SpotifyArtistService::class.java)
 
   fun searchArtist(name: String, clientId: String): Artist? {
-    logger.debug("searchArtist {} {}", name, clientId)
+    logger.debug("searchArtist {} {}", name, clientId.asSafeClientIdForLogs())
     val result =
       spotifyRestService.doGet<ArtistSearchResult>(
         SEARCH_URL,
@@ -32,19 +33,24 @@ class SpotifyArtistService(private val spotifyRestService: SpotifyRestService) {
         clientId = clientId,
       )
     val artist = result.artists.items.firstOrNull()
-    logger.debug("searchArtist {} {} -> {}", name, clientId, artist)
+    logger.debug("searchArtist {} {} -> {}", name, clientId.asSafeClientIdForLogs(), artist)
     return artist
   }
 
   fun getArtistTopTracks(artistId: String, clientId: String): List<Track> {
-    logger.debug("getArtistTopTracks {} {}", artistId, clientId)
+    logger.debug("getArtistTopTracks {} {}", artistId, clientId.asSafeClientIdForLogs())
     val result =
       spotifyRestService.doGet<ArtistTopTracks>(
         TOP_TRACKS_URL,
         params = mapOf("id" to artistId, "market" to MARKET),
         clientId = clientId,
       )
-    logger.debug("getArtistTopTracks {} {} -> {}", artistId, clientId, result.tracks.size)
+    logger.debug(
+      "getArtistTopTracks {} {} -> {}",
+      artistId,
+      clientId.asSafeClientIdForLogs(),
+      result.tracks.size,
+    )
     return result.tracks
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -29,6 +29,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.AppEnvironment.Spotify
 import com.lis.spotify.domain.AuthToken
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.persistence.SpotifyTokenStore
 import com.lis.spotify.persistence.StoredSpotifyAuthToken
 import java.security.SecureRandom
@@ -57,7 +58,10 @@ class SpotifyAuthenticationService(
   private val tokenCache = ConcurrentHashMap<String, AuthToken>()
 
   fun getHeaders(token: AuthToken): HttpHeaders {
-    logger.debug("Creating headers with Bearer token for clientId={}", token.clientId)
+    logger.debug(
+      "Creating headers with Bearer token for clientId={}",
+      token.clientId.asSafeClientIdForLogs(),
+    )
     return HttpHeaders().apply {
       this[HttpHeaders.AUTHORIZATION] = "Bearer ${token.access_token}"
       this[HttpHeaders.ACCEPT] = "application/json"
@@ -68,10 +72,13 @@ class SpotifyAuthenticationService(
   fun getHeaders(clientId: String): HttpHeaders {
     val authToken = getAuthToken(clientId)
     return if (authToken != null) {
-      logger.debug("Creating headers for clientId={}", clientId)
+      logger.debug("Creating headers for clientId={}", clientId.asSafeClientIdForLogs())
       getHeaders(authToken)
     } else {
-      logger.warn("No token found for clientId={}, returning empty headers", clientId)
+      logger.warn(
+        "No token found for clientId={}, returning empty headers",
+        clientId.asSafeClientIdForLogs(),
+      )
       HttpHeaders()
     }
   }
@@ -93,10 +100,10 @@ class SpotifyAuthenticationService(
   fun setAuthToken(token: AuthToken) {
     val clientId =
       requireNotNull(token.clientId) { "clientId is required to store a Spotify auth token" }
-    logger.info("Storing AuthToken for clientId={}", clientId)
+    logger.info("Storing AuthToken for clientId={}", clientId.asSafeClientIdForLogs())
     spotifyTokenStore.save(StoredSpotifyAuthToken.fromAuthToken(token, clock.instant()))
     tokenCache[clientId] = token
-    logger.debug("AuthToken persisted and cached for {}", clientId)
+    logger.debug("AuthToken persisted and cached for {}", clientId.asSafeClientIdForLogs())
   }
 
   fun seedRefreshToken(clientId: String, refreshToken: String) {
@@ -107,7 +114,7 @@ class SpotifyAuthenticationService(
 
     val existing = getAuthToken(clientId)
     if (existing?.refresh_token == refreshToken) {
-      logger.debug("Refresh token already cached for clientId={}", clientId)
+      logger.debug("Refresh token already cached for clientId={}", clientId.asSafeClientIdForLogs())
       return
     }
 
@@ -124,10 +131,13 @@ class SpotifyAuthenticationService(
   }
 
   fun getAuthToken(clientId: String): AuthToken? {
-    logger.debug("Attempting to retrieve AuthToken from cache for clientId={}", clientId)
+    logger.debug(
+      "Attempting to retrieve AuthToken from cache for clientId={}",
+      clientId.asSafeClientIdForLogs(),
+    )
     val cached = tokenCache[clientId]
     if (cached != null) {
-      logger.debug("getAuthToken {} found in cache", clientId)
+      logger.debug("getAuthToken {} found in cache", clientId.asSafeClientIdForLogs())
       return cached
     }
 
@@ -135,16 +145,19 @@ class SpotifyAuthenticationService(
     if (token != null) {
       tokenCache[clientId] = token
     }
-    logger.debug("getAuthToken {} found={}", clientId, token != null)
+    logger.debug("getAuthToken {} found={}", clientId.asSafeClientIdForLogs(), token != null)
     return token
   }
 
   fun refreshToken(clientId: String): Boolean {
-    logger.info("Attempting to refresh token for clientId={}", clientId)
+    logger.info("Attempting to refresh token for clientId={}", clientId.asSafeClientIdForLogs())
     val currentToken = getAuthToken(clientId)
     val refreshTokenValue = currentToken?.refresh_token.orEmpty()
     if (refreshTokenValue.isEmpty()) {
-      logger.warn("No refresh token available for clientId={}; cannot refresh.", clientId)
+      logger.warn(
+        "No refresh token available for clientId={}; cannot refresh.",
+        clientId.asSafeClientIdForLogs(),
+      )
       return false
     }
 
@@ -165,7 +178,10 @@ class SpotifyAuthenticationService(
           .postForObject<AuthToken>(tokenUrl, entity)
 
       if (authToken == null) {
-        logger.warn("Spotify token refresh returned no body for clientId={}", clientId)
+        logger.warn(
+          "Spotify token refresh returned no body for clientId={}",
+          clientId.asSafeClientIdForLogs(),
+        )
         false
       } else {
         // Preserve the existing refresh token.
@@ -174,22 +190,26 @@ class SpotifyAuthenticationService(
 
         logger.info(
           "Successfully refreshed token (access token redacted) for clientId={}",
-          clientId,
+          clientId.asSafeClientIdForLogs(),
         )
         setAuthToken(authToken)
-        logger.debug("refreshToken {} new token stored", clientId)
+        logger.debug("refreshToken {} new token stored", clientId.asSafeClientIdForLogs())
         true
       }
     } catch (ex: Exception) {
-      logger.error("Error while refreshing token for clientId={}", clientId, ex)
+      logger.error(
+        "Error while refreshing token for clientId={}",
+        clientId.asSafeClientIdForLogs(),
+        ex,
+      )
       false
     }
   }
 
   fun isAuthorized(clientId: String): Boolean {
-    logger.debug("Checking if clientId={} is authorized", clientId)
+    logger.debug("Checking if clientId={} is authorized", clientId.asSafeClientIdForLogs())
     val authorized = clientId.isNotEmpty() && getAuthToken(clientId) != null
-    logger.debug("isAuthorized {} -> {}", clientId, authorized)
+    logger.debug("isAuthorized {} -> {}", clientId.asSafeClientIdForLogs(), authorized)
     return authorized
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyBandPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyBandPlaylistService.kt
@@ -12,6 +12,7 @@
 
 package com.lis.spotify.service
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -34,11 +35,18 @@ class SpotifyBandPlaylistService(
         .distinctBy { it.lowercase() }
         .take(MAX_BAND_COUNT)
     if (cleaned.isEmpty()) {
-      logger.warn("createBandPlaylist called with no band names for {}", clientId)
+      logger.warn(
+        "createBandPlaylist called with no band names for {}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return null
     }
 
-    logger.info("Creating band playlist for {} bands (clientId={})", cleaned.size, clientId)
+    logger.info(
+      "Creating band playlist for {} bands (clientId={})",
+      cleaned.size,
+      clientId.asSafeClientIdForLogs(),
+    )
 
     val trackIds =
       runBlocking(Dispatchers.IO) {
@@ -48,7 +56,11 @@ class SpotifyBandPlaylistService(
               async(Dispatchers.IO) {
                 val artist = spotifyArtistService.searchArtist(band, clientId)
                 if (artist == null) {
-                  logger.warn("No Spotify artist match for '{}' (clientId={})", band, clientId)
+                  logger.warn(
+                    "No Spotify artist match for '{}' (clientId={})",
+                    band,
+                    clientId.asSafeClientIdForLogs(),
+                  )
                   emptyList()
                 } else {
                   spotifyArtistService.getArtistTopTracks(artist.id, clientId).map { it.id }
@@ -60,7 +72,11 @@ class SpotifyBandPlaylistService(
       }
 
     if (trackIds.isEmpty()) {
-      logger.warn("No tracks found for bands {} (clientId={})", cleaned, clientId)
+      logger.warn(
+        "No tracks found for bands {} (clientId={})",
+        cleaned,
+        clientId.asSafeClientIdForLogs(),
+      )
       return null
     }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyPlaylistService.kt
@@ -16,6 +16,7 @@ import com.lis.spotify.domain.Playlist
 import com.lis.spotify.domain.PlaylistTracks
 import com.lis.spotify.domain.Playlists
 import com.lis.spotify.domain.Track
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -25,8 +26,8 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
   private fun isUri(id: String) = id.startsWith("spotify:track:")
 
   fun getCurrentUserPlaylists(clientId: String): MutableList<Playlist> {
-    logger.debug("getCurrentUserPlaylists {}", clientId)
-    logger.info("getCurrentUserPlaylists: {}", clientId)
+    logger.debug("getCurrentUserPlaylists {}", clientId.asSafeClientIdForLogs())
+    logger.info("getCurrentUserPlaylists: {}", clientId.asSafeClientIdForLogs())
 
     val playlistList: MutableList<Playlist> = ArrayList()
     var url: String = USER_PLAYLISTS_URL
@@ -36,13 +37,17 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
 
       url = playlists.next.orEmpty()
     } while (!playlists.next.isNullOrEmpty())
-    logger.debug("getCurrentUserPlaylists {} -> {} playlists", clientId, playlistList.size)
+    logger.debug(
+      "getCurrentUserPlaylists {} -> {} playlists",
+      clientId.asSafeClientIdForLogs(),
+      playlistList.size,
+    )
     return playlistList
   }
 
   fun getPlaylistTracks(id: String, clientId: String): List<Track>? {
-    logger.debug("getPlaylistTracks {} {}", id, clientId)
-    logger.info("getPlaylistTracks: {} {}", id, clientId)
+    logger.debug("getPlaylistTracks {} {}", id, clientId.asSafeClientIdForLogs())
+    logger.info("getPlaylistTracks: {} {}", id, clientId.asSafeClientIdForLogs())
 
     val trackList: MutableList<Track> = ArrayList()
     var url: String = PLAYLIST_TRACKS_URL
@@ -53,12 +58,17 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
 
       url = tracks.next.orEmpty()
     } while (!tracks.next.isNullOrEmpty())
-    logger.debug("getPlaylistTracks {} {} -> {} tracks", id, clientId, trackList.size)
+    logger.debug(
+      "getPlaylistTracks {} {} -> {} tracks",
+      id,
+      clientId.asSafeClientIdForLogs(),
+      trackList.size,
+    )
     return trackList
   }
 
   fun getPlaylistTrackIds(id: String, clientId: String): List<String>? {
-    logger.debug("getPlaylistTrackIds {} {}", id, clientId)
+    logger.debug("getPlaylistTrackIds {} {}", id, clientId.asSafeClientIdForLogs())
     return getPlaylistTracks(id, clientId = clientId)?.map { it.id }
   }
 
@@ -66,8 +76,18 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     require(tracks.isNotEmpty()) { "Track list must not be empty" }
     tracks.forEach { require(!it.startsWith("spotify:") || isUri(it)) { "Invalid track URI: $it" } }
 
-    logger.debug("deleteTracksFromPlaylist {} {} {}", playlistId, clientId, tracks.size)
-    logger.info("deleteTracksFromPlaylist: {} {} {}", playlistId, clientId, tracks)
+    logger.debug(
+      "deleteTracksFromPlaylist {} {} {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks.size,
+    )
+    logger.info(
+      "deleteTracksFromPlaylist: {} {} {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks,
+    )
 
     tracks.chunked(100).map { chunk ->
       val payload =
@@ -80,12 +100,27 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
         clientId = clientId,
       )
     }
-    logger.debug("deleteTracksFromPlaylist {} {} -> removed {}", playlistId, clientId, tracks.size)
+    logger.debug(
+      "deleteTracksFromPlaylist {} {} -> removed {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks.size,
+    )
   }
 
   fun addTracksToPlaylist(playlistId: String, tracks: List<String>, clientId: String) {
-    logger.debug("addTracksToPlaylist {} {} {}", playlistId, clientId, tracks.size)
-    logger.info("addTracksToPlaylist: {} {} {}", playlistId, clientId, tracks)
+    logger.debug(
+      "addTracksToPlaylist {} {} {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks.size,
+    )
+    logger.info(
+      "addTracksToPlaylist: {} {} {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks,
+    )
 
     tracks.chunked(100).map {
       spotifyRestService.doPost<Any>(
@@ -95,7 +130,12 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
         clientId = clientId,
       )
     }
-    logger.debug("addTracksToPlaylist {} {} -> added {}", playlistId, clientId, tracks.size)
+    logger.debug(
+      "addTracksToPlaylist {} {} -> added {}",
+      playlistId,
+      clientId.asSafeClientIdForLogs(),
+      tracks.size,
+    )
   }
 
   private fun getDiff(old: List<String>, new: List<String>): ArrayList<String> {
@@ -103,8 +143,18 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
   }
 
   fun replacePlaylistTracks(id: String, trackList: List<String>, clientId: String) {
-    logger.debug("replacePlaylistTracks {} {} {}", id, clientId, trackList.size)
-    logger.info("replacePlaylistTracks: {} {} {}", id, clientId, trackList.size)
+    logger.debug(
+      "replacePlaylistTracks {} {} {}",
+      id,
+      clientId.asSafeClientIdForLogs(),
+      trackList.size,
+    )
+    logger.info(
+      "replacePlaylistTracks: {} {} {}",
+      id,
+      clientId.asSafeClientIdForLogs(),
+      trackList.size,
+    )
 
     spotifyRestService.doPut<Any>(
       PLAYLIST_TRACKS_URL,
@@ -112,7 +162,12 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
       params = mapOf("id" to id),
       clientId = clientId,
     )
-    logger.debug("replacePlaylistTracks {} {} -> replaced {}", id, clientId, trackList.size)
+    logger.debug(
+      "replacePlaylistTracks {} {} -> replaced {}",
+      id,
+      clientId.asSafeClientIdForLogs(),
+      trackList.size,
+    )
   }
 
   fun deduplicatePlaylist(id: String, clientId: String) {
@@ -133,8 +188,8 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     trackList: List<String>,
     clientId: String,
   ): Map<String, List<String>> {
-    logger.debug("modifyPlaylist {} {} {}", id, clientId, trackList.size)
-    logger.info("modifyPlaylist: {} {} {}", id, clientId, trackList.size)
+    logger.debug("modifyPlaylist {} {} {}", id, clientId.asSafeClientIdForLogs(), trackList.size)
+    logger.info("modifyPlaylist: {} {} {}", id, clientId.asSafeClientIdForLogs(), trackList.size)
 
     val old = getPlaylistTrackIds(id, clientId).orEmpty()
     val oldSet = old.toSet()
@@ -154,7 +209,7 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     logger.debug(
       "modifyPlaylist {} {} -> added {} removed {}",
       id,
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       tracksToAdd.size,
       tracksToRemove.size,
     )
@@ -162,8 +217,8 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
   }
 
   fun createPlaylist(name: String, clientId: String, public: Boolean = true): Playlist {
-    logger.debug("createPlaylist {} {} public={}", name, clientId, public)
-    logger.info("createPlaylist: {} {} public={}", name, clientId, public)
+    logger.debug("createPlaylist {} {} public={}", name, clientId.asSafeClientIdForLogs(), public)
+    logger.info("createPlaylist: {} {} public={}", name, clientId.asSafeClientIdForLogs(), public)
 
     return spotifyRestService.doPost<Playlist>(
       USER_PLAYLISTS_URL,
@@ -177,8 +232,18 @@ class SpotifyPlaylistService(var spotifyRestService: SpotifyRestService) {
     clientId: String,
     public: Boolean = true,
   ): Playlist {
-    logger.debug("getOrCreatePlaylist {} {} public={}", playlistName, clientId, public)
-    logger.info("getOrCreatePlaylist: {} {} public={}", playlistName, clientId, public)
+    logger.debug(
+      "getOrCreatePlaylist {} {} public={}",
+      playlistName,
+      clientId.asSafeClientIdForLogs(),
+      public,
+    )
+    logger.info(
+      "getOrCreatePlaylist: {} {} public={}",
+      playlistName,
+      clientId.asSafeClientIdForLogs(),
+      public,
+    )
 
     val findAny =
       getCurrentUserPlaylists(clientId).stream().filter { it.name == playlistName }.findAny()

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyRestService.kt
@@ -12,6 +12,7 @@
 
 package com.lis.spotify.service
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import org.slf4j.LoggerFactory
 import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.HttpEntity
@@ -58,7 +59,7 @@ class SpotifyRestService(
       } catch (e: HttpClientErrorException.Unauthorized) {
         logger.warn(
           "Unauthorized Spotify request for clientId={}; attempting token refresh.",
-          clientId,
+          clientId.asSafeClientIdForLogs(),
         )
         if (spotifyAuthenticationService.refreshToken(clientId)) {
           try {
@@ -73,12 +74,15 @@ class SpotifyRestService(
           } catch (retryEx: HttpClientErrorException.Unauthorized) {
             logger.error(
               "Unauthorized Spotify request for clientId={} after refresh attempt.",
-              clientId,
+              clientId.asSafeClientIdForLogs(),
               retryEx,
             )
           }
         } else {
-          logger.warn("Could not refresh Spotify token for clientId={}", clientId)
+          logger.warn(
+            "Could not refresh Spotify token for clientId={}",
+            clientId.asSafeClientIdForLogs(),
+          )
         }
         throw AuthenticationRequiredException("SPOTIFY")
       }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
@@ -18,6 +18,7 @@ import com.google.common.cache.CacheBuilder
 import com.lis.spotify.domain.SearchResult
 import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.persistence.SpotifySearchCacheStore
 import com.lis.spotify.persistence.StoredSpotifySearchCacheEntry
 import java.nio.charset.StandardCharsets
@@ -77,7 +78,7 @@ class SpotifySearchService(
     CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build()
 
   fun doSearch(song: Song, clientId: String): SearchResult? {
-    logger.debug("doSearch single {} {}", song, clientId)
+    logger.debug("doSearch single {} {}", song, clientId.asSafeClientIdForLogs())
     val query = buildQuery(song)
     val cacheKey = cacheKey(clientId, query)
     val now = clock.instant()
@@ -94,14 +95,14 @@ class SpotifySearchService(
   }
 
   fun doSearch(values: List<Song>, clientId: String, progress: () -> Unit = {}): List<String> {
-    logger.debug("doSearch batch {} {}", clientId, values.size)
-    logger.info("doSearch: {} {}", clientId, values.size)
+    logger.debug("doSearch batch {} {}", clientId.asSafeClientIdForLogs(), values.size)
+    logger.info("doSearch: {} {}", clientId.asSafeClientIdForLogs(), values.size)
     lateinit var retVal: List<String>
     val time = measureTimeMillis {
       retVal = runBlocking(Dispatchers.IO) { searchTrackIds(values, clientId, progress) }
     }
     logger.debug("doSearch batch result {} items", retVal.size)
-    logger.info("doSearch: {} {} took: {}", clientId, values.size, time)
+    logger.info("doSearch: {} {} took: {}", clientId.asSafeClientIdForLogs(), values.size, time)
     return retVal
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopArtistService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopArtistService.kt
@@ -14,6 +14,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Artist
 import com.lis.spotify.domain.Artists
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -29,35 +30,52 @@ class SpotifyTopArtistService(var spotifyRestService: SpotifyRestService) {
   }
 
   private fun getTopArtists(term: String, clientId: String): Artists {
-    logger.debug("getTopArtists {} {}", term, clientId)
+    logger.debug("getTopArtists {} {}", term, clientId.asSafeClientIdForLogs())
     val artists =
       spotifyRestService.doGet<Artists>(
         URL,
         params = mapOf("limit" to 10, "time_range" to term),
         clientId = clientId,
       )
-    logger.debug("getTopArtists {} {} -> {} items", term, clientId, artists.items.size)
+    logger.debug(
+      "getTopArtists {} {} -> {} items",
+      term,
+      clientId.asSafeClientIdForLogs(),
+      artists.items.size,
+    )
     return artists
   }
 
   fun getTopArtistsLongTerm(clientId: String): List<Artist> {
-    logger.debug("getTopArtistsLongTerm {}", clientId)
+    logger.debug("getTopArtistsLongTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopArtists(LONG_TERM, clientId).items
-    logger.debug("getTopArtistsLongTerm {} -> {} items", clientId, items.size)
+    logger.debug(
+      "getTopArtistsLongTerm {} -> {} items",
+      clientId.asSafeClientIdForLogs(),
+      items.size,
+    )
     return items
   }
 
   fun getTopArtistsMidTerm(clientId: String): List<Artist> {
-    logger.debug("getTopArtistsMidTerm {}", clientId)
+    logger.debug("getTopArtistsMidTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopArtists(MID_TERM, clientId).items
-    logger.debug("getTopArtistsMidTerm {} -> {} items", clientId, items.size)
+    logger.debug(
+      "getTopArtistsMidTerm {} -> {} items",
+      clientId.asSafeClientIdForLogs(),
+      items.size,
+    )
     return items
   }
 
   fun getTopArtistsShortTerm(clientId: String): List<Artist> {
-    logger.debug("getTopArtistsShortTerm {}", clientId)
+    logger.debug("getTopArtistsShortTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopArtists(SHORT_TERM, clientId).items
-    logger.debug("getTopArtistsShortTerm {} -> {} items", clientId, items.size)
+    logger.debug(
+      "getTopArtistsShortTerm {} -> {} items",
+      clientId.asSafeClientIdForLogs(),
+      items.size,
+    )
     return items
   }
 }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
@@ -1,5 +1,6 @@
 package com.lis.spotify.service
 
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import com.lis.spotify.persistence.RefreshStateStore
 import com.lis.spotify.persistence.StoredRefreshState
 import java.time.Clock
@@ -102,7 +103,7 @@ class SpotifyTopPlaylistsRefreshService(
       logger.info(
         "Configured top playlist refresh finished for trigger={} clientId={} playlists={}",
         trigger,
-        refreshClientId,
+        refreshClientId.asSafeClientIdForLogs(),
         playlistIds,
       )
       playlistIds
@@ -110,7 +111,7 @@ class SpotifyTopPlaylistsRefreshService(
       logger.error(
         "Configured top playlist refresh failed for trigger={} clientId={}",
         trigger,
-        refreshClientId,
+        refreshClientId.asSafeClientIdForLogs(),
         ex,
       )
       saveRefreshState(

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -15,6 +15,7 @@ package com.lis.spotify.service
 import com.lis.spotify.domain.Playlist
 import com.lis.spotify.domain.Song
 import com.lis.spotify.domain.Track
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.ZoneId
@@ -76,8 +77,8 @@ class SpotifyTopPlaylistsService(
   private val logger = LoggerFactory.getLogger(SpotifyTopPlaylistsService::class.java)
 
   fun updateTopPlaylists(clientId: String): List<String> {
-    logger.debug("updateTopPlaylists {}", clientId)
-    logger.info("updateTopPlaylists: {}", clientId)
+    logger.debug("updateTopPlaylists {}", clientId.asSafeClientIdForLogs())
+    logger.info("updateTopPlaylists: {}", clientId.asSafeClientIdForLogs())
 
     return runBlocking(Dispatchers.IO) {
       val shortTerm =
@@ -130,8 +131,8 @@ class SpotifyTopPlaylistsService(
       }
 
       val result = ids.toList()
-      logger.debug("updateTopPlaylists {} -> {}", clientId, result)
-      logger.info("Updated top playlists for {} -> {}", clientId, result)
+      logger.debug("updateTopPlaylists {} -> {}", clientId.asSafeClientIdForLogs(), result)
+      logger.info("Updated top playlists for {} -> {}", clientId.asSafeClientIdForLogs(), result)
       result
     }
   }
@@ -142,8 +143,8 @@ class SpotifyTopPlaylistsService(
     lastFmSessionKey: String? = null,
     progress: (Int, String) -> Unit = { _, _ -> },
   ) {
-    logger.debug("updateYearlyPlaylists {} {}", clientId, lastFmLogin)
-    logger.info("updateYearlyPlaylists: {}", clientId)
+    logger.debug("updateYearlyPlaylists {} {}", clientId.asSafeClientIdForLogs(), lastFmLogin)
+    logger.info("updateYearlyPlaylists: {}", clientId.asSafeClientIdForLogs())
     runBlocking(Dispatchers.IO) {
       val years = (firstSupportedYear..getYear()).toList().sortedDescending()
       val total = years.size.coerceAtLeast(1)
@@ -196,7 +197,7 @@ class SpotifyTopPlaylistsService(
         .awaitAll()
     }
     progress(100, "Yearly playlists refreshed")
-    logger.info("updateYearlyPlaylists {} completed", clientId)
+    logger.info("updateYearlyPlaylists {} completed", clientId.asSafeClientIdForLogs())
   }
 
   fun updateForgottenObsessionsPlaylist(
@@ -208,8 +209,12 @@ class SpotifyTopPlaylistsService(
     val normalizedLastFmLogin = lastFmLogin.trim()
     require(normalizedLastFmLogin.isNotBlank()) { "lastFmLogin must not be blank" }
 
-    logger.debug("updateForgottenObsessionsPlaylist {} {}", clientId, normalizedLastFmLogin)
-    logger.info("updateForgottenObsessionsPlaylist: {}", clientId)
+    logger.debug(
+      "updateForgottenObsessionsPlaylist {} {}",
+      clientId.asSafeClientIdForLogs(),
+      normalizedLastFmLogin,
+    )
+    logger.info("updateForgottenObsessionsPlaylist: {}", clientId.asSafeClientIdForLogs())
 
     val years = (firstSupportedYear..getYear()).toList().sortedDescending()
     val totalSteps = (years.size + 2).coerceAtLeast(1)
@@ -265,7 +270,7 @@ class SpotifyTopPlaylistsService(
       )
     if (candidates.isEmpty()) {
       progress(100, "No forgotten obsessions found yet")
-      logger.info("No forgotten obsessions found for {}", clientId)
+      logger.info("No forgotten obsessions found for {}", clientId.asSafeClientIdForLogs())
       return ForgottenObsessionsPlaylistResult(
         playlistId = null,
         playlistTrackCount = 0,
@@ -325,7 +330,10 @@ class SpotifyTopPlaylistsService(
 
     if (trackIds.isEmpty()) {
       progress(100, "No Spotify matches found for forgotten obsessions")
-      logger.info("Forgotten obsessions candidates found but no Spotify matches for {}", clientId)
+      logger.info(
+        "Forgotten obsessions candidates found but no Spotify matches for {}",
+        clientId.asSafeClientIdForLogs(),
+      )
       return ForgottenObsessionsPlaylistResult(
         playlistId = null,
         playlistTrackCount = 0,
@@ -370,11 +378,11 @@ class SpotifyTopPlaylistsService(
 
     logger.debug(
       "updatePrivateMoodTaxonomyPlaylists {} {} {}",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       normalizedLastFmLogin,
       normalizedPlaylistSize,
     )
-    logger.info("updatePrivateMoodTaxonomyPlaylists: {}", clientId)
+    logger.info("updatePrivateMoodTaxonomyPlaylists: {}", clientId.asSafeClientIdForLogs())
 
     val years = (firstSupportedYear..getYear()).toList().sortedDescending()
     val yearSemaphore = Semaphore(yearlyParallelism.coerceAtLeast(1))
@@ -570,7 +578,7 @@ class SpotifyTopPlaylistsService(
       )
     logger.info(
       "Private mood taxonomy refreshed for {} -> {}",
-      clientId,
+      clientId.asSafeClientIdForLogs(),
       result.playlists.associate { it.label to it.trackCount },
     )
     return result
@@ -581,7 +589,7 @@ class SpotifyTopPlaylistsService(
       logger.warn(
         "Missing Spotify scopes {} for private mood taxonomy clientId={}",
         PRIVATE_MOOD_REQUIRED_SCOPES,
-        clientId,
+        clientId.asSafeClientIdForLogs(),
       )
       throw AuthenticationRequiredException("SPOTIFY")
     }

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopTrackService.kt
@@ -14,6 +14,7 @@ package com.lis.spotify.service
 
 import com.lis.spotify.domain.Track
 import com.lis.spotify.domain.Tracks
+import com.lis.spotify.logging.asSafeClientIdForLogs
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -29,41 +30,54 @@ class SpotifyTopTrackService(var spotifyRestService: SpotifyRestService) {
   }
 
   private fun getTopTracks(term: String, clientId: String): Tracks {
-    logger.debug("getTopTracks {} {}", term, clientId)
+    logger.debug("getTopTracks {} {}", term, clientId.asSafeClientIdForLogs())
     val tracks =
       spotifyRestService.doGet<Tracks>(
         URL,
         params = mapOf("limit" to 50, "time_range" to term),
         clientId = clientId,
       )
-    logger.debug("getTopTracks {} {} -> {} items", term, clientId, tracks.items.size)
+    logger.debug(
+      "getTopTracks {} {} -> {} items",
+      term,
+      clientId.asSafeClientIdForLogs(),
+      tracks.items.size,
+    )
     return tracks
   }
 
   fun getTopTracksLongTerm(clientId: String): List<Track> {
-    logger.info("Fetching long-term top tracks for {}", clientId)
-    logger.debug("getTopTracksLongTerm {}", clientId)
+    logger.info("Fetching long-term top tracks for {}", clientId.asSafeClientIdForLogs())
+    logger.debug("getTopTracksLongTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopTracks(LONG_TERM, clientId).items
-    logger.debug("getTopTracksLongTerm {} -> {} items", clientId, items.size)
-    logger.info("Fetched {} long-term tracks for {}", items.size, clientId)
+    logger.debug(
+      "getTopTracksLongTerm {} -> {} items",
+      clientId.asSafeClientIdForLogs(),
+      items.size,
+    )
+    logger.info("Fetched {} long-term tracks for {}", items.size, clientId.asSafeClientIdForLogs())
     return items
   }
 
   fun getTopTracksMidTerm(clientId: String): List<Track> {
-    logger.info("Fetching mid-term top tracks for {}", clientId)
-    logger.debug("getTopTracksMidTerm {}", clientId)
+    logger.info("Fetching mid-term top tracks for {}", clientId.asSafeClientIdForLogs())
+    logger.debug("getTopTracksMidTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopTracks(MID_TERM, clientId).items
-    logger.debug("getTopTracksMidTerm {} -> {} items", clientId, items.size)
-    logger.info("Fetched {} mid-term tracks for {}", items.size, clientId)
+    logger.debug("getTopTracksMidTerm {} -> {} items", clientId.asSafeClientIdForLogs(), items.size)
+    logger.info("Fetched {} mid-term tracks for {}", items.size, clientId.asSafeClientIdForLogs())
     return items
   }
 
   fun getTopTracksShortTerm(clientId: String): List<Track> {
-    logger.info("Fetching short-term top tracks for {}", clientId)
-    logger.debug("getTopTracksShortTerm {}", clientId)
+    logger.info("Fetching short-term top tracks for {}", clientId.asSafeClientIdForLogs())
+    logger.debug("getTopTracksShortTerm {}", clientId.asSafeClientIdForLogs())
     val items = getTopTracks(SHORT_TERM, clientId).items
-    logger.debug("getTopTracksShortTerm {} -> {} items", clientId, items.size)
-    logger.info("Fetched {} short-term tracks for {}", items.size, clientId)
+    logger.debug(
+      "getTopTracksShortTerm {} -> {} items",
+      clientId.asSafeClientIdForLogs(),
+      items.size,
+    )
+    logger.info("Fetched {} short-term tracks for {}", items.size, clientId.asSafeClientIdForLogs())
     return items
   }
 }

--- a/src/test/kotlin/com/lis/spotify/logging/LogSanitizerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/logging/LogSanitizerTest.kt
@@ -1,0 +1,29 @@
+package com.lis.spotify.logging
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LogSanitizerTest {
+  @Test
+  fun redactsOpaqueSessionIds() {
+    val sessionId = "session_abcdefghijklmnopqrstuvwxyz0123456789"
+
+    val sanitized = sessionId.asSafeClientIdForLogs()
+
+    assertTrue(sanitized.startsWith("session_[redacted:"))
+    assertFalse(sanitized.contains("abcdefghijklmnopqrstuvwxyz0123456789"))
+  }
+
+  @Test
+  fun leavesNonSessionClientIdsVisible() {
+    assertEquals("spotify-user-id", "spotify-user-id".asSafeClientIdForLogs())
+  }
+
+  @Test
+  fun rendersBlankClientIdsWithoutRevealingValues() {
+    assertEquals("[blank]", "".asSafeClientIdForLogs())
+    assertEquals("[blank]", null.asSafeClientIdForLogs())
+  }
+}


### PR DESCRIPTION
### Motivation

- Opaque `session_...` values are now used as bearer session cookies and were being logged at INFO level, which exposes session credentials to anyone with access to application logs.
- The change prevents credential disclosure by ensuring logs do not emit raw session-bearing `clientId` values.

### Description

- Add a small log-sanitizer helper `asSafeClientIdForLogs()` in `src/main/kotlin/com/lis/spotify/logging/LogSanitizer.kt` that redacts `session_` IDs but leaves non-session identifiers readable and renders blank/null safely.
- Replace direct `clientId` arguments in log statements across authentication, controller, service, and persistence layers (e.g. `SpotifyAuthenticationService`, `SpotifyAuthenticationController`, `SpotifyTopPlaylistsController`, `JobsController`, `SpotifyPlaylistService`, `SpotifyRestService`, `SpotifyTopPlaylistsService`, `JobService`, token stores) to call the sanitizer before formatting.
- Preserve existing authorization behavior: the `clientId` value is still passed unchanged to authorization checks and service calls; only log arguments are sanitized.
- Add unit tests `src/test/kotlin/com/lis/spotify/logging/LogSanitizerTest.kt` covering redaction of session IDs, passthrough of non-session IDs, and blank/null handling.

### Testing

- Ran formatting with `./gradlew ktfmtFormat` which completed successfully.
- Executed the test suite via `./gradlew test` and all tests passed.
- Built the project with `./gradlew build` and the build succeeded including jacoco checks.
- Performed a source-level scan to verify logger calls no longer include raw `clientId` arguments and found no remaining instances.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05aa55885c83269cb58bdb545a1378)