### PR TITLE
Fix four more correctness and robustness bugs

### DIFF
--- a/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/LastFmAuthenticationController.kt
@@ -127,8 +127,12 @@ class LastFmAuthenticationController(private val lastFmAuthService: LastFmAuthen
         response.addCookie(createCookie(LAST_FM_LOGIN_COOKIE, login, request, httpOnly = false))
         lastFmAuthService.setSession(login, key)
         logger.info("Successfully authenticated Last.fm user {}", login)
+        "redirect:/"
+      } else {
+        // No usable session key/login was resolved, so do not present this as a success.
+        logger.warn("Last.fm callback returned no usable session key or login")
+        "redirect:/error"
       }
-      "redirect:/"
     } else {
       "redirect:/error"
     }

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyAuthenticationController.kt
@@ -138,10 +138,13 @@ class SpotifyAuthenticationController(
         spotifyAuthenticationService.setAuthToken(authToken)
         response.addCookie(createCookie("clientId", sessionId, request))
         logger.info("Successfully set auth token for Spotify user: {}", spotifyUserId)
+        "redirect:/"
       } else {
+        // No session was established (e.g. the /v1/me lookup failed), so surface an error instead
+        // of redirecting to the app as if the user were authenticated.
         logger.warn("Could not retrieve client ID. Auth token not stored.")
+        "redirect:/error"
       }
-      "redirect:/"
     } catch (ex: Exception) {
       logger.error("Error occurred while handling Spotify callback.", ex)
       "redirect:/error"

--- a/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
+++ b/src/main/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistController.kt
@@ -35,6 +35,14 @@ class SpotifyBandPlaylistController(
     @RequestBody request: BandPlaylistRequest,
   ): ResponseEntity<String> {
     requireAuthorizedSession(clientId)
+    if (request.bands.size > MAX_BAND_REQUEST_ENTRIES) {
+      logger.warn(
+        "Rejecting band playlist request with {} raw entries; maximum is {}",
+        request.bands.size,
+        MAX_BAND_REQUEST_ENTRIES,
+      )
+      return ResponseEntity.badRequest().build()
+    }
     val bands = request.bands.map { it.trim() }.filter { it.isNotEmpty() }
     if (bands.isEmpty()) {
       logger.warn("Band playlist request had no valid bands for clientId={}", clientId)
@@ -68,6 +76,9 @@ class SpotifyBandPlaylistController(
   }
 
   companion object {
+    // Generous bound on raw request entries (far above the MAX_BAND_COUNT distinct limit) so a
+    // malicious client cannot force unbounded trimming/dedup work before the size check.
+    private const val MAX_BAND_REQUEST_ENTRIES = 200
     private val logger = LoggerFactory.getLogger(SpotifyBandPlaylistController::class.java)
   }
 }

--- a/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
+++ b/src/main/kotlin/com/lis/spotify/service/LastFmService.kt
@@ -455,6 +455,7 @@ class LastFmService(
     var artist: String? = null
     var title: String? = null
     var playedAtEpochSecond: Long? = null
+    var nowPlaying = false
 
     while (parser.nextToken() != JsonToken.END_OBJECT) {
       if (parser.currentToken != JsonToken.FIELD_NAME) {
@@ -467,8 +468,15 @@ class LastFmService(
         "artist" -> artist = parseRecentTrackArtist(parser)
         "name" -> title = parser.valueAsString
         "date" -> playedAtEpochSecond = parseRecentTrackPlayedAt(parser)
+        "@attr" -> nowPlaying = parseRecentTrackNowPlaying(parser)
         else -> parser.skipChildren()
       }
+    }
+
+    // Last.fm prepends the currently-playing track to page 1 regardless of the requested
+    // from/to window, and it carries no date. Dropping it keeps it out of the wrong year/window.
+    if (nowPlaying) {
+      return null
     }
 
     if (artist.isNullOrBlank() || title.isNullOrBlank()) {
@@ -476,6 +484,29 @@ class LastFmService(
     }
 
     return Song(artist = artist, title = title, playedAtEpochSecond = playedAtEpochSecond)
+  }
+
+  private fun parseRecentTrackNowPlaying(parser: com.fasterxml.jackson.core.JsonParser): Boolean {
+    if (parser.currentToken != JsonToken.START_OBJECT) {
+      parser.skipChildren()
+      return false
+    }
+
+    var nowPlaying = false
+    while (parser.nextToken() != JsonToken.END_OBJECT) {
+      if (parser.currentToken != JsonToken.FIELD_NAME) {
+        continue
+      }
+
+      val fieldName = parser.currentName()
+      parser.nextToken()
+      when (fieldName) {
+        "nowplaying" -> nowPlaying = parser.valueAsString.equals("true", ignoreCase = true)
+        else -> parser.skipChildren()
+      }
+    }
+
+    return nowPlaying
   }
 
   private fun parseRecentTrackArtist(parser: com.fasterxml.jackson.core.JsonParser): String? {

--- a/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/LastFmAuthenticationControllerTest.kt
@@ -59,6 +59,18 @@ class LastFmAuthenticationControllerTest {
   }
 
   @Test
+  fun handleCallbackWithSessionButMissingKeyRedirectsToError() {
+    // Session object present but without a usable key: this is not a successful authentication.
+    every { service.getSession("tok") } returns mapOf("session" to mapOf("name" to "login"))
+    val response = mockk<HttpServletResponse>(relaxed = true)
+
+    val result = controller.handleCallback("tok", "state", requestWithState(), response)
+
+    assertEquals("redirect:/error", result)
+    verify(exactly = 0) { service.setSession(any(), any()) }
+  }
+
+  @Test
   fun handleCallbackRejectsInvalidState() {
     val response = mockk<HttpServletResponse>(relaxed = true)
     val result = controller.handleCallback("tok", "wrong", requestWithState(), response)

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyAuthenticationControllerTest.kt
@@ -142,6 +142,44 @@ class SpotifyAuthenticationControllerTest {
   }
 
   @Test
+  fun callbackRedirectsToErrorWhenUserLookupFails() {
+    val request = mockk<HttpServletRequest>()
+    every { request.getHeader(any()) } returns null
+    every { request.scheme } returns "http"
+    every { request.serverName } returns "localhost"
+    every { request.serverPort } returns 80
+    every { request.isSecure } returns false
+    every { request.cookies } returns arrayOf(Cookie("spotifyAuthState", "expected-state"))
+    val response = mockk<HttpServletResponse>(relaxed = true)
+
+    val builderAuthed = mockk<RestTemplateBuilder>()
+    every { builder.basicAuthentication(any(), any()) } returns builderAuthed
+    every { builderAuthed.build() } returns restTemplate
+    every { builder.build() } returns restTemplate
+
+    val token = AuthToken("a", "b", "c", 0, "r", null)
+    every {
+      restTemplate.postForObject<AuthToken>(Spotify.TOKEN_URL, any(), AuthToken::class.java)
+    } returns token
+    every { spotifyService.getHeaders(token) } returns HttpHeaders()
+    // The /v1/me lookup fails, so no session can be established.
+    every {
+      restTemplate.exchange<User>(
+        any<String>(),
+        HttpMethod.GET,
+        any<HttpEntity<*>>(),
+        any<ParameterizedTypeReference<User>>(),
+      )
+    } throws RuntimeException()
+
+    val result = controller.callback(request, "code", "expected-state", response)
+
+    assertEquals("redirect:/error", result)
+    verify(exactly = 0) { spotifyService.setAuthToken(any()) }
+    verify(exactly = 0) { response.addCookie(match { it.name == "clientId" }) }
+  }
+
+  @Test
   fun callbackRejectsInvalidState() {
     val request = mockk<HttpServletRequest>()
     every { request.getHeader(any()) } returns null

--- a/src/test/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistControllerTest.kt
+++ b/src/test/kotlin/com/lis/spotify/controller/SpotifyBandPlaylistControllerTest.kt
@@ -61,6 +61,15 @@ class SpotifyBandPlaylistControllerTest {
   }
 
   @Test
+  fun createBandPlaylistRejectsOversizedRawRequest() {
+    // A huge raw list must be rejected on size before any per-element trimming/dedup work.
+    val response =
+      controller.createBandPlaylist("cid", BandPlaylistRequest((1..201).map { "Band" }))
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+  }
+
+  @Test
   fun createBandPlaylistReturnsBadRequestForTooManyBands() {
     val response =
       controller.createBandPlaylist(

--- a/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
+++ b/src/test/kotlin/com/lis/spotify/service/LastFmServiceTest.kt
@@ -59,6 +59,28 @@ class LastFmServiceTest {
   }
 
   @Test
+  fun yearlyChartlistExcludesNowPlayingTrack() {
+    val rest = mockk<RestTemplate>()
+    val service = service()
+    service.rest = rest
+    // Last.fm prepends the currently-playing track (nowplaying=true, no date) on page 1 regardless
+    // of the requested window; it must not leak into the queried year.
+    val payload =
+      """
+      {"recenttracks":{"@attr":{"totalPages":"1"},"track":[
+        {"artist":{"#text":"Now Artist"},"name":"Now Playing","@attr":{"nowplaying":"true"}},
+        {"artist":{"#text":"A"},"name":"T","date":{"uts":"1700000000"}}
+      ]}}
+      """
+        .trimIndent()
+    every { rest.getForObject(any<URI>(), String::class.java) } returns payload
+
+    val songs = service.yearlyChartlist("cid", 2020, "login")
+
+    assertEquals(listOf(Song("A", "T", playedAtEpochSecond = 1_700_000_000)), songs)
+  }
+
+  @Test
   fun pagingReturnsAllSongs() {
     val rest = mockk<RestTemplate>()
     val service = service()


### PR DESCRIPTION
## Summary

A second, deeper review pass over the Last.fm parsing and OAuth callback flows surfaced four more genuine defects. Each is fixed with a regression test; `./gradlew build` (compile, tests, ktfmt, 90% coverage gate) is green.

## Fixes

1. **Last.fm "now playing" track leaked into every year's chartlist** — `LastFmService.parseRecentTrackItem` never checked a track's `@attr`/`nowplaying` flag. Last.fm prepends the currently-playing track to page 1 of every `getRecentTracks` response *regardless of the `from`/`to` window*, and it carries no date, so a track being played in 2026 was added to (for example) the 2020 chartlist and thus polluted every yearly `LAST.FM <year>` playlist. Now-playing tracks are now dropped.

2. **Spotify callback reported success when the user lookup failed** — after a successful token exchange, if the `/v1/me` call returned no user id, `SpotifyAuthenticationController.callback` set no session cookie yet still redirected to `/` as if authenticated; every subsequent action then 401'd with no prompt to re-auth. Now redirects to `/error`, consistent with the catch branch.

3. **Last.fm callback reported success when no session was resolved** — `LastFmAuthenticationController.handleCallback` fell through to `redirect:/` even when no usable session key/login was obtained. Now redirects to `/error`.

4. **Unbounded band-playlist input** — `SpotifyBandPlaylistController` ran `map`/`trim`/`filter`/`distinctBy` over the entire deserialized `bands` list before its size check, so an authenticated client could submit a huge list and force unbounded work. Added an early bound on the raw request size.

## Not changed (evaluated)

The Last.fm callback's fallback to the `lastFmLogin` cookie when the session response omits `name` was reviewed and left as-is: it is existing, tested behaviour to preserve the typed login across the redirect, and it is not practically exploitable (real Last.fm responses always include `name`, so the client-supplied cookie is never authoritative).

## Testing

`./gradlew build` — all unit + integration tests (including four new regression tests), ktfmt check, and the 90% Jacoco coverage gate pass on the Java 21 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D59JUHqftNskE4w5YgAYCx)_