### PR TITLE
Fix six correctness and reliability bugs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
+++ b/src/main/kotlin/com/lis/spotify/persistence/InMemoryAppStateStores.kt
@@ -20,9 +20,17 @@ class InMemoryJobStatusStore : JobStatusStore {
   }
 
   override fun deleteExpired(now: Instant): Int {
-    val expiredIds = jobs.filterValues { !it.expiresAt.isAfter(now) }.keys
-    expiredIds.forEach { jobs.remove(it) }
-    return expiredIds.size
+    var removed = 0
+    for (entry in jobs.entries) {
+      if (!entry.value.expiresAt.isAfter(now)) {
+        // Remove only if the value is still the same expired snapshot; a concurrent save() that
+        // refreshed this job to a later expiry must not be deleted.
+        if (jobs.remove(entry.key, entry.value)) {
+          removed++
+        }
+      }
+    }
+    return removed
   }
 
   fun clear() {

--- a/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LyricsService.kt
@@ -77,6 +77,7 @@ class LyricsService(
 
     val lookupCandidates = buildLyricsLookupCandidates(song)
     var lyrics: String? = null
+    var transientFailure = false
 
     for ((index, candidate) in lookupCandidates.withIndex()) {
       try {
@@ -122,14 +123,17 @@ class LyricsService(
           }
           else -> {
             logger.warn("Lyrics lookup failed for {} - {}", song.artist, song.title, ex)
+            transientFailure = true
             break
           }
         }
       } catch (ex: ResourceAccessException) {
         logger.warn("Lyrics lookup network error for {} - {}", song.artist, song.title, ex)
+        transientFailure = true
         break
       } catch (ex: Exception) {
         logger.warn("Unexpected lyrics lookup failure for {} - {}", song.artist, song.title, ex)
+        transientFailure = true
         break
       }
 
@@ -145,7 +149,11 @@ class LyricsService(
       }
     }
 
-    lyricsCache.put(key, LyricsLookupResult(lyrics))
+    // Only cache a definitive result. A transient/network failure left lyrics unresolved, so
+    // caching null here would suppress retries for the full cache TTL after a momentary outage.
+    if (!transientFailure) {
+      lyricsCache.put(key, LyricsLookupResult(lyrics))
+    }
     return lyrics
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyAuthenticationService.kt
@@ -169,9 +169,11 @@ class SpotifyAuthenticationService(
         logger.warn("Spotify token refresh returned no body for clientId={}", clientId)
         false
       } else {
-        // Preserve the existing refresh token.
+        // Spotify may rotate the refresh token on refresh; keep the new one when present and
+        // only fall back to the existing token if the response omits it.
         authToken.clientId = clientId
-        authToken.refresh_token = refreshTokenValue
+        authToken.refresh_token =
+          authToken.refresh_token?.takeIf { it.isNotBlank() } ?: refreshTokenValue
 
         logger.info(
           "Successfully refreshed token (access token redacted) for clientId={}",

--- a/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifySearchService.kt
@@ -155,7 +155,14 @@ class SpotifySearchService(
         }
     }
 
-    val storedEntry = spotifySearchCacheStore.findByKey(cacheKey) ?: return null
+    val storedEntry =
+      try {
+        spotifySearchCacheStore.findByKey(cacheKey)
+      } catch (ex: Exception) {
+        // The persistent cache is best-effort; a store failure must not abort the search batch.
+        logger.warn("Failed to read persistent Spotify search cache {}, ignoring", cacheKey, ex)
+        null
+      } ?: return null
     if (!storedEntry.isFresh(now)) {
       return null
     }
@@ -179,7 +186,12 @@ class SpotifySearchService(
         updatedAt = now,
         expiresAt = now.plus(cacheTtl),
       )
-    spotifySearchCacheStore.save(entry)
+    try {
+      spotifySearchCacheStore.save(entry)
+    } catch (ex: Exception) {
+      // The persistent cache is best-effort; a store failure must not abort the search batch.
+      logger.warn("Failed to persist Spotify search cache {}, keeping in-memory only", cacheKey, ex)
+    }
     searchCache.put(cacheKey, entry)
   }
 

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshService.kt
@@ -5,6 +5,7 @@ import com.lis.spotify.persistence.StoredRefreshState
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -26,6 +27,7 @@ class SpotifyTopPlaylistsRefreshService(
 ) {
   private val clock: Clock = Clock.systemUTC()
   private val refreshTokenCacheClientId = "configured-top-playlists-refresh-${UUID.randomUUID()}"
+  private val refreshInProgress = AtomicBoolean(false)
 
   @EventListener(ApplicationReadyEvent::class)
   fun triggerRefreshOnStartup() {
@@ -46,6 +48,23 @@ class SpotifyTopPlaylistsRefreshService(
   }
 
   fun refreshConfiguredPlaylists(trigger: String): List<String>? {
+    // Startup, scheduled, and HTTP triggers can fire concurrently; a single-flight guard prevents
+    // overlapping runs from double-mutating the shared refresh state and the same Spotify account.
+    if (!refreshInProgress.compareAndSet(false, true)) {
+      logger.warn(
+        "Skipping configured top playlist refresh for trigger={} because a refresh is already in progress",
+        trigger,
+      )
+      return null
+    }
+    return try {
+      doRefreshConfiguredPlaylists(trigger)
+    } finally {
+      refreshInProgress.set(false)
+    }
+  }
+
+  private fun doRefreshConfiguredPlaylists(trigger: String): List<String>? {
     val startedAt = Instant.now(clock)
     val previousState = currentRefreshState()
     saveRefreshState(

--- a/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsService.kt
@@ -263,7 +263,7 @@ class SpotifyTopPlaylistsService(
       totalMatchingBatches,
     )
     val trackIds = mutableListOf<String>()
-    var spotifyMatchCount = 0
+    val matchedTrackIds = mutableSetOf<String>()
     var candidateOffset = 0
     var batchIndex = 0
     while (
@@ -272,7 +272,7 @@ class SpotifyTopPlaylistsService(
       val batch = candidates.drop(candidateOffset).take(FORGOTTEN_OBSESSIONS_SEARCH_BATCH_SIZE)
       val matchedBatch =
         runBlocking(Dispatchers.IO) { spotifySearchService.searchTrackIds(batch, clientId) }
-      spotifyMatchCount += matchedBatch.size
+      matchedTrackIds += matchedBatch
       val remainingCapacity = FORGOTTEN_OBSESSIONS_TARGET_TRACK_COUNT - trackIds.size
       trackIds += matchedBatch.filterNot { it in trackIds }.take(remainingCapacity)
       candidateOffset += batch.size
@@ -296,7 +296,7 @@ class SpotifyTopPlaylistsService(
         batchIndex,
         totalMatchingBatches,
         trackIds.size,
-        spotifyMatchCount,
+        matchedTrackIds.size,
       )
     }
 
@@ -325,12 +325,12 @@ class SpotifyTopPlaylistsService(
       "Forgotten obsessions playlist {} refreshed with {} playlist tracks from {} Spotify matches",
       playlistId,
       trackIds.size,
-      spotifyMatchCount,
+      matchedTrackIds.size,
     )
     return ForgottenObsessionsPlaylistResult(
       playlistId = playlistId,
       playlistTrackCount = trackIds.size,
-      spotifyMatchCount = spotifyMatchCount,
+      spotifyMatchCount = matchedTrackIds.size,
       candidateCount = candidates.size,
     )
   }

--- a/src/test/kotlin/com/lis/spotify/persistence/InMemoryAppStateStoresTest.kt
+++ b/src/test/kotlin/com/lis/spotify/persistence/InMemoryAppStateStoresTest.kt
@@ -2,7 +2,12 @@ package com.lis.spotify.persistence
 
 import com.lis.spotify.domain.JobState
 import java.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
@@ -25,6 +30,26 @@ class InMemoryAppStateStoresTest {
     store.clear()
 
     assertNull(store.findById("active"))
+  }
+
+  @Test
+  fun deleteExpiredDoesNotDropAJobThatIsConcurrentlyRefreshed() = runBlocking {
+    val store = InMemoryJobStatusStore()
+    val now = Instant.parse("2026-04-08T10:00:00Z")
+    // Seed the job as already expired so cleanup will target it.
+    store.save(storedJob("job", now.minusSeconds(1)))
+
+    coroutineScope {
+      launch(Dispatchers.Default) {
+        repeat(5000) { store.save(storedJob("job", now.plusSeconds(3600))) }
+      }
+      launch(Dispatchers.Default) { repeat(5000) { store.deleteExpired(now) } }
+    }
+
+    // A refreshed (non-expired) job must survive concurrent cleanup passes.
+    store.save(storedJob("job", now.plusSeconds(3600)))
+    store.deleteExpired(now)
+    assertNotNull(store.findById("job"))
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LyricsServiceTest.kt
@@ -128,6 +128,41 @@ class LyricsServiceTest {
   }
 
   @Test
+  fun fetchLyricsDoesNotCacheNullAfterTransientFailure() {
+    val rest = mockk<RestTemplate>()
+    val service = LyricsService()
+    service.rest = rest
+    service.retryBaseDelayMillis = 0
+    service.retrySleeper = {}
+    val unavailable =
+      HttpClientErrorException.create(
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "",
+        HttpHeaders(),
+        ByteArray(0),
+        null,
+      )
+    var outageCleared = false
+
+    every { rest.getForObject(any<URI>(), Map::class.java) } answers
+      {
+        if (!outageCleared) {
+          throw unavailable
+        }
+        mapOf("plainLyrics" to "recovered", "instrumental" to false)
+      }
+
+    // A persistent transient outage must leave the lookup uncached, not poison it as "no lyrics".
+    val first = service.fetchLyrics(Song("Artist A", "Song A"))
+    assertNull(first)
+
+    // Once the outage clears, the next lookup must retry rather than return a cached null.
+    outageCleared = true
+    val second = service.fetchLyrics(Song("Artist A", "Song A"))
+    assertEquals("recovered", second)
+  }
+
+  @Test
   fun buildPrivateMoodLyricsProfilesUsesOpenAiAndFallsBackForMissingAssessments() {
     val rest = mockk<RestTemplate>()
     val service = LyricsService()

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyAuthenticationServiceTest.kt
@@ -75,10 +75,11 @@ class SpotifyAuthenticationServiceTest {
   }
 
   @Test
-  fun refreshTokenStoresNewToken() {
+  fun refreshTokenStoresRotatedRefreshToken() {
     val builderAuthed = mockk<RestTemplateBuilder>()
     every { builder.basicAuthentication(any(), any()) } returns builderAuthed
     every { builderAuthed.build() } returns restTemplate
+    // Spotify rotated the refresh token; the response carries a new one that must be stored.
     val newToken = AuthToken("access", "Bearer", "", 0, "new", "cid")
     every { restTemplate.postForObject(any<URI>(), any(), AuthToken::class.java) } returns newToken
     service.setAuthToken(AuthToken("old", "", "", 0, "refresh", "cid"))
@@ -86,8 +87,24 @@ class SpotifyAuthenticationServiceTest {
     assertTrue(refreshed)
     val stored = service.getAuthToken("cid")
     assertEquals("access", stored?.access_token)
-    assertEquals("refresh", stored?.refresh_token)
+    assertEquals("new", stored?.refresh_token)
     assertEquals("cid", stored?.clientId)
+  }
+
+  @Test
+  fun refreshTokenPreservesExistingRefreshTokenWhenResponseOmitsIt() {
+    val builderAuthed = mockk<RestTemplateBuilder>()
+    every { builder.basicAuthentication(any(), any()) } returns builderAuthed
+    every { builderAuthed.build() } returns restTemplate
+    // Response without a rotated refresh token: the existing one must be preserved.
+    val newToken = AuthToken("access2", "Bearer", "", 0, null, "cid")
+    every { restTemplate.postForObject(any<URI>(), any(), AuthToken::class.java) } returns newToken
+    service.setAuthToken(AuthToken("old", "", "", 0, "refresh", "cid"))
+    val refreshed = service.refreshToken("cid")
+    assertTrue(refreshed)
+    val stored = service.getAuthToken("cid")
+    assertEquals("access2", stored?.access_token)
+    assertEquals("refresh", stored?.refresh_token)
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifySearchServiceTest.kt
@@ -192,6 +192,20 @@ class SpotifySearchServiceTest {
   }
 
   @Test
+  fun searchSurvivesPersistentCacheStoreFailures() {
+    val rest = mockk<SpotifyRestService>()
+    val service = SpotifySearchService(rest, ThrowingSpotifySearchCacheStore(), fixedClock())
+    val track = Track("1", "t", listOf(Artist("2", "a")), Album("3", "al", emptyList()))
+    val result = SearchResult(SearchResultInternal(listOf(track)))
+    every { rest.doRequest(any<() -> Any>()) } returns result
+
+    // A failing persistent cache must degrade gracefully, not abort the whole batch search.
+    val ids = service.doSearch(listOf(Song("a", "t")), "cid")
+
+    assertEquals(listOf("1"), ids)
+  }
+
+  @Test
   fun batchSearchUsesConfiguredParallelism() {
     val rest = mockk<SpotifyRestService>()
     val service =
@@ -384,6 +398,16 @@ class SpotifySearchServiceTest {
 
   private fun fixedClock(instant: String = "2026-04-08T10:00:00Z"): Clock {
     return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC)
+  }
+
+  private class ThrowingSpotifySearchCacheStore : SpotifySearchCacheStore {
+    override fun save(entry: StoredSpotifySearchCacheEntry): StoredSpotifySearchCacheEntry {
+      throw RuntimeException("persistent cache save unavailable")
+    }
+
+    override fun findByKey(cacheKey: String): StoredSpotifySearchCacheEntry? {
+      throw RuntimeException("persistent cache read unavailable")
+    }
   }
 
   private class CorruptSpotifySearchCacheStore(private val now: Instant) : SpotifySearchCacheStore {

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsRefreshServiceTest.kt
@@ -5,6 +5,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -80,6 +83,53 @@ class SpotifyTopPlaylistsRefreshServiceTest {
     verify { authService.refreshToken(cacheClientId.captured) }
     verify(exactly = 0) { topPlaylistsService.updateTopPlaylists(any()) }
     assertEquals("FAILED_SPOTIFY_REFRESH", refreshStateStore.getTopPlaylists()?.lastStatus)
+  }
+
+  @Test
+  fun refreshConfiguredPlaylistsSkipsWhenAlreadyRunning() {
+    val authService = mockk<SpotifyAuthenticationService>(relaxed = true)
+    val topPlaylistsService = mockk<SpotifyTopPlaylistsService>()
+    val refreshStateStore = InMemoryRefreshStateStore()
+    every { authService.refreshToken(any()) } returns true
+
+    val started = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    every { topPlaylistsService.updateTopPlaylists(any()) } answers
+      {
+        started.countDown()
+        release.await(2, TimeUnit.SECONDS)
+        listOf("playlist-1")
+      }
+
+    val service =
+      SpotifyTopPlaylistsRefreshService(
+        spotifyAuthenticationService = authService,
+        spotifyTopPlaylistsService = topPlaylistsService,
+        refreshStateStore = refreshStateStore,
+        refreshEnabled = true,
+        refreshClientId = "cid",
+        refreshToken = "refresh-token",
+        refreshOnStartupEnabled = true,
+        refreshTriggerToken = "secret",
+      )
+
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val first = executor.submit<List<String>?> { service.refreshConfiguredPlaylists("first") }
+      assertTrue(started.await(2, TimeUnit.SECONDS))
+
+      // A second trigger while the first run is in flight must be skipped, not run concurrently.
+      val second = service.refreshConfiguredPlaylists("second")
+      assertNull(second)
+
+      release.countDown()
+      assertEquals(listOf("playlist-1"), first.get(2, TimeUnit.SECONDS))
+    } finally {
+      release.countDown()
+      executor.shutdownNow()
+    }
+
+    verify(exactly = 1) { topPlaylistsService.updateTopPlaylists(any()) }
   }
 
   @Test

--- a/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/SpotifyTopPlaylistsServiceTest.kt
@@ -403,6 +403,50 @@ class SpotifyTopPlaylistsServiceTest {
     verify(exactly = 0) { playlistService.modifyPlaylist(any(), any(), any()) }
   }
 
+  @Test
+  fun updateForgottenObsessionsPlaylistCountsUniqueSpotifyMatchesAcrossBatches() {
+    val playlistService = mockk<SpotifyPlaylistService>(relaxed = true)
+    val trackService = mockk<SpotifyTopTrackService>(relaxed = true)
+    val lastFmService = mockk<LastFmService>()
+    val searchService = mockk<SpotifySearchService>()
+    val playlist = Playlist("forgotten-id", "Forgotten Obsessions")
+    val service =
+      SpotifyTopPlaylistsService(playlistService, trackService, lastFmService, searchService)
+
+    service.firstSupportedYear = 2024
+    service.currentYearProvider = { 2024 }
+
+    every {
+      lastFmService.yearlyChartlist(
+        "cid",
+        2024,
+        "login",
+        SpotifyTopPlaylistsService.FORGOTTEN_OBSESSIONS_YEARLY_SCROBBLE_LIMIT,
+      )
+    } returns
+      (1..150).flatMap { index ->
+        (1..5).map { play ->
+          Song(
+            artist = "Artist $index",
+            title = "Song $index",
+            playedAtEpochSecond = 1_500_000_000L + play,
+          )
+        }
+      }
+    // Two search batches that overlap on track-21..30, so 30 + 30 raw matches are only 50 unique.
+    coEvery { searchService.searchTrackIds(any(), "cid") } returnsMany
+      listOf((1..30).map { "track-$it" }, (21..50).map { "track-$it" })
+    every { playlistService.getCurrentUserPlaylists("cid") } returns mutableListOf()
+    every { playlistService.createPlaylist("Forgotten Obsessions", "cid") } returns playlist
+    every { playlistService.modifyPlaylist(any(), any(), "cid") } returns emptyMap()
+
+    val result = service.updateForgottenObsessionsPlaylist("cid", "login")
+
+    assertEquals("forgotten-id", result.playlistId)
+    assertEquals(50, result.playlistTrackCount)
+    assertEquals(50, result.spotifyMatchCount)
+  }
+
   private fun fixedClock(instant: String = "2026-04-08T10:00:00Z"): Clock {
     return Clock.fixed(Instant.parse(instant), ZoneOffset.UTC)
   }


### PR DESCRIPTION
## Summary

A systematic bug hunt across the auth, HTTP, job, playlist, and persistence layers turned up six genuine defects. Each is fixed with a regression test; `./gradlew build` (compile, tests, ktfmt, 90% coverage gate) is green.

## Fixes

1. **Rotated Spotify refresh token discarded** — `SpotifyAuthenticationService.refreshToken` unconditionally overwrote the refresh token with the *old* value, throwing away any rotated token Spotify returned. The next refresh then sent a stale token → `invalid_grant` → the user was permanently logged out. Now the new token is kept when present, falling back to the old one only when the response omits it.

2. **Transient failures poisoned the lyrics negative cache** — `LyricsService.fetchLyrics` cached a `null` result for 12 hours even when the lookup failed on a 5xx/network error, so a momentary lrclib outage suppressed lyric lookups (and mood scoring) for the full TTL. Null is now cached only on a definitive miss.

3. **Cache-store failure aborted the whole search batch** — `SpotifySearchService` read/wrote the persistent search cache without guarding; a store exception propagated through `awaitAll` and cancelled every sibling coroutine, turning a best-effort cache hiccup into a total search failure. Store access now degrades gracefully (matching `LastFmService`).

4. **Configured refresh had no concurrency guard** — the startup, scheduled, and HTTP-triggered paths of `SpotifyTopPlaylistsRefreshService` could run at once, interleaving the shared refresh-state row and double-mutating the same Spotify account. Added a single-flight guard that skips a run already in progress.

5. **Forgotten-obsessions match count double-counted across batches** — `spotifyMatchCount` summed per-batch match sizes, so a track matched in two search batches inflated the reported count. Now counts unique matched track IDs.

6. **Expired-job cleanup could drop a refreshed job** — `InMemoryJobStatusStore.deleteExpired` removed keys from a stale snapshot; a job refreshed to a later expiry between the snapshot and the removal was deleted anyway. Now uses a value-conditional remove.

## Testing

`./gradlew build` — all unit + integration tests (including six new regression tests), ktfmt check, and the 90% Jacoco coverage gate pass on the Java 21 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D59JUHqftNskE4w5YgAYCx)_